### PR TITLE
Set the Dart version in the example to our minimum

### DIFF
--- a/auth0_flutter/example/pubspec.lock
+++ b/auth0_flutter/example/pubspec.lock
@@ -192,5 +192,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"
   flutter: ">=2.10.0"

--- a/auth0_flutter/example/pubspec.yaml
+++ b/auth0_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the auth0_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
### Description

This PR sets the minimum Dart version in the example app to `2.16.0` (instead of `2.16.1`).

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
