### PR TITLE
Add basic UI to example app [SDK-3224]

### DIFF
--- a/auth0_flutter/example/lib/main.dart
+++ b/auth0_flutter/example/lib/main.dart
@@ -5,49 +5,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ExampleApp());
 }
 
-class MyApp extends StatefulWidget {
-  const MyApp({final Key? key}) : super(key: key);
+const double padding = 24.0;
+
+class ExampleApp extends StatefulWidget {
+  const ExampleApp({final Key? key}) : super(key: key);
 
   @override
-  State<MyApp> createState() => _MyAppState();
+  State<ExampleApp> createState() => _ExampleAppState();
 }
 
-class _MyAppState extends State<MyApp> {
-  String _platformVersion = 'Unknown';
+class _ExampleAppState extends State<ExampleApp> {
   String _token = 'Unknown';
 
   @override
   void initState() {
     super.initState();
-    initPlatformState();
   }
 
-  // Platform messages are asynchronous, so we initialize in an async method.
-  Future<void> initPlatformState() async {
-    String platformVersion;
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    // We also handle the message potentially returning null.
-    try {
-      platformVersion =
-          await Auth0Flutter.platformVersion ?? 'Unknown platform version';
-    } on PlatformException {
-      platformVersion = 'Failed to get platform version.';
-    }
-
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted) return;
-
-    setState(() {
-      _platformVersion = platformVersion;
-    });
-  }
-
-  Future<void> loginAction() async {
+  Future<void> webAuthLogin() async {
     String token;
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
@@ -71,20 +49,109 @@ class _MyAppState extends State<MyApp> {
   Widget build(final BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: Center(
-            child:
-                Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-          Text('Running on: $_platformVersion'),
-          Text('With token: $_token'),
-          ElevatedButton(
-            onPressed: loginAction,
-            child: const Text('Login'),
-          ),
-        ])),
-      ),
+          appBar: AppBar(title: const Text('Auth0 Example')),
+          body: CustomScrollView(
+            slivers: <Widget>[
+              SliverToBoxAdapter(
+                  child: Padding(
+                padding: const EdgeInsets.all(padding),
+                child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const FormCard(),
+                      WebAuthCard(webAuthLogin),
+                    ]),
+              )),
+              SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                          padding, 0.0, padding, padding),
+                      child: Center(child: Text('With token: $_token')))),
+            ],
+          )),
     );
+  }
+}
+
+class FormCard extends StatefulWidget {
+  const FormCard({final Key? key}) : super(key: key);
+
+  @override
+  FormCardState createState() {
+    return FormCardState();
+  }
+}
+
+class FormCardState extends State<FormCard> {
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(final BuildContext context) {
+    return Card(
+        child: Padding(
+            padding: const EdgeInsets.all(padding),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  TextFormField(
+                    decoration: const InputDecoration(
+                      hintText: 'Username or email',
+                    ),
+                    validator: (final String? value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please enter an username or email';
+                      }
+                      return null;
+                    },
+                  ),
+                  TextFormField(
+                    decoration: const InputDecoration(
+                      hintText: 'Password',
+                    ),
+                    obscureText: true,
+                    enableSuggestions: false,
+                    autocorrect: false,
+                    validator: (final String? value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please enter a password';
+                      }
+                      return null;
+                    },
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (_formKey.currentState != null &&
+                          _formKey.currentState!.validate()) {
+                        // Process data.
+                      }
+                    },
+                    child: const Text('API Login'),
+                  ),
+                ],
+              ),
+            )));
+  }
+}
+
+class WebAuthCard extends StatelessWidget {
+  final Future<void> Function() loginAction;
+
+  const WebAuthCard(final this.loginAction, {final Key? key}) : super(key: key);
+
+  @override
+  Widget build(final BuildContext context) {
+    return Card(
+        child: Padding(
+            padding: const EdgeInsets.all(padding),
+            child: SizedBox(
+              width: double.maxFinite,
+              child: ElevatedButton(
+                onPressed: loginAction,
+                child: const Text('Web Auth Login'),
+              ),
+            )));
   }
 }

--- a/auth0_flutter/example/test/widget_test.dart
+++ b/auth0_flutter/example/test/widget_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Verify Platform version', (final WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const ExampleApp());
 
     // Verify that platform version is retrieved.
     expect(


### PR DESCRIPTION
### Description

This PR adds a basic UI to the example app:
- Form for embedded login
- Button for Web Auth login
- Text area for the result

![Simulator Screen Shot - iPhone 13 - 2022-03-25 at 03 59 19](https://user-images.githubusercontent.com/5055789/160071773-b26e220b-1f33-46cb-afbd-025eeae59ab8.png)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
