### PR TITLE
Copy env file for iOS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           name: Run iOS Tests
           command: |
             pod install
+            cp ../.env.example ../.env
             xcodebuild test -scheme Runner -workspace Runner.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 13'
           working_directory: ./auth0_flutter/example/ios
       - run:


### PR DESCRIPTION
Fixes the Circle CI build because it needs the `.env` file to exist.