### PR TITLE
[SDK-3260] Consistent usages of scopes

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -25,7 +25,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
         val loginBuilder = api
             .login(args["usernameOrEmail"] as String, args["password"] as String, args["connectionOrRealm"] as String);
 
-        val scopes = args.getOrDefault("scope", arrayListOf<String>()) as ArrayList<*>
+        val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             loginBuilder.setScope(scopes.joinToString(separator = " "))
         }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -71,7 +71,7 @@ class LoginWebAuthRequestHandler : WebAuthRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 // Success! Access token and ID token are presents
-                val scope = credentials.scope?.split(" ") ?: listOf()
+                val scopes = credentials.scope?.split(" ") ?: listOf()
                 val jwt = JWT(credentials.idToken)
 
                 // Map all claim values to their underlying type as Any
@@ -88,7 +88,7 @@ class LoginWebAuthRequestHandler : WebAuthRequestHandler {
                     "refreshToken" to credentials.refreshToken,
                     "userProfile" to claims,
                     "expiresAt" to formattedDate,
-                    "scopes" to scope
+                    "scopes" to scopes
                 ))
             }
         })

--- a/auth0_flutter/lib/src/authentication_api.dart
+++ b/auth0_flutter/lib/src/authentication_api.dart
@@ -9,13 +9,13 @@ class AuthenticationApi {
           {required final String usernameOrEmail,
           required final String password,
           required final String connectionOrRealm,
-          final Set<String> scope = const {},
+          final Set<String> scopes = const {},
           final Map<String, String> parameters = const {}}) =>
       Auth0FlutterAuthPlatform.instance.login(AuthLoginOptions(
           usernameOrEmail: usernameOrEmail,
           password: password,
           connectionOrRealm: connectionOrRealm,
-          scope: scope,
+          scopes: scopes,
           account: account,
           parameters: parameters));
 

--- a/auth0_flutter/test/authentication_api_test.dart
+++ b/auth0_flutter/test/authentication_api_test.dart
@@ -86,7 +86,7 @@ void main() {
           usernameOrEmail: 'test-user',
           password: 'test-pass',
           connectionOrRealm: 'test-realm',
-          scope: {'test-scope1', 'test-scope2'},
+          scopes: {'test-scope1', 'test-scope2'},
           parameters: {'test': 'test-parameter'});
 
       final verificationResult =
@@ -96,7 +96,7 @@ void main() {
       expect(verificationResult.usernameOrEmail, 'test-user');
       expect(verificationResult.password, 'test-pass');
       expect(verificationResult.connectionOrRealm, 'test-realm');
-      expect(verificationResult.scope, {'test-scope1', 'test-scope2'});
+      expect(verificationResult.scopes, {'test-scope1', 'test-scope2'});
       expect(verificationResult.parameters['test'], 'test-parameter');
       expect(result, TestPlatform.loginResult);
     });
@@ -113,7 +113,7 @@ void main() {
       final verificationResult =
           verify(mockedPlatform.login(captureAny)).captured.single;
       // ignore: inference_failure_on_collection_literal
-      expect(verificationResult.scope, []);
+      expect(verificationResult.scopes, []);
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.parameters, {});
       expect(result, TestPlatform.loginResult);

--- a/auth0_flutter_platform_interface/lib/src/auth/auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth/auth_login_options.dart
@@ -5,7 +5,7 @@ class AuthLoginOptions {
   final String usernameOrEmail;
   final String password;
   final String connectionOrRealm;
-  final Set<String> scope;
+  final Set<String> scopes;
   final Map<String, String> parameters;
 
   AuthLoginOptions(
@@ -13,7 +13,7 @@ class AuthLoginOptions {
       required this.usernameOrEmail,
       required this.password,
       required this.connectionOrRealm,
-      this.scope = const {},
+      this.scopes = const {},
       this.parameters = const {}});
 
       Map<String, dynamic> toMap() => {
@@ -22,7 +22,7 @@ class AuthLoginOptions {
         'usernameOrEmail': usernameOrEmail,
         'password': password,
         'connectionOrRealm': connectionOrRealm,
-        'scope': scope.toList(),
+        'scopes': scopes.toList(),
         'parameters': parameters
       };
 }


### PR DESCRIPTION
Ensures we use `scopes` everywhere instead of a mix of `scope` and `scopes`.