### PR TITLE
Add boolean properties to iOS Auth API Error [SDK-3257]

### DIFF
--- a/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIExtensionsTests.swift
@@ -5,7 +5,7 @@ import Auth0
 
 class AuthAPIExtensionsTests: XCTestCase {
     func testInitializesFlutterErrorFromAuthAPIError() {
-        let errors: [AuthAPIErrorFlag: [String: String]] = [
+        let errors: [AuthAPIErrorFlag: [String: Any]] = [
             .isMultifactorRequired: ["code": "mfa_required"],
             .isMultifactorEnrollRequired: ["code": "unsupported_challenge_type"],
             .isMultifactorCodeInvalid: ["code": "invalid_grant", "error_description": "Invalid otp_code."],
@@ -19,7 +19,10 @@ class AuthAPIExtensionsTests: XCTestCase {
                                      + " anymore."],
             .isAccessDenied: ["code": "access_denied"],
             .isTooManyAttempts: ["code": "too_many_attempts"],
-            .isVerificationRequired: ["code": "requires_verification"]
+            .isVerificationRequired: ["code": "requires_verification"],
+            .isPasswordLeaked: ["code": "password_leaked"],
+            .isLoginRequired: ["code": "login_required"],
+            .isNetworkError: ["cause": URLError(URLError.Code.notConnectedToInternet)]
         ]
         for (flag, info) in errors {
             let error = AuthenticationError(info: info, statusCode: 400)

--- a/auth0_flutter/example/ios/Tests/Utilities.swift
+++ b/auth0_flutter/example/ios/Tests/Utilities.swift
@@ -119,7 +119,10 @@ func assert(flutterError: FlutterError,
        flags[AuthAPIErrorFlag.isRefreshTokenDeleted] == authenticationError.isRefreshTokenDeleted,
        flags[AuthAPIErrorFlag.isAccessDenied] == authenticationError.isAccessDenied,
        flags[AuthAPIErrorFlag.isTooManyAttempts] == authenticationError.isTooManyAttempts,
-       flags[AuthAPIErrorFlag.isVerificationRequired] == authenticationError.isVerificationRequired {
+       flags[AuthAPIErrorFlag.isVerificationRequired] == authenticationError.isVerificationRequired,
+       flags[AuthAPIErrorFlag.isPasswordLeaked] == authenticationError.isPasswordLeaked,
+       flags[AuthAPIErrorFlag.isLoginRequired] == authenticationError.isLoginRequired,
+       flags[AuthAPIErrorFlag.isNetworkError] == authenticationError.isNetworkError {
         return
     }
     XCTFail("The handler did not produce the error '\(authenticationError)'", file: file, line: line)

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -14,6 +14,9 @@ enum AuthAPIErrorFlag: String, CaseIterable {
     case isAccessDenied
     case isTooManyAttempts
     case isVerificationRequired
+    case isPasswordLeaked
+    case isLoginRequired
+    case isNetworkError
 
     static let key = "_errorFlags"
 }
@@ -34,7 +37,10 @@ extension FlutterError {
             AuthAPIErrorFlag.isRefreshTokenDeleted.rawValue: authenticationError.isRefreshTokenDeleted,
             AuthAPIErrorFlag.isAccessDenied.rawValue: authenticationError.isAccessDenied,
             AuthAPIErrorFlag.isTooManyAttempts.rawValue: authenticationError.isTooManyAttempts,
-            AuthAPIErrorFlag.isVerificationRequired.rawValue: authenticationError.isVerificationRequired
+            AuthAPIErrorFlag.isVerificationRequired.rawValue: authenticationError.isVerificationRequired,
+            AuthAPIErrorFlag.isPasswordLeaked.rawValue: authenticationError.isPasswordLeaked,
+            AuthAPIErrorFlag.isLoginRequired.rawValue: authenticationError.isLoginRequired,
+            AuthAPIErrorFlag.isNetworkError.rawValue: authenticationError.isNetworkError,
         ]
         var errorDetails = authenticationError.details ?? [:]
         errorDetails[AuthAPIErrorFlag.key] = errorFlags

--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -45,6 +45,20 @@ extension Auth0Error {
     }
 }
 
+extension Auth0APIError {
+    var isPasswordLeaked: Bool {
+        return self.code == "password_leaked"
+    }
+
+    var isLoginRequired: Bool {
+        return self.code == "login_required"
+    }
+
+    var isNetworkError: Bool {
+        return (self.cause as? URLError)?.code == URLError.Code.notConnectedToInternet
+    }
+}
+
 extension Credentials {
     func asDictionary() throws -> [String: Any] {
         let jwt = try decode(jwt: idToken)


### PR DESCRIPTION
### Description

This PR extends the `AuthenticationError` type from Auth0.swift with the following boolean properties:
- `isPasswordLeaked`
- `isLoginRequired`
- `isNetworkError`

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
