### PR TITLE
Ensure the iOS native layer always includes a scopes array in a Credentials result [SDK-3305]

### DIFF
--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -66,10 +66,10 @@ extension Credentials {
             CredentialsProperty.accessToken.rawValue: accessToken,
             CredentialsProperty.idToken.rawValue: idToken,
             CredentialsProperty.expiresAt.rawValue: expiresIn.asISO8601String,
+            CredentialsProperty.scopes.rawValue: scope?.split(separator: " ").map(String.init) ?? [],
             CredentialsProperty.userProfile.rawValue: UserInfo(json: jwt.body)?.asDictionary() ?? [:]
         ]
         data[CredentialsProperty.refreshToken] = refreshToken
-        data[CredentialsProperty.scopes] = scope?.split(separator: " ").map(String.init)
         return data
     }
 }


### PR DESCRIPTION
### Description

Currently, when the iOS native layer returns a Credentials result (for Web Auth login, Auth API login, and Auth API renew) scopes does not default to an empty array in case of a nil value, while the Dart code expects scopes to always be an array/list.

This PR ensures that `scopes` is always an array in the returned result.
The same is done for `userProfile`, although that could never happen in practice, as that would require an empty ID Token.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
