### PR TITLE
Implement telemetry for iOS [SDK-3308]

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
@@ -21,24 +21,25 @@ class MethodCallRequest {
 
             assertHasProperties(
                 listOf(
-                    "domain",
-                    "clientId",
-                    "userAgent",
-                    "userAgent.name",
-                    "userAgent.version"
+                    "_account",
+                    "_account.domain",
+                    "_account.clientId",
+                    "_userAgent",
+                    "_userAgent.name",
+                    "_userAgent.version"
                 ), args
             );
 
+            val accountMap = args["_account"] as Map<String, String>;
             val account = Auth0(
-                args["clientId"] as String,
-                args["domain"] as String
+                accountMap["clientId"] as String,
+                accountMap["domain"] as String
             )
 
-            val userAgent = args["userAgent"] as Map<String, String>;
-
+            val userAgentMap = args["_userAgent"] as Map<String, String>;
             account.auth0UserAgent = Auth0UserAgent(
-                name = userAgent["name"] as String,
-                version = userAgent["version"] as String,
+                name = userAgentMap["name"] as String,
+                version = userAgentMap["version"] as String,
             )
 
             return MethodCallRequest(account, args);

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandlerTest.kt
@@ -14,9 +14,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class Auth0FlutterAuthMethodCallHandlerTest {
     private val defaultArguments = hashMapOf<String, Any?>(
-        "domain" to "test.auth0.com",
-        "clientId" to "test-client",
-        "userAgent" to mapOf(
+        "_account" to mapOf(
+            "domain" to "test.auth0.com",
+            "clientId" to "test-client",
+        ),
+        "_userAgent" to mapOf(
             "name" to "auth0-flutter",
             "version" to "1.0.0"
         )

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterWebAuthMethodCallHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterWebAuthMethodCallHandlerTest.kt
@@ -17,8 +17,14 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class Auth0FlutterWebAuthMethodCallHandlerTest {
     private val defaultArguments = hashMapOf<String, Any?>(
-        "domain" to "test.auth0.com",
-        "clientId" to "test-client"
+        "_account" to mapOf(
+            "domain" to "test.auth0.com",
+            "clientId" to "test-client",
+        ),
+        "_userAgent" to mapOf(
+            "name" to "auth0-flutter",
+            "version" to "1.0.0"
+        )
     )
 
     private fun runCallHandler(

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.auth0.auth0_flutter
 
+import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.provider.WebAuthProvider
@@ -33,7 +34,7 @@ class LogoutWebAuthRequestHandlerTest {
             resultCallback(mockResult, mockBuilder)
         }.`when`(mockBuilder).start(any(), any())
 
-        handler.handle(mock(), MethodCallRequest("test-domain", "test-client", args), mockResult)
+        handler.handle(mock(), MethodCallRequest(Auth0("test-domain", "test-client"), args), mockResult)
     }
 
     @Test
@@ -75,6 +76,6 @@ class LogoutWebAuthRequestHandlerTest {
             verify(mockResult).error("code", "description", exception)
         }.`when`(mockBuilder).start(any(), any())
 
-        handler.handle(mock(), MethodCallRequest("test-domain", "test-client", mock()), mockResult)
+        handler.handle(mock(), MethodCallRequest(Auth0("test-domain", "test-client"), mock()), mockResult)
     }
 }

--- a/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIHandlerTests.swift
@@ -1,8 +1,19 @@
 import XCTest
+import Auth0
 
 @testable import auth0_flutter
 
-fileprivate typealias Argument = AuthAPIHandler.Argument
+fileprivate class SpySUT: AuthAPIHandler {
+    fileprivate(set) var accountValue: Account?
+    fileprivate(set) var userAgentValue: UserAgent?
+
+    override func makeClient(account: Account, userAgent: UserAgent) -> Authentication {
+        accountValue = account
+        userAgentValue = userAgent
+
+        return SpyAuthentication()
+    }
+}
 
 class AuthAPIHandlerTests: XCTestCase {
     var sut: AuthAPIHandler!
@@ -22,29 +33,46 @@ extension AuthAPIHandlerTests {
     }
 }
 
-// MARK: - Required Arguments Error
+// MARK: - Required Arguments
 
 extension AuthAPIHandlerTests {
     func testProducesErrorWhenArgumentsAreMissing() {
         let expectation = expectation(description: "arguments are missing")
-        sut.handle(FlutterMethodCall(methodName: "foo", arguments: nil)) { result in
+        sut.handle(FlutterMethodCall(methodName: "", arguments: nil)) { result in
             assert(result: result, isError: .argumentsMissing)
             expectation.fulfill()
         }
         wait(for: [expectation])
     }
 
-    func testProducesErrorWhenRequiredArgumentsAreMissing() {
-        let keys: [Argument] = [.clientId, .domain]
-        let expectations = keys.map { expectation(description: "\($0.rawValue) is missing") }
-        for (argument, currentExpectation) in zip(keys, expectations) {
-            let methodCall = FlutterMethodCall(methodName: "foo", arguments: arguments(without: argument))
-            sut.handle(methodCall) { result in
-                assert(result: result, isError: .requiredArgumentMissing(argument.rawValue))
-                currentExpectation.fulfill()
-            }
+    func testProducesErrorWhenAccountIsMissing() {
+        let expectation = expectation(description: "account is missing")
+        sut.handle(FlutterMethodCall(methodName: "", arguments: arguments(without: Account.key))) { result in
+            assert(result: result, isError: .accountMissing)
+            expectation.fulfill()
         }
-        wait(for: expectations)
+        wait(for: [expectation])
+    }
+
+    func testProducesErrorWhenUserAgentIsMissing() {
+        let expectation = expectation(description: "userAgent is missing")
+        sut.handle(FlutterMethodCall(methodName: "", arguments: arguments(without: UserAgent.key))) { result in
+            assert(result: result, isError: .userAgentMissing)
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testMakesClientWithRequiredArguments() {
+        let account = [AccountProperty.clientId.rawValue: "foo", AccountProperty.domain.rawValue: "bar"]
+        let userAgent = [UserAgentProperty.name.rawValue: "baz", UserAgentProperty.version.rawValue: "qux"]
+        let argumentsDictionary = [Account.key: account, UserAgent.key: userAgent]
+        let sut = SpySUT()
+        sut.handle(FlutterMethodCall(methodName: "", arguments: argumentsDictionary)) { _ in }
+        XCTAssertEqual(sut.accountValue?.clientId, account[AccountProperty.clientId])
+        XCTAssertEqual(sut.accountValue?.domain, account[AccountProperty.domain])
+        XCTAssertEqual(sut.userAgentValue?.name, userAgent[UserAgentProperty.name])
+        XCTAssertEqual(sut.userAgentValue?.version, userAgent[UserAgentProperty.version])
     }
 }
 
@@ -73,6 +101,9 @@ extension AuthAPIHandlerTests {
 
 extension AuthAPIHandlerTests {
     override func arguments() -> [String: Any] {
-        return [Argument.clientId.rawValue: "foo", Argument.domain.rawValue: "bar"]
+        return [
+            Account.key: [AccountProperty.clientId.rawValue: "", AccountProperty.domain.rawValue: ""],
+            UserAgent.key: [UserAgentProperty.name.rawValue: "", UserAgentProperty.version.rawValue: ""]
+        ]
     }
 }

--- a/auth0_flutter/example/ios/Tests/Utilities.swift
+++ b/auth0_flutter/example/ios/Tests/Utilities.swift
@@ -35,16 +35,24 @@ extension XCTestCase {
         return [:]
     }
 
-    func arguments<K: RawRepresentable, V>(withKey key: K, value: V) -> [String: Any] where K.RawValue == String {
+    func arguments<V>(withKey key: String, value: V) -> [String: Any] {
         var dictionary = arguments()
-        dictionary[key.rawValue] = value
+        dictionary[key] = value
+        return dictionary
+    }
+
+    func arguments<K: RawRepresentable, V>(withKey key: K, value: V) -> [String: Any] where K.RawValue == String {
+        return arguments(withKey: key.rawValue, value: value)
+    }
+
+    func arguments(without key: String) -> [String: Any] {
+        var dictionary = arguments()
+        dictionary.removeValue(forKey: key)
         return dictionary
     }
 
     func arguments<K: RawRepresentable>(without key: K) -> [String: Any] where K.RawValue == String {
-        var dictionary = arguments()
-        dictionary.removeValue(forKey: key.rawValue)
-        return dictionary
+        return arguments(without: key.rawValue)
     }
 }
 

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
@@ -2,11 +2,6 @@ import Flutter
 import Auth0
 
 public class AuthAPIHandler: NSObject, FlutterPlugin {
-    enum Argument: String {
-        case clientId
-        case domain
-    }
-
     enum Method: String, CaseIterable {
         case loginWithUsernameOrEmail = "auth#login"
         case signup = "auth#signUp"
@@ -30,14 +25,16 @@ public class AuthAPIHandler: NSObject, FlutterPlugin {
         guard let arguments = call.arguments as? [String: Any] else {
             return result(FlutterError(from: .argumentsMissing))
         }
-        guard let clientId = arguments[Argument.clientId] as? String else {
-            return result(FlutterError(from: .requiredArgumentMissing(Argument.clientId.rawValue)))
+        guard let accountDictionary = arguments[Account.key] as? [String: String],
+              let account = Account(from: accountDictionary) else {
+            return result(FlutterError(from: .accountMissing))
         }
-        guard let domain = arguments[Argument.domain] as? String else {
-            return result(FlutterError(from: .requiredArgumentMissing(Argument.domain.rawValue)))
+        guard let userAgentDictionary = arguments[UserAgent.key] as? [String: String],
+              let userAgent = UserAgent(from: userAgentDictionary) else {
+            return result(FlutterError(from: .userAgentMissing))
         }
 
-        let client = Auth0.authentication(clientId: clientId, domain: domain)
+        let client = makeClient(account: account, userAgent: userAgent)
 
         switch Method(rawValue: call.method) {
         case .loginWithUsernameOrEmail: callLoginWithUsernameOrEmail(with: arguments, using: client, result: result)
@@ -47,6 +44,12 @@ public class AuthAPIHandler: NSObject, FlutterPlugin {
         case .resetPassword: callResetPassword(with: arguments, using: client, result: result)
         default: result(FlutterMethodNotImplemented)
         }
+    }
+
+    func makeClient(account: Account, userAgent: UserAgent) -> Authentication {
+        var client = Auth0.authentication(clientId: account.clientId, domain: account.domain)
+        client.using(inLibrary: userAgent.name, version: userAgent.version)
+        return client
     }
 }
 

--- a/auth0_flutter/ios/Classes/Enums.swift
+++ b/auth0_flutter/ios/Classes/Enums.swift
@@ -1,3 +1,13 @@
+enum AccountProperty: String {
+    case clientId
+    case domain
+}
+
+enum UserAgentProperty: String {
+    case name
+    case version
+}
+
 enum CredentialsProperty: String, CaseIterable {
     case accessToken
     case idToken
@@ -33,12 +43,16 @@ enum UserInfoProperty: String, CaseIterable {
 
 enum HandlerError {
     case argumentsMissing
+    case accountMissing
+    case userAgentMissing
     case requiredArgumentMissing(String)
     case idTokenDecodingFailed
 
     var code: String {
         switch self {
         case .argumentsMissing: return "SWIFT_ARGUMENTS_MISSING"
+        case .accountMissing: return "SWIFT_ACCOUNT_MISSING"
+        case .userAgentMissing: return "SWIFT_USER_AGENT_MISSING"
         case .requiredArgumentMissing: return "SWIFT_REQUIRED_ARGUMENT_MISSING"
         case .idTokenDecodingFailed: return "SWIFT_ID_TOKEN_DECODING_FAILED"
         }
@@ -47,6 +61,8 @@ enum HandlerError {
     var message: String {
         switch self {
         case .argumentsMissing: return "The arguments dictionary is missing or has the wrong type."
+        case .accountMissing: return "The account dictionary is missing or incomplete, or has the wrong type."
+        case .userAgentMissing: return "The userAgent dictionary is missing or incomplete, or has the wrong type."
         case let .requiredArgumentMissing(argument):
             return "The required argument '\(argument)' is missing or has the wrong type."
         case .idTokenDecodingFailed: return "Unable to decode the ID Token."

--- a/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
+++ b/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
@@ -1,5 +1,38 @@
 import Flutter
 
+struct Account {
+    let clientId: String
+    let domain: String
+
+    static let key = "_account"
+
+    init?(from dictionary: [String: String]) {
+        guard let clientId = dictionary[AccountProperty.clientId],
+              let domain = dictionary[AccountProperty.domain] else {
+            return nil
+        }
+
+        self.clientId = clientId
+        self.domain = domain
+    }
+}
+
+struct UserAgent {
+    let name: String
+    let version: String
+
+    static let key = "_userAgent"
+
+    init?(from dictionary: [String: String]) {
+        guard let name = dictionary[UserAgentProperty.name], let version = dictionary[UserAgentProperty.version] else {
+            return nil
+        }
+
+        self.name = name
+        self.version = version
+    }
+}
+
 public class SwiftAuth0FlutterPlugin: NSObject, FlutterPlugin {
     static var handlers: [FlutterPlugin.Type] = [WebAuthHandler.self, AuthAPIHandler.self]
 

--- a/auth0_flutter_platform_interface/lib/src/request/request.dart
+++ b/auth0_flutter_platform_interface/lib/src/request/request.dart
@@ -13,9 +13,9 @@ abstract class BaseRequest<TOptions extends RequestOptions> {
     required this.userAgent,
   });
 
-  Map<String, dynamic> toMap() => account.toMap()
-    ..addAll(options.toMap())
-    ..addAll({'userAgent': userAgent.toMap()});
+  Map<String, dynamic> toMap() => options.toMap()
+    ..addAll({'_account': account.toMap()})
+    ..addAll({'_userAgent': userAgent.toMap()});
 }
 
 class ApiRequest<TOptions extends RequestOptions>

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
@@ -87,11 +87,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['email'], 'test-email');
       expect(verificationResult.arguments['username'], 'test-user');
       expect(verificationResult.arguments['password'], 'test-pass');
@@ -233,8 +235,12 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['usernameOrEmail'], 'test-email');
       expect(verificationResult.arguments['password'], 'test-pass');
       expect(
@@ -348,11 +354,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['email'], 'test-email');
       expect(verificationResult.arguments['connection'], 'test-connection');
       expect(verificationResult.arguments['parameters']['test'], 'test-123');
@@ -410,11 +418,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(
           verificationResult.arguments['refreshToken'], 'test-refresh-token');
     });
@@ -518,11 +528,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['accessToken'], 'test-token');
     });
 

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -79,11 +79,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['scopes'], ['a', 'b']);
       expect(verificationResult.arguments['audience'], 'test-audience');
       expect(verificationResult.arguments['redirectUri'], 'http://google.com');
@@ -186,11 +188,13 @@ void main() {
 
       final verificationResult =
           verify(mocked.methodCallHandler(captureAny)).captured.single;
-      expect(verificationResult.arguments['domain'], 'test-domain');
-      expect(verificationResult.arguments['clientId'], 'test-clientId');
-      expect(verificationResult.arguments['userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
       expect(
-          verificationResult.arguments['userAgent']['version'], 'test-version');
+          verificationResult.arguments['_userAgent']['version'],
+          'test-version');
       expect(verificationResult.arguments['returnTo'], 'http://localhost:1234');
       expect(verificationResult.arguments['scheme'], 'test-scheme');
     });


### PR DESCRIPTION
### Description

This PR passes telemetry data through the iOS layer to Auth0.swift.
Also, since the telemetry data was put into a nested arguments map, the same was done for the account data.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
