### PR TITLE
Add audience param to Auth API login method (Dart & Android)

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -41,6 +41,10 @@ class LoginApiRequestHandler : ApiRequestHandler {
             loginBuilder.setScope(scopes.joinToString(separator = " "))
         }
 
+        if (args.getOrDefault("audience", null) is String) {
+            loginBuilder.setAudience(args["audience"] as String)
+        }
+
         if (args.getOrDefault("parameters", null) is HashMap<*, *>) {
             loginBuilder.addParameters(args["parameters"] as Map<String, String>)
         }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
@@ -121,6 +121,59 @@ class LoginApiRequestHandlerTest {
     }
 
     @Test
+    fun `should configure the audience when provided`() {
+        val options = hashMapOf(
+            "usernameOrEmail" to "test-email",
+            "password" to "test-pass",
+            "connectionOrRealm" to "test-connection",
+            "audience" to "test-audience"
+        );
+        val handler = LoginApiRequestHandler();
+        val mockLoginBuilder = mock<AuthenticationRequest>();
+        val mockApi = mock<AuthenticationAPIClient>();
+        val mockAccount = mock<Auth0>();
+        val mockResult = mock<Result>();
+        val request = MethodCallRequest(account = mockAccount, options);
+
+        doReturn(mockLoginBuilder).`when`(mockApi).login(any(), any(), any());
+        doReturn(mockLoginBuilder).`when`(mockLoginBuilder).setScope(any());
+
+        handler.handle(
+            mockApi,
+            request,
+            mockResult
+        );
+
+        verify(mockLoginBuilder).setAudience("test-audience");
+    }
+
+    @Test
+    fun `should not configure the audience when not provided`() {
+        val options = hashMapOf(
+            "usernameOrEmail" to "test-email",
+            "password" to "test-pass",
+            "connectionOrRealm" to "test-connection",
+        );
+        val handler = LoginApiRequestHandler();
+        val mockLoginBuilder = mock<AuthenticationRequest>();
+        val mockApi = mock<AuthenticationAPIClient>();
+        val mockAccount = mock<Auth0>();
+        val mockResult = mock<Result>();
+        val request = MethodCallRequest(account = mockAccount, options);
+
+        doReturn(mockLoginBuilder).`when`(mockApi).login(any(), any(), any());
+        doReturn(mockLoginBuilder).`when`(mockLoginBuilder).setScope(any());
+
+        handler.handle(
+            mockApi,
+            request,
+            mockResult
+        );
+
+        verify(mockLoginBuilder, times(0)).setAudience(any());
+    }
+
+    @Test
     fun `should configure the scopes when provided`() {
         val options = hashMapOf(
             "usernameOrEmail" to "test-email",

--- a/auth0_flutter/lib/src/authentication_api.dart
+++ b/auth0_flutter/lib/src/authentication_api.dart
@@ -10,6 +10,7 @@ class AuthenticationApi {
     required final String usernameOrEmail,
     required final String password,
     required final String connectionOrRealm,
+    final String? audience,
     final Set<String> scopes = const {},
     final Map<String, String> parameters = const {},
   }) =>
@@ -17,6 +18,7 @@ class AuthenticationApi {
         usernameOrEmail: usernameOrEmail,
         password: password,
         connectionOrRealm: connectionOrRealm,
+        audience: audience,
         scopes: scopes,
         parameters: parameters,
       )));

--- a/auth0_flutter/test/authentication_api_test.dart
+++ b/auth0_flutter/test/authentication_api_test.dart
@@ -58,8 +58,9 @@ void main() {
         userMetadata: {'test': 'test-123'},
       );
 
-      final verificationResult =
-          verify(mockedPlatform.signup(captureAny)).captured.single as ApiRequest<AuthSignupOptions>;
+      final verificationResult = verify(mockedPlatform.signup(captureAny))
+          .captured
+          .single as ApiRequest<AuthSignupOptions>;
       expect(verificationResult.account.domain, 'test-domain');
       expect(verificationResult.account.clientId, 'test-clientId');
       expect(verificationResult.options.email, 'test-email');
@@ -79,8 +80,9 @@ void main() {
             connection: 'test-realm',
           );
 
-      final verificationResult =
-          verify(mockedPlatform.signup(captureAny)).captured.single as ApiRequest<AuthSignupOptions>;
+      final verificationResult = verify(mockedPlatform.signup(captureAny))
+          .captured
+          .single as ApiRequest<AuthSignupOptions>;
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.options.userMetadata, {});
       expect(result, TestPlatform.signupResult);
@@ -96,16 +98,19 @@ void main() {
           usernameOrEmail: 'test-user',
           password: 'test-pass',
           connectionOrRealm: 'test-realm',
+          audience: 'test-audience',
           scopes: {'test-scope1', 'test-scope2'},
           parameters: {'test': 'test-parameter'});
 
-      final verificationResult =
-          verify(mockedPlatform.login(captureAny)).captured.single as ApiRequest<AuthLoginOptions>;
+      final verificationResult = verify(mockedPlatform.login(captureAny))
+          .captured
+          .single as ApiRequest<AuthLoginOptions>;
       expect(verificationResult.account.domain, 'test-domain');
       expect(verificationResult.account.clientId, 'test-clientId');
       expect(verificationResult.options.usernameOrEmail, 'test-user');
       expect(verificationResult.options.password, 'test-pass');
       expect(verificationResult.options.connectionOrRealm, 'test-realm');
+      expect(verificationResult.options.audience, 'test-audience');
       expect(verificationResult.options.scopes, {'test-scope1', 'test-scope2'});
       expect(verificationResult.options.parameters['test'], 'test-parameter');
       expect(result, TestPlatform.loginResult);
@@ -120,13 +125,30 @@ void main() {
           password: 'test-pass',
           connectionOrRealm: 'test-realm');
 
-      final verificationResult =
-          verify(mockedPlatform.login(captureAny)).captured.single as ApiRequest<AuthLoginOptions>;
+      final verificationResult = verify(mockedPlatform.login(captureAny))
+          .captured
+          .single as ApiRequest<AuthLoginOptions>;
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.options.scopes, []);
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.options.parameters, {});
       expect(result, TestPlatform.loginResult);
+    });
+
+    test('set audience to null when omitted', () async {
+      when(mockedPlatform.login(any))
+          .thenAnswer((final _) async => TestPlatform.loginResult);
+
+      await Auth0('test-domain', 'test-clientId').api.login(
+          usernameOrEmail: 'test-user',
+          password: 'test-pass',
+          connectionOrRealm: 'test-realm');
+
+      final verificationResult = verify(mockedPlatform.login(captureAny))
+          .captured
+          .single as ApiRequest<AuthLoginOptions>;
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options.audience, null);
     });
   });
 
@@ -175,7 +197,8 @@ void main() {
               parameters: {'test': 'test-123'});
 
       final verificationResult =
-          verify(mockedPlatform.renewAccessToken(captureAny)).captured.single as ApiRequest<AuthRenewAccessTokenOptions>;
+          verify(mockedPlatform.renewAccessToken(captureAny)).captured.single
+              as ApiRequest<AuthRenewAccessTokenOptions>;
       expect(verificationResult.account.domain, 'test-domain');
       expect(verificationResult.account.clientId, 'test-clientId');
       expect(verificationResult.options.refreshToken, 'test-refresh-token');
@@ -193,7 +216,8 @@ void main() {
           .renewAccessToken(refreshToken: 'test-refresh-token');
 
       final verificationResult =
-          verify(mockedPlatform.renewAccessToken(captureAny)).captured.single as ApiRequest<AuthRenewAccessTokenOptions>;
+          verify(mockedPlatform.renewAccessToken(captureAny)).captured.single
+              as ApiRequest<AuthRenewAccessTokenOptions>;
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.options.scopes, []);
       // ignore: inference_failure_on_collection_literal

--- a/auth0_flutter_platform_interface/lib/src/auth/auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth/auth_login_options.dart
@@ -4,6 +4,7 @@ class AuthLoginOptions implements RequestOptions {
   final String usernameOrEmail;
   final String password;
   final String connectionOrRealm;
+  final String? audience;
   final Set<String> scopes;
   final Map<String, String> parameters;
 
@@ -11,6 +12,7 @@ class AuthLoginOptions implements RequestOptions {
       {required this.usernameOrEmail,
       required this.password,
       required this.connectionOrRealm,
+      this.audience,
       this.scopes = const {},
       this.parameters = const {}});
 
@@ -19,6 +21,7 @@ class AuthLoginOptions implements RequestOptions {
         'usernameOrEmail': usernameOrEmail,
         'password': password,
         'connectionOrRealm': connectionOrRealm,
+        'audience': audience,
         'scopes': scopes.toList(),
         'parameters': parameters
       };

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
@@ -229,6 +229,7 @@ void main() {
                 usernameOrEmail: 'test-email',
                 password: 'test-pass',
                 connectionOrRealm: 'test-connection',
+                audience: 'test-audience',
                 scopes: {'a', 'b'},
                 parameters: {'test': 'test-123'})),
       );
@@ -245,6 +246,7 @@ void main() {
       expect(verificationResult.arguments['password'], 'test-pass');
       expect(
           verificationResult.arguments['connectionOrRealm'], 'test-connection');
+      expect(verificationResult.arguments['audience'], 'test-audience');
       expect(verificationResult.arguments['scopes'], ['a', 'b']);
       expect(verificationResult.arguments['parameters']['test'], 'test-123');
     });


### PR DESCRIPTION
This PR adds the missing audience parameter to the API Login method.