### PR TITLE
Add support for custom parameters to Auth API userProfile (iOS) [SDK-3316]

### DIFF
--- a/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIUserInfoMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIUserInfoMethodHandlerTests.swift
@@ -18,13 +18,15 @@ class AuthAPIUserInfoMethodHandlerTests: XCTestCase {
 
 extension AuthAPIUserInfoMethodHandlerTests {
     func testProducesErrorWhenRequiredArgumentsAreMissing() {
-        let key = Argument.accessToken
-        let expectation = expectation(description: "\(key.rawValue) is missing")
-        sut.handle(with: arguments(without: key)) { result in
-            assert(result: result, isError: .requiredArgumentMissing(key.rawValue))
-            expectation.fulfill()
+        let keys: [Argument] = [.accessToken, .parameters]
+        let expectations = keys.map { expectation(description: "\($0.rawValue) is missing") }
+        for (argument, currentExpectation) in zip(keys, expectations) {
+            sut.handle(with: arguments(without: argument)) { result in
+                assert(result: result, isError: .requiredArgumentMissing(argument.rawValue))
+                currentExpectation.fulfill()
+            }
         }
-        wait(for: [expectation])
+        wait(for: expectations)
     }
 }
 
@@ -100,6 +102,6 @@ extension AuthAPIUserInfoMethodHandlerTests {
 
 extension AuthAPIUserInfoMethodHandlerTests {
     override func arguments() -> [String: Any] {
-        return [Argument.accessToken.rawValue: ""]
+        return [Argument.accessToken.rawValue: "", Argument.parameters.rawValue: [:]]
     }
 }

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
@@ -10,6 +10,7 @@ fileprivate extension MethodHandler {
 struct AuthAPIUserInfoMethodHandler: MethodHandler {
     enum Argument: String {
         case accessToken
+        case parameters
     }
 
     let client: Authentication
@@ -18,9 +19,13 @@ struct AuthAPIUserInfoMethodHandler: MethodHandler {
         guard let accessToken = arguments[Argument.accessToken.rawValue] as? String else {
             return callback(FlutterError(from: .requiredArgumentMissing(Argument.accessToken.rawValue)))
         }
+        guard let parameters = arguments[Argument.parameters] as? [String: Any] else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.parameters.rawValue)))
+        }
 
         client
             .userInfo(withAccessToken: accessToken)
+            .parameters(parameters)
             .start {
                 switch $0 {
                 case let .success(userInfo): callback(result(from: userInfo))


### PR DESCRIPTION
### Description

This PR has the iOS native layer accept a `parameters` argument in the Auth API `userProfile` method and passes it through to Auth0.Swift.

Note that while manual testing this, a bug was found in the underlying Auth0.swift SDK, as it is sending the parameters in the body of the request instead of as query parameters (this one being a GET request). This will need to get addressed in Auth0.swift.

**iOS**
<img width="861" alt="Screen Shot 2022-04-25 at 20 41 38" src="https://user-images.githubusercontent.com/5055789/165192378-5f2b30b0-2603-4fdc-b9a6-c423d46c7284.png">

**Android**
<img width="941" alt="Screen Shot 2022-04-25 at 20 41 23" src="https://user-images.githubusercontent.com/5055789/165192404-582119ba-77d2-43ec-9f7a-f321f9aa45fc.png">

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
