### PR TITLE
Include status code value in the details dictionary of the Auth API error (iOS) [SDK-3318]

### DIFF
--- a/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPIExtensionsTests.swift
@@ -27,7 +27,7 @@ class AuthAPIExtensionsTests: XCTestCase {
         for (flag, info) in errors {
             let error = AuthenticationError(info: info, statusCode: 400)
             let flutterError = FlutterError(from: error)
-            let flags = (flutterError.details as? [String: Any])?[AuthAPIErrorFlag.key] as? [String: Bool]
+            let flags = (flutterError.details as? [String: Any])?[AuthAPIErrorKey.errorFlags] as? [String: Bool]
             assert(flutterError: flutterError, is: error)
             XCTAssertEqual(flags?[flag], true)
         }

--- a/auth0_flutter/example/ios/Tests/ExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/ExtensionsTests.swift
@@ -9,6 +9,9 @@ class ExtensionsTests: XCTestCase {}
 // MARK: - Auth0Error+details
 
 extension ExtensionsTests {
+
+    // MARK: Cause
+
     func testReturnsNilWhenErrorIsAuth0ErrorWithNoCause() {
         XCTAssertNil(MockAuth0Error(debugDescription: "foo").details)
     }
@@ -30,6 +33,14 @@ extension ExtensionsTests {
         let error = MockAuth0APIError(info: [:], statusCode: 0, cause: cause)
         let expected = ["cause": String(describing: cause)]
         XCTAssertTrue(error.details == expected)
+    }
+
+    // MARK: Status code
+
+    func testRemovesStatusCodeWhenErrorIsAuth0APIError() {
+        let cause = MockError()
+        let error = MockAuth0APIError(info: [:], statusCode: 0, cause: cause)
+        XCTAssertNil(error.details?["statusCode"])
     }
 }
 

--- a/auth0_flutter/example/ios/Tests/Utilities.swift
+++ b/auth0_flutter/example/ios/Tests/Utilities.swift
@@ -106,10 +106,14 @@ func assert(flutterError: FlutterError, is authenticationError: AuthenticationEr
 
     XCTAssertEqual(flutterError.code, authenticationError.code)
     XCTAssertEqual(flutterError.message, String(describing: authenticationError))
-    XCTAssertTrue(details.filter({ $0.key != AuthAPIErrorFlag.key }) == authenticationError.details)
 
-    guard let flags = details[AuthAPIErrorFlag.key] as? [String: Bool] else {
-        return XCTFail("'details' is missing the '\(AuthAPIErrorFlag.key)' dictionary")
+    let keysToFilter = AuthAPIErrorKey.allCases.map(\.rawValue)
+
+    XCTAssertTrue(details.filter({ !keysToFilter.contains($0.key) }) == authenticationError.details)
+    XCTAssertEqual(details[AuthAPIErrorKey.statusCode] as? Int, authenticationError.statusCode)
+
+    guard let flags = details[AuthAPIErrorKey.errorFlags] as? [String: Bool] else {
+        return XCTFail("'details' is missing the '\(AuthAPIErrorKey.errorFlags.rawValue)' dictionary")
     }
 
     XCTAssertEqual(flags[AuthAPIErrorFlag.isMultifactorRequired], authenticationError.isMultifactorRequired)

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -17,8 +17,11 @@ enum AuthAPIErrorFlag: String, CaseIterable {
     case isPasswordLeaked
     case isLoginRequired
     case isNetworkError
+}
 
-    static let key = "_errorFlags"
+enum AuthAPIErrorKey: String, CaseIterable {
+    case errorFlags = "_errorFlags"
+    case statusCode = "_statusCode"
 }
 
 // MARK: - Extensions
@@ -43,7 +46,8 @@ extension FlutterError {
             AuthAPIErrorFlag.isNetworkError.rawValue: authenticationError.isNetworkError,
         ]
         var errorDetails = authenticationError.details ?? [:]
-        errorDetails[AuthAPIErrorFlag.key] = errorFlags
+        errorDetails[AuthAPIErrorKey.errorFlags] = errorFlags
+        errorDetails[AuthAPIErrorKey.statusCode] = authenticationError.statusCode
 
         self.init(code: authenticationError.code,
                   message: String(describing: authenticationError),

--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -35,6 +35,7 @@ extension Auth0Error {
     var details: [String: Any]? {
         if let apiError = self as? Auth0APIError {
             var info = apiError.info
+            info.removeValue(forKey: "statusCode")
             if let cause = cause {
                 info["cause"] = String(describing: cause)
             }


### PR DESCRIPTION
### Description

This PR includes the status code value from `AuthenticationError` in the details dictionary of `FlutterError`.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
