### PR TITLE
Specify the platform interface as a git dependency

### DIFF
--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   auth0_flutter_platform_interface:
-      git:
-        url: git@github.com:auth0/auth0-flutter.git
-        ref: main
-        path: auth0_flutter_platform_interface
+    git:
+      url: git@github.com:auth0/auth0-flutter.git
+      ref: main
+      path: auth0_flutter_platform_interface
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
### Description

To be able to install the EA SDK in an app, the dependency on the platform interface package cannot be a relative path.
This PR sets it to be a git package dependency, as specified in: https://dart.dev/tools/pub/dependencies#git-packages

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
