### PR TITLE
Export `IdTokenValidationConfig` from app-facing package [SDK-3326]

### DIFF
--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -5,7 +5,7 @@ import 'src/version.dart';
 import 'src/web_authentication.dart';
 
 export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart'
-    show WebAuthException, ApiException;
+    show WebAuthException, ApiException, IdTokenValidationConfig;
 
 class Auth0 {
   final Account _account;

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -16,6 +16,7 @@ export 'src/request/request.dart';
 export 'src/request/request_options.dart';
 export 'src/user_agent.dart';
 export 'src/user_profile.dart';
+export 'src/web-auth/id_token_validation_config.dart';
 export 'src/web-auth/web_auth_exception.dart';
 export 'src/web-auth/web_auth_login_input.dart';
 export 'src/web-auth/web_auth_logout_input.dart';

--- a/auth0_flutter_platform_interface/lib/src/web-auth/id_token_validation_config.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/id_token_validation_config.dart
@@ -1,0 +1,7 @@
+class IdTokenValidationConfig {
+  final int? leeway;
+  final String? issuer;
+  final int? maxAge;
+
+  const IdTokenValidationConfig({this.leeway, this.issuer, this.maxAge});
+}

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_input.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_input.dart
@@ -1,12 +1,5 @@
 import '../request/request_options.dart';
-
-class IdTokenValidationConfig {
-  final int? leeway;
-  final String? issuer;
-  final int? maxAge;
-
-  const IdTokenValidationConfig({this.leeway, this.issuer, this.maxAge});
-}
+import 'id_token_validation_config.dart';
 
 class WebAuthLoginInput implements RequestOptions {
   final IdTokenValidationConfig? idTokenValidationConfig;


### PR DESCRIPTION
### Description

The `IdTokenValidationConfig` class was not being exported from the app-facing package, and thus was inaccessible from an app.
This PR exports it so it is accessible.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
