### PR TITLE
Reference the platform interface package by its relative path

### DIFF
--- a/auth0_flutter/example/pubspec.lock
+++ b/auth0_flutter/example/pubspec.lock
@@ -18,11 +18,9 @@ packages:
   auth0_flutter_platform_interface:
     dependency: transitive
     description:
-      path: auth0_flutter_platform_interface
-      ref: main
-      resolved-ref: b6308b45305ce0a56ad9fb67ca127d99ed5aa83b
-      url: "git@github.com:auth0/auth0-flutter.git"
-    source: git
+      path: "../../auth0_flutter_platform_interface"
+      relative: true
+    source: path
     version: "0.0.1"
   boolean_selector:
     dependency: transitive

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -10,10 +10,7 @@ environment:
 
 dependencies:
   auth0_flutter_platform_interface:
-    git:
-      url: git@github.com:auth0/auth0-flutter.git
-      ref: main
-      path: auth0_flutter_platform_interface
+    path: ../auth0_flutter_platform_interface
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
## Description

This PR changes the platform interface package dependency in the `pubspec.yaml` to be a local relative reference, so it can be correctly referenced when installing the Flutter SDK via zip.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
