### PR TITLE
Add content in the example app's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Auth0 SDK for Flutter (Beta)
 
+Auth0 SDK for Android / iOS Flutter apps.
+
 > ⚠️ This library is currently in Beta. We do not recommend using this library in production yet. As we move towards First Availaibility, please be aware that releases may contain breaking changes.
 
 | Package                                                                 | Description                                   |
@@ -10,6 +12,12 @@
 ## Getting Started
 
 See the README of the [auth0_flutter](./auth0_flutter#readme) package.
+
+## Issue Reporting
+
+For general support or usage questions, use the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums or raise a [support ticket](https://support.auth0.com/). Only [raise an issue](https://github.com/auth0/auth0_flutter/issues) if you have found a bug or want to request a feature.
+
+**Do not report security vulnerabilities on the public GitHub issue tracker.** The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
 
 ## What is Auth0?
 

--- a/auth0_flutter/example/.env.example
+++ b/auth0_flutter/example/.env.example
@@ -1,3 +1,17 @@
+#
+# Your Auth0 Domain.
+# 
 AUTH0_DOMAIN=
+#
+# The Client Id of your Auth0 application.
+#
 AUTH0_CLIENT_ID=
-AUTH0_CUSTOM_SCHEME=
+#
+# The custom scheme for the Android callback and logout URLs.
+# Only set a value if you prefer not to use the default scheme (https).
+# If you set a value:
+# 1. Update the Android callback and logout URLs in the
+# settings page of your Auth0 application with the custom scheme value.
+# 2. Update the scheme value in android/app/src/main/res/values/strings.xml
+#
+# AUTH0_CUSTOM_SCHEME=

--- a/auth0_flutter/example/README.md
+++ b/auth0_flutter/example/README.md
@@ -1,16 +1,61 @@
 # auth0_flutter_example
 
-Demonstrates how to use the auth0_flutter plugin.
+Flutter app for Android / iOS that demonstrates how to use the auth0_flutter SDK.
 
-## Getting Started
+## Configuration
 
-This project is a starting point for a Flutter application.
+### 1. Configure Auth0 Application
 
-A few resources to get you started if this is your first Flutter project:
+Go to the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/) and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platforms used by your app. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with the value of your Custom Domain instead of the value from the settings page.
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+#### Android
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```text
+https://YOUR_AUTH0_DOMAIN/android/YOUR_APP_PACKAGE_NAME/callback
+```
+
+E.g. if your Auth0 Domain was `company.us.auth0.com` and your Android app package name was `com.company.myapp`, then this value would be:
+
+```text
+https://company.us.auth0.com/android/com.company.myapp/callback
+```
+
+#### iOS
+
+```text
+YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
+```
+
+E.g. if your iOS bundle identifier was `com.company.myapp` and your Auth0 Domain was `company.us.auth0.com`, then this value would be:
+
+```text
+com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
+```
+
+### 2. Configure Flutter app
+
+Rename the `.env.example` file to `.env`. Then, open it and fill in the values:
+
+- `AUTH0_DOMAIN`: your Auth0 Domain, e.g. `company.us.auth0.com`.
+- `AUTH0_CLIENT_ID`: the Client Id of your Auth0 application, available in its [settings page](https://manage.auth0.com/#/applications/).
+
+### 3. Configure Android project
+
+Open the `android/app/src/main/res/values/strings.xml` file and replace `YOUR_AUTH0_DOMAIN` with your own value, e.g. `company.us.auth0.com`. This value will be passed to the respective manifest placeholder.
+
+## What is Auth0?
+
+Auth0 helps you to:
+
+- Add authentication with [multiple sources](https://auth0.com/docs/authenticate/identity-providers), either social identity providers such as **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce** (amongst others), or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS, or any SAML Identity Provider**.
+- Add authentication through more traditional **[username/password databases](https://auth0.com/docs/authenticate/database-connections/custom-db)**.
+- Add support for **[linking different user accounts](https://auth0.com/docs/manage-users/user-accounts/user-account-linking)** with the same user.
+- Support for generating signed [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens) to call your APIs and **flow the user identity** securely.
+- Analytics of how, when, and where users are logging in.
+- Pull data from other sources and add it to the user profile through [JavaScript Actions](https://auth0.com/docs/customize/actions).
+
+**Why Auth0?** Because you should save time, be happy, and focus on what really matters: building your product.
+
+## License
+
+This project is licensed under the MIT license. See the [LICENSE](../LICENSE) file for more information.

--- a/auth0_flutter_platform_interface/README.md
+++ b/auth0_flutter_platform_interface/README.md
@@ -2,6 +2,12 @@
 
 This package provides the common interface for platform implementations.
 
+## Issue Reporting
+
+For general support or usage questions, use the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums or raise a [support ticket](https://support.auth0.com/). Only [raise an issue](https://github.com/auth0/auth0_flutter/issues) if you have found a bug or want to request a feature.
+
+**Do not report security vulnerabilities on the public GitHub issue tracker.** The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
+
 ## What is Auth0?
 
 Auth0 helps you to:


### PR DESCRIPTION
### Description

This PR adds configuration instructions to the example app README, along with some explicative comments in the app's `.env.example` file.
Also, an "Issue Reporting" section was added to the root README and the README of the platform interface package.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
