### PR TITLE
Update `SpyWebAuth` for Auth0.swift 2.1.0

### DIFF
--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
@@ -107,6 +107,10 @@ class SpyWebAuth: WebAuth {
         return self
     }
 
+    func provider(_ provider: @escaping WebAuthProvider) -> Self {
+        return self
+    }
+
     func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void) {
         calledLogin = true
         callback(loginResult)


### PR DESCRIPTION
### Description

This PR updates the `SpyWebAuth` test spy by adding the newly introduced method `provider(_:)` so it conforms to the `WebAuth` protocol. This method was introduced in [Auth0.swift 2.1.0](https://github.com/auth0/Auth0.swift/releases/tag/2.1.0).

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
