### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Stage: Beta Release](https://img.shields.io/badge/stage-beta-orange)
+[![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-flutter)](https://circleci.com/gh/auth0/auth0-flutter)
+[![Codecov](https://img.shields.io/codecov/c/github/auth0/auth0-flutter)](https://codecov.io/gh/auth0/auth0-flutter)
+
 # Auth0 SDK for Flutter (Beta)
 
 Auth0 SDK for Android / iOS Flutter apps.


### PR DESCRIPTION
### Description

Adds the following badges to the readme:

- beta indicator
- code coverage
- CI status

Both the code coverage and CI status badge won't work until the repo is made public.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
