### PR TITLE
Disable UI animations when smoke testing (iOS)

### DIFF
--- a/auth0_flutter/example/ios/Runner/AppDelegate.swift
+++ b/auth0_flutter/example/ios/Runner/AppDelegate.swift
@@ -3,11 +3,15 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        GeneratedPluginRegistrant.register(with: self)
+        if ProcessInfo.processInfo.arguments.contains("SmokeTests") {
+            self.window?.layer.speed = 0.0
+            UIView.setAnimationsEnabled(false)
+        }
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
 }

--- a/auth0_flutter/example/ios/UITests/SmokeTests.swift
+++ b/auth0_flutter/example/ios/UITests/SmokeTests.swift
@@ -11,6 +11,7 @@ class SmokeTests: XCTestCase {
     override func setUp() {
         continueAfterFailure = false
         let app = XCUIApplication()
+        app.launchArguments = ["SmokeTests"]
         app.launchEnvironment = ProcessInfo.processInfo.environment
         app.launch()
     }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR disables the UI animations when running the iOS smoke tests, for a faster and smoother test run.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
