### PR TITLE
Use Xcode version `13.0.0` instead of `13`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       ios_simulator:
         type: string
     macos:
-      xcode: 13
+      xcode: '13.0.0'
     environment:
       BUNDLE_RETRY: 3
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
### Description

This PRR updates the Xcode version in the CircleCI config from `13` to `13.0.0`, as `13` suddenly stopped working.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
