### PR TITLE
Rename `Credentials.userProfile` to `Credentials.user` [SDK-3461]

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -37,7 +37,7 @@ class Credentials {
   /// Properties and attributes relating to the authenticated user.
   ///
   /// [Read more about Auth0 User Profiles](https://auth0.com/docs/manage-users/user-accounts/user-profiles)
-  final UserProfile userProfile;
+  final UserProfile user;
 
   Credentials({
     required this.idToken,
@@ -45,7 +45,7 @@ class Credentials {
     this.refreshToken,
     required this.expiresAt,
     this.scopes = const {},
-    required this.userProfile,
+    required this.user,
   });
 
   factory Credentials.fromMap(final Map<dynamic, dynamic> result) =>
@@ -55,7 +55,7 @@ class Credentials {
         refreshToken: result['refreshToken'] as String?,
         expiresAt: DateTime.parse(result['expiresAt'] as String),
         scopes: Set<String>.from(result['scopes'] as List<Object?>),
-        userProfile: UserProfile.fromMap(Map<String, dynamic>.from(
+        user: UserProfile.fromMap(Map<String, dynamic>.from(
             result['userProfile'] as Map<dynamic, dynamic>)),
       );
 }

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
@@ -335,7 +335,7 @@ void main() {
       expect(result.scopes, MethodCallHandler.loginResult['scopes']);
       expect(
           result.refreshToken, MethodCallHandler.loginResult['refreshToken']);
-      expect(result.userProfile.name,
+      expect(result.user.name,
           MethodCallHandler.loginResult['userProfile']['name']);
     });
 
@@ -558,7 +558,7 @@ void main() {
           result.expiresAt,
           DateTime.parse(
               MethodCallHandler.renewResult['expiresAt'] as String));
-      expect(result.userProfile.name,
+      expect(result.user.name,
           MethodCallHandler.renewResult['userProfile']['name']);
     });
 

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -148,7 +148,7 @@ void main() {
       expect(result.scopes, MethodCallHandler.loginResult['scopes']);
       expect(
           result.refreshToken, MethodCallHandler.loginResult['refreshToken']);
-      expect(result.userProfile.name,
+      expect(result.user.name,
           MethodCallHandler.loginResult['userProfile']['name']);
     });
   


### PR DESCRIPTION
### Description

This PR renames the `userProfile` property from `Credentials` to `user`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
