### PR TITLE
chore: update ClearCredentials test assertion to be consistent with HasValidCredentials

### DIFF
--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearCredentialsRequestHandlerTest.kt
@@ -61,7 +61,6 @@ class ClearCredentialsRequestHandlerTest {
         val captor = argumentCaptor<Boolean>()
         verify(mockResult).success(captor.capture())
 
-        assert(captor.firstValue)
-
+        assertThat(captor.firstValue, equalTo(true))
     }
 }


### PR DESCRIPTION
The `clearCredentials` method on Android Credentials Manager handler always returns `true`, same as `hasValidCredentials`, but the assertion in the test is different. This PR aligns them.