### PR TITLE
Prepare auth0_flutter_platform_interface 1.0.0-beta.1 for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       ios_simulator:
         type: string
     macos:
-      xcode: 13
+      xcode: '13.0.0'
     environment:
       BUNDLE_RETRY: 3
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Change Log
 
-## [1.0.0-beta.0](https://github.com/auth0/Auth0.swift/tree/1.0.0-beta.0) (2022-05-05)
+## [1.0.0-beta.1](https://github.com/auth0/auth0-flutter/tree/1.0.0-beta.1) (2022-07-08)
+
+This is the first public beta release of the **Auth0 Flutter SDK**! 🎉 
+
+> ⚠️ This release is not yet suitable for use in production
+
+The Auth0 Flutter SDK is a new SDK designed to make it quick and easy to integrate Auth0 into Flutter applications. Today, the SDK offers the following features:
+
+- Support for iOS and Android
+- Integration with [Auth0 Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login)
+- Integration with the [Auth0 Authentication API](https://auth0.com/docs/api/authentication) for:
+  - username and password login
+  - signup
+  - refreshing access tokens
+  - password reset
+  - fetching user profile
+
+Check out [the Readme](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/README.md) for a more detailed run through of the capabilities and API.
+
+## [1.0.0-beta.0](https://github.com/auth0/auth0-flutter/tree/1.0.0-beta.0) (2022-05-05)
 
 **Added**
 

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,16 +1,14 @@
 name: auth0_flutter
-description: A new flutter plugin project.
-version: 1.0.0-beta.0
+description: Auth0 SDK for Flutter
+version: 1.0.0-beta.1 
 homepage: https://github.com/auth0/auth0-flutter
-publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
-  auth0_flutter_platform_interface:
-    path: ../auth0_flutter_platform_interface
+  auth0_flutter_platform_interface: 1.0.0-beta.1
   flutter:
     sdk: flutter
 

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -2,13 +2,15 @@ name: auth0_flutter
 description: Auth0 SDK for Flutter
 version: 1.0.0-beta.1 
 homepage: https://github.com/auth0/auth0-flutter
+publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
-  auth0_flutter_platform_interface: 1.0.0-beta.1
+  auth0_flutter_platform_interface:
+    path: ../auth0_flutter_platform_interface
   flutter:
     sdk: flutter
 

--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Change Log
 
-## [1.0.0-beta.0](https://github.com/auth0/Auth0.swift/tree/1.0.0-beta.0) (2022-05-05)
+## [1.0.0-beta.1](https://github.com/auth0/auth0-flutter/tree/1.0.0-beta.1) (2022-07-08)
+
+This is the first public beta release of the **Auth0 Flutter SDK**! 🎉 
+
+> ⚠️ This release is not yet suitable for use in production
+
+The Auth0 Flutter SDK is a new SDK designed to make it quick and easy to integrate Auth0 into Flutter applications. Today, the SDK offers the following features:
+
+- Support for iOS and Android
+- Integration with [Auth0 Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login)
+- Integration with the [Auth0 Authentication API](https://auth0.com/docs/api/authentication) for:
+  - username and password login
+  - signup
+  - refreshing access tokens
+  - password reset
+  - fetching user profile
+
+Check out [the Readme](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/README.md) for a more detailed run through of the capabilities and API.
+
+## [1.0.0-beta.0](https://github.com/auth0/auth0-flutter/tree/1.0.0-beta.0) (2022-05-05)
 
 **Added**
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter plugin.
-version: 1.0.0-beta.0
+version: 1.0.0-beta.1
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:


### PR DESCRIPTION
This sets up the changelog for both packages to reflect the 1.0.0-beta.1 release, as well as some changes in the pubspec.yml files.

This will allow me to publish `auth0_flutter_platform_interface`; a release PR for `auth0_flutter` will follow shortly after.