### PR TITLE
Add `offline_access` to the default scope [SDK-3435]

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -223,7 +223,7 @@ final result = await auth0.webAuthentication.login();
 <details>
   <summary>Add scope values</summary>
 
-  Specify [scopes](https://auth0.com/docs/get-started/apis/scopes) to request permission to access protected resources, like the user profile. The default scope values are `openid`, `profile` and `email`. Regardless of the values specified, `openid` is always included.
+  Specify [scopes](https://auth0.com/docs/get-started/apis/scopes) to request permission to access protected resources, like the user profile. The default scope values are `openid`, `profile`, `email`, and `offline_access`. Regardless of the values specified, `openid` is always included.
 
   ```dart
   final result = await auth0.webAuthentication
@@ -371,7 +371,7 @@ final result = await auth0.api.login(
 <details>
   <summary>Add scope values</summary>
 
-  Specify [scopes](https://auth0.com/docs/get-started/apis/scopes) to request permission to access protected resources, like the user profile. The default scope values are `openid`, `profile` and `email`. Regardless of the values specified, `openid` is always included.
+  Specify [scopes](https://auth0.com/docs/get-started/apis/scopes) to request permission to access protected resources, like the user profile. The default scope values are `openid`, `profile`, `email`, and `offline_access`. Regardless of the values specified, `openid` is always included.
 
   ```dart
   final result = await auth0.api.login(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -37,9 +37,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
             );
 
         val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
-        if (scopes.isNotEmpty()) {
-            loginBuilder.setScope(scopes.joinToString(separator = " "))
-        }
+        loginBuilder.setScope(scopes.joinToString(separator = " "))
 
         if (args.getOrDefault("audience", null) is String) {
             loginBuilder.setAudience(args["audience"] as String)

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -25,9 +25,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
         val args = request.data
         val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
 
-        if (scopes.isNotEmpty()) {
-            builder.withScope(scopes.joinToString(separator = " "))
-        }
+        builder.withScope(scopes.joinToString(separator = " "))
 
         if (args.getOrDefault("audience", null) is String) {
             builder.withAudience(args["audience"] as String)

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -24,7 +24,7 @@ import java.util.*
 @RunWith(RobolectricTestRunner::class)
 class LoginWebAuthRequestHandlerTest {
     private val defaultCredentials =
-        Credentials(JwtTestUtils.createJwt(), "test", "", null, Date(), "openid profile email")
+        Credentials(JwtTestUtils.createJwt(), "test", "", null, Date(), "openid profile email offline_access")
 
     fun runRequestHandler(
         args: HashMap<String, Any?> = hashMapOf(),
@@ -61,11 +61,11 @@ class LoginWebAuthRequestHandlerTest {
                 assertThat(map["idToken"], equalTo(defaultCredentials.idToken))
                 assertThat(map["accessToken"], equalTo(defaultCredentials.accessToken))
                 assertThat(map["expiresAt"], equalTo(formattedDate))
-                assertThat(map["scopes"], equalTo(listOf("openid", "profile", "email")))
+                assertThat(map["scopes"], equalTo(listOf("openid", "profile", "email", "offline_access")))
                 assertThat(map["refreshToken"], nullValue())
             })
 
-            verify(builder, never()).withScope(any())
+            verify(builder).withScope("")
             verify(builder, never()).withAudience(any())
             verify(builder, never()).withOrganization(any())
             verify(builder, never()).withInvitationUrl(any())
@@ -81,31 +81,31 @@ class LoginWebAuthRequestHandlerTest {
     @Test
     fun `handler should request scopes from the SDK when specified`() {
         val args = hashMapOf<String, Any?>(
-            "scopes" to arrayListOf("openid", "profile", "email")
+            "scopes" to arrayListOf("openid", "profile", "email", "offline_access")
         )
 
         runRequestHandler(args) { _, builder ->
-            verify(builder).withScope("openid profile email")
+            verify(builder).withScope("openid profile email offline_access")
         }
     }
 
     @Test
-    fun `handler should not add scopes when given an empty array`() {
+    fun `handler should add an empty scope when given an empty array`() {
         val args = hashMapOf<String, Any?>(
             "scopes" to arrayListOf<String>()
         )
 
         runRequestHandler(args) { _, builder ->
-            verify(builder, never()).withScope(anyOrNull())
+            verify(builder).withScope("")
         }
     }
 
     @Test
-    fun `handler should not add scopes when not specified`() {
+    fun `handler should add an empty scope when not specified`() {
         val args = hashMapOf<String, Any?>()
 
         runRequestHandler(args) { _, builder ->
-            verify(builder, never()).withScope(anyOrNull())
+            verify(builder).withScope("")
         }
     }
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
@@ -201,7 +201,7 @@ class LoginApiRequestHandlerTest {
     }
 
     @Test
-    fun `should not configure the scopes when not provided`() {
+    fun `should configure an empty scope when not provided`() {
         val options = hashMapOf(
             "usernameOrEmail" to "test-email",
             "password" to "test-pass",
@@ -223,7 +223,7 @@ class LoginApiRequestHandlerTest {
             mockResult
         );
 
-        verify(mockLoginBuilder, times(0)).setScope(any());
+        verify(mockLoginBuilder).setScope("");
     }
 
     @Test

--- a/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandlerTests.swift
@@ -85,9 +85,9 @@ extension AuthAPILoginUsernameOrEmailMethodHandlerTests {
         XCTAssertEqual(spy.arguments["scope"] as? String, value.asSpaceSeparatedString)
     }
 
-    func testAddsDefaultScopesWhenEmpty() {
+    func testAddsEmptyScopeWhenEmpty() {
         sut.handle(with: arguments(withKey: Argument.scopes, value: [])) { _ in }
-        XCTAssertEqual(spy.arguments["scope"] as? String, Auth0.defaultScope)
+        XCTAssertEqual(spy.arguments["scope"] as? String, "")
     }
 
     // MARK: audience

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerSpies.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerSpies.swift
@@ -13,7 +13,6 @@ class SpyCredentialsStorage: CredentialsStorage {
 
     func getEntry(forKey key: String) -> Data? {
         self.calledGetEntry = true
-        print("called get entry: \(self.calledGetEntry)")
         return self.getEntryReturnValue
     }
 

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
@@ -79,9 +79,9 @@ extension WebAuthLoginHandlerTests {
         XCTAssertEqual(spy.scopeValue, value.asSpaceSeparatedString)
     }
 
-    func testDoesNotAddScopesWhenEmpty() {
+    func testAddsEmptyScopeWhenEmpty() {
         sut.handle(with: arguments(withKey: Argument.scopes, value:  [])) { _ in }
-        XCTAssertNil(spy.scopeValue)
+        XCTAssertEqual(spy.scopeValue, "")
     }
 
     // MARK: audience

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
@@ -37,7 +37,7 @@ struct AuthAPILoginUsernameOrEmailMethodHandler: MethodHandler {
                    password: password,
                    realmOrConnection: connectionOrRealm,
                    audience: audience,
-                   scope: scopes.isEmpty ? Auth0.defaultScope : scopes.asSpaceSeparatedString)
+                   scope: scopes.asSpaceSeparatedString)
             .parameters(parameters)
             .start {
                 switch $0 {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -29,11 +29,9 @@ struct WebAuthLoginMethodHandler: MethodHandler {
             return callback(FlutterError(from: .requiredArgumentMissing(Argument.parameters.rawValue)))
         }
 
-        var webAuth = client.parameters(parameters)
-
-        if !scopes.isEmpty {
-            webAuth = webAuth.scope(scopes.asSpaceSeparatedString)
-        }
+        var webAuth = client
+            .scope(scopes.asSpaceSeparatedString)
+            .parameters(parameters)
 
         if useEphemeralSession {
             webAuth = webAuth.useEphemeralSession()

--- a/auth0_flutter/lib/src/authentication_api.dart
+++ b/auth0_flutter/lib/src/authentication_api.dart
@@ -38,7 +38,7 @@ class AuthenticationApi {
   /// ## Notes
   ///
   /// * [audience] relates to the API Identifier you want to reference in your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings))
-  /// * [scopes] defaults to `openid profile email`
+  /// * [scopes] defaults to `openid profile email offline_access`
   /// * [parameters] can be used to sent through custom parameters to the endpoint to be picked up in a Rule or Action.
   ///
   /// ## Usage example
@@ -55,7 +55,12 @@ class AuthenticationApi {
     required final String password,
     required final String connectionOrRealm,
     final String? audience,
-    final Set<String> scopes = const {},
+    final Set<String> scopes = const {
+      'openid',
+      'profile',
+      'email',
+      'offline_access'
+    },
     final Map<String, String> parameters = const {},
   }) =>
       Auth0FlutterAuthPlatform.instance
@@ -134,7 +139,7 @@ class AuthenticationApi {
   ///   usernameOrEmail: 'my@email.com',
   ///   password: 'my_password'
   ///   connectionOrRealm: 'Username-Password-Authentication',
-  ///   scopes: {'openid', 'profile', 'email', 'offline_access'}
+  ///   scopes: {'openid', 'profile', 'email', 'phone', 'offline_access'}
   /// });
   ///
   /// if (result.refreshToken != null) {

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -39,13 +39,18 @@ class WebAuthentication {
   /// * (iOS only): [useEphemeralSession] controls whether shared persistent storage is used for cookies. [Read more on the effects this setting has](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md#1-how-can-i-disable-the-login-alert-box)
   /// * (Android only): specify [scheme] if you're using a custom URL scheme for your app. This value must match the value used to configure the `auth0Scheme` manifest placeholder, for the Redirect intent filter to work
   /// * [audience] relates to the API Identifier you want to reference in your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings))
-  /// * [scopes] defaults to `openid profile email`. You can override these scopes, but `openid` is always requested regardless of this setting.
+  /// * [scopes] defaults to `openid profile email offline_access`. You can override these scopes, but `openid` is always requested regardless of this setting.
   /// * Arbitrary [parameters] can be specified and then picked up in a custom Auth0 [Action](https://auth0.com/docs/customize/actions) or [Rule](https://auth0.com/docs/customize/rules).
   /// * If you want to log into a specific organization, provide the [organizationId]. Provide [invitationUrl] if a user has been invited to
   ///   join an organization.
   Future<Credentials> login({
     final String? audience,
-    final Set<String> scopes = const {},
+    final Set<String> scopes = const {
+      'openid',
+      'profile',
+      'email',
+      'offline_access'
+    },
     final String? redirectUrl,
     final String? organizationId,
     final String? invitationUrl,

--- a/auth0_flutter/test/authentication_api_test.dart
+++ b/auth0_flutter/test/authentication_api_test.dart
@@ -21,7 +21,7 @@ class TestPlatform extends Mock
     'idToken': 'idToken',
     'refreshToken': 'refreshToken',
     'expiresAt': DateTime.now().toIso8601String(),
-    'scopes': ['a'],
+    'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'
   });
@@ -31,7 +31,7 @@ class TestPlatform extends Mock
     'idToken': 'idToken',
     'refreshToken': 'refreshToken',
     'expiresAt': DateTime.now().toIso8601String(),
-    'scopes': ['a'],
+    'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'
   });
@@ -131,7 +131,8 @@ void main() {
           .captured
           .single as ApiRequest<AuthLoginOptions>;
       // ignore: inference_failure_on_collection_literal
-      expect(verificationResult.options.scopes, []);
+      expect(verificationResult.options.scopes,
+          ['openid', 'profile', 'email', 'offline_access']);
       // ignore: inference_failure_on_collection_literal
       expect(verificationResult.options.parameters, {});
       expect(result, TestPlatform.loginResult);

--- a/auth0_flutter/test/web_authentication_test.dart
+++ b/auth0_flutter/test/web_authentication_test.dart
@@ -148,6 +148,27 @@ void main() {
           verificationResult.accessToken, TestPlatform.loginResult.accessToken);
     });
 
+    test('set scope and parameters to default value when omitted', () async {
+      when(mockedPlatform.login(any))
+          .thenAnswer((final _) async => TestPlatform.loginResult);
+      when(mockedCMPlatform.saveCredentials(any))
+          .thenAnswer((final _) async => true);
+
+      final result = await Auth0('test-domain', 'test-clientId')
+          .webAuthentication()
+          .login();
+
+      final verificationResult = verify(mockedPlatform.login(captureAny))
+          .captured
+          .single as WebAuthRequest<WebAuthLoginOptions>;
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options.scopes,
+          ['openid', 'profile', 'email', 'offline_access']);
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options.parameters, {});
+      expect(result, TestPlatform.loginResult);
+    });
+  
     test('does not use EphemeralSession by default', () async {
       when(mockedPlatform.login(any))
           .thenAnswer((final _) async => TestPlatform.loginResult);


### PR DESCRIPTION
### Description

This PR moves the default scope value from the native SDK layer to the Dart layer, and updates it to be `openid profile email offline_access`. 

Previously, the default scope value was set by Auth0.Android and Auth0.swift, and was equal to `openid profile email`. This meant that the native wrapper code would not pass along any empty scope values received from the Dart layer, to allow that default value to be set by Auth0.Android and Auth0.swift. Now, the Dart layer is setting the default scope value, so we pass along the received value as-is to Auth0.Android and Auth0.swift. These native SDKs will make sure to add `openid` to any received scope value that does not already have it, even if it's empty. 

### Testing

The unit tests were updated, and also the changes were tested manually using an iPhone 13 simulator running iOS 15.5 and an Android emulator running Android 12 (API 31).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
