### PR TITLE
Fix token type key in Kotlin handlers

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -74,7 +74,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
                         "userProfile" to userProfile.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scope,
-                        "type" to credentials.type
+                        "tokenType" to credentials.type
                     )
                 )
             }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -63,7 +63,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
                         "userProfile" to userProfile.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scope,
-                        "type" to credentials.type
+                        "tokenType" to credentials.type
                     )
                 )
             }


### PR DESCRIPTION
### Description

This PR fixes an issue where the Login and Renew handlers from the Android Auth API client were returning the wrong key for the token type, causing an error in the Dart code. `type` was the key being returned by these handlers, while the Dart code [expected](https://github.com/auth0/auth0-flutter/blob/first-availability/auth0_flutter_platform_interface/lib/src/credentials.dart#L62) `tokenType`. 

<img width="1106" alt="Screen Shot 2022-07-08 at 20 32 18" src="https://user-images.githubusercontent.com/5055789/178082035-685d8dfa-3b75-4bc0-a12c-a1d7923f3f13.png">

This was found while manually testing the changes in https://github.com/auth0/auth0-flutter/pull/112.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
