### PR TITLE
Use current Circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
 jobs:
   test_flutter_package:
     docker:
-      - image: cimg/base:2022.04
+      - image: cimg/base:current
     steps:
       - checkout
       - flutter/install_sdk_and_pub:


### PR DESCRIPTION
### Description

This PR uses the `current` CircleCI Docker image instead of the `2022.04`, so it's always up-to-date.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
