### PR TITLE
Add GitHub templates [SDK-3493]

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -1,0 +1,78 @@
+name: 🐞 Report a bug
+description: Have you found a bug or issue? Create a bug report for this library
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please do not report security vulnerabilities here**. The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: The issue can be reproduced in the [auth0_flutter sample app](https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample) (or N/A).
+          required: true
+        - label: I have looked into the [README](https://github.com/auth0/auth0-flutter/tree/main/auth0_flutter#readme) and have not found a suitable solution or answer.
+          required: true
+        - label: I have looked into the [API documentation](https://pub.dev/documentation/auth0_flutter/latest/) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [issues](https://github.com/auth0/auth0-flutter/issues) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums and have not found a suitable solution or answer.
+          required: true
+        - label: I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the issue, including what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
+      placeholder: |
+        1. Step 1...
+        2. Step 2...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: environment-version
+    attributes:
+      label: auth0_flutter version
+    validations:
+      required: true
+
+  - type: input
+    id: environment-flutter-version
+    attributes:
+      label: Flutter version
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment-platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - Android
+        - iOS
+    validations:
+      required: true
+
+  - type: input
+    id: environment-platform-version
+    attributes:
+      label: Platform version(s)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/Feature Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature Request.yml
@@ -1,0 +1,53 @@
+name: 🧩 Feature request
+description: Suggest an idea or a feature for this library
+labels: ["feature request"]
+
+body:
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have looked into the [README](https://github.com/auth0/auth0-flutter/tree/main/auth0_flutter#readme) and have not found a suitable solution or answer.
+          required: true
+        - label: I have looked into the [API documentation](https://pub.dev/documentation/auth0_flutter/latest/) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [issues](https://github.com/auth0/auth0-flutter/issues) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums and have not found a suitable solution or answer.
+          required: true
+        - label: I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem you'd like to have solved
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe the ideal solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-and-workarounds
+    attributes:
+      label: Alternatives and current workarounds
+      description: A clear and concise description of any alternatives you've considered or any workarounds that are currently in place.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Help & Questions
+    url: https://community.auth0.com/c/sdks/5
+    about: Ask general support or usage questions in the Auth0 Community forums.
+  - name: 📑 FAQ
+    url: https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md
+    about: Check some commonly asked questions.
+  - name: 📖 API Documentation
+    url: https://pub.dev/documentation/auth0_flutter/latest/
+    about: Check the public API documentation for in-depth overview of all the available features.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
+
+By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
+-->
+
+- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
+- [ ] I have added documentation for all new/changed functionality (or N/A)
+
+<!--
+❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 📋 Changes
+
+<!--
+Describe both what is changing and why this is important. Include:
+
+- Types and methods added, deleted, deprecated, or changed
+- A summary of usage if this is a new feature or a change to a public API
+-->
+
+### 📎 References
+
+<!--
+Add relevant links supporting this change, such as:
+
+- GitHub issue/PR number addressed or fixed
+- Auth0 Community post
+- StackOverflow answer
+- Related pull requests/issues from other repositories
+
+If there are no references, simply delete this section.
+-->
+
+### 🎯 Testing
+
+<!--
+Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 ❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
-By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
+By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
 - [ ] All new/changed/fixed functionality is covered by tests (or N/A)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ By submitting a Pull Request to this repository, you agree to the terms within t
 - [ ] I have added documentation for all new/changed functionality (or N/A)
 
 <!--
-❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
+❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
 -->
 
 ### 📋 Changes


### PR DESCRIPTION
### Description

This PR adds GitHub [form issues](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) for feature requests and bug reports, and a pull request template.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
