### PR TITLE
fix(android): hasValidCredentials accepts minTtl as int

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandler.kt
@@ -15,9 +15,9 @@ class HasValidCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        var minTtl = request.data.get("minTtl") as Long? ?: 0;
+        val minTtl = request.data.get("minTtl") as Int? ?: 0;
 
-        result.success(credentialsManager.hasValidCredentials(minTtl));
+        result.success(credentialsManager.hasValidCredentials(minTtl.toLong()));
     }
 
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandlerTest.kt
@@ -17,13 +17,13 @@ class HasValidCredentialsRequestHandlerTest {
     @Test
     fun `should call hasValidCredentials with the correct parameters`() {
         val handler = HasValidCredentialsRequestHandler();
-        var minTtl: Long = 30;
+        val minTtl = 30;
         val options = hashMapOf(
             "minTtl" to minTtl,
         );
         val mockResult = mock<Result>();
         val mockAccount = mock<Auth0>();
-        var mockCredentialsManager = mock<SecureCredentialsManager>();
+        val mockCredentialsManager = mock<SecureCredentialsManager>();
         val request = MethodCallRequest(account = mockAccount, options);
 
         handler.handle(
@@ -33,7 +33,7 @@ class HasValidCredentialsRequestHandlerTest {
             mockResult
         );
 
-        verify(mockCredentialsManager).hasValidCredentials(minTtl);
+        verify(mockCredentialsManager).hasValidCredentials(minTtl.toLong());
     }
 
     @Test
@@ -41,7 +41,7 @@ class HasValidCredentialsRequestHandlerTest {
         val handler = HasValidCredentialsRequestHandler();
         val mockResult = mock<Result>();
         val mockAccount = mock<Auth0>();
-        var mockCredentialsManager = mock<SecureCredentialsManager>();
+        val mockCredentialsManager = mock<SecureCredentialsManager>();
         val request = MethodCallRequest(account = mockAccount, mock());
 
         handler.handle(
@@ -57,13 +57,13 @@ class HasValidCredentialsRequestHandlerTest {
     @Test
     fun `should call result success on success`() {
         val handler = HasValidCredentialsRequestHandler();
-        var minTtl: Long = 30;
+        val minTtl = 30;
         val options = hashMapOf(
             "minTtl" to minTtl,
         );
         val mockResult = mock<Result>();
         val mockAccount = mock<Auth0>();
-        var mockCredentialsManager = mock<SecureCredentialsManager>();
+        val mockCredentialsManager = mock<SecureCredentialsManager>();
         val request = MethodCallRequest(account = mockAccount, options);
 
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This fixes an issue where `minTtl` is sent as an argument for `hasValidCredentials` as an `int`, but on Android this wrongly expects a `Long`.

It also fixes up a few cases where `val` could safely be used for immutability.

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Unit tests updated to match new requirements.