### PR TITLE
Have the Credentials Manager API follow the Dart design guidelines

### DIFF
--- a/auth0_flutter/lib/src/credentials_manager.dart
+++ b/auth0_flutter/lib/src/credentials_manager.dart
@@ -8,7 +8,7 @@ abstract class CredentialsManager {
     final Map<String, String> parameters = const {},
   });
 
-  Future<bool> set(final Credentials credentials);
+  Future<bool> storeCredentials(final Credentials credentials);
 
   Future<bool> hasValidCredentials({
     final int minTtl = 0,
@@ -51,7 +51,7 @@ class DefaultCredentialsManager extends CredentialsManager {
 
   /// Stores the given credentials in the storage. Must have an `access_token` or `id_token` and a `expires_in` value.
   @override
-  Future<bool> set(final Credentials credentials) =>
+  Future<bool> storeCredentials(final Credentials credentials) =>
       CredentialsManagerPlatform.instance.saveCredentials(
           _createApiRequest(SaveCredentialsOptions(credentials: credentials)));
 

--- a/auth0_flutter/lib/src/credentials_manager.dart
+++ b/auth0_flutter/lib/src/credentials_manager.dart
@@ -2,7 +2,7 @@ import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
 
 /// Abstract CredentialsManager that can be used to provide a custom CredentialManager.
 abstract class CredentialsManager {
-  Future<Credentials> get({
+  Future<Credentials> credentials({
     final int minTtl = 0,
     final Set<String> scopes = const {},
     final Map<String, String> parameters = const {},
@@ -37,7 +37,7 @@ class DefaultCredentialsManager extends CredentialsManager {
   /// Use the [scopes] parameter to set the scope to request for the access token. If `null` is passed, the previous scope will be kept.
   /// Use the [parameters] parameter to send additional parameters in the request to refresh expired credentials.
   @override
-  Future<Credentials> get({
+  Future<Credentials> credentials({
     final int minTtl = 0,
     final Set<String> scopes = const {},
     final Map<String, String> parameters = const {},

--- a/auth0_flutter/lib/src/credentials_manager.dart
+++ b/auth0_flutter/lib/src/credentials_manager.dart
@@ -14,7 +14,7 @@ abstract class CredentialsManager {
     final int minTtl = 0,
   });
 
-  Future<bool> clear();
+  Future<bool> clearCredentials();
 }
 
 /// Default [CredentialsManager] implementation that passes calls to
@@ -67,7 +67,7 @@ class DefaultCredentialsManager extends CredentialsManager {
 
   /// Removes the credentials from the storage if present.
   @override
-  Future<bool> clear() => CredentialsManagerPlatform.instance
+  Future<bool> clearCredentials() => CredentialsManagerPlatform.instance
       .clearCredentials(_createApiRequest(null));
 
   CredentialsManagerRequest<TOptions>

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -88,7 +88,7 @@ class WebAuthentication {
     await Auth0FlutterWebAuthPlatform.instance.logout(_createWebAuthRequest(
       WebAuthLogoutOptions(returnTo: returnTo, scheme: scheme),
     ));
-    await _credentialsManager?.clear();
+    await _credentialsManager?.clearCredentials();
   }
 
   WebAuthRequest<TOptions>

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -72,7 +72,7 @@ class WebAuthentication {
             scheme: scheme,
             useEphemeralSession: useEphemeralSession)));
 
-    await _credentialsManager?.set(credentials);
+    await _credentialsManager?.storeCredentials(credentials);
 
     return credentials;
   }

--- a/auth0_flutter/test/credentials_manager_test.dart
+++ b/auth0_flutter/test/credentials_manager_test.dart
@@ -77,7 +77,8 @@ void main() {
       when(mockedPlatform.saveCredentials(any))
           .thenAnswer((final _) async => true);
 
-      await DefaultCredentialsManager(account, userAgent).set(TestPlatform.credentials);
+      await DefaultCredentialsManager(account, userAgent)
+          .storeCredentials(TestPlatform.credentials);
 
       final verificationResult =
           verify(mockedPlatform.saveCredentials(captureAny)).captured.single

--- a/auth0_flutter/test/credentials_manager_test.dart
+++ b/auth0_flutter/test/credentials_manager_test.dart
@@ -153,7 +153,7 @@ void main() {
       when(mockedPlatform.clearCredentials(any))
           .thenAnswer((final _) async => true);
 
-      await DefaultCredentialsManager(account, userAgent).clear();
+      await DefaultCredentialsManager(account, userAgent).clearCredentials();
 
       final verificationResult =
           verify(mockedPlatform.clearCredentials(captureAny)).captured.single

--- a/auth0_flutter/test/credentials_manager_test.dart
+++ b/auth0_flutter/test/credentials_manager_test.dart
@@ -43,7 +43,7 @@ void main() {
           .thenAnswer((final _) async => TestPlatform.credentials);
 
       await DefaultCredentialsManager(account, userAgent)
-          .get(minTtl: 30, scopes: {'a', 'b'}, parameters: {'a': 'b'});
+          .credentials(minTtl: 30, scopes: {'a', 'b'}, parameters: {'a': 'b'});
 
       final verificationResult =
           verify(mockedPlatform.getCredentials(captureAny)).captured.single
@@ -60,7 +60,7 @@ void main() {
       when(mockedPlatform.getCredentials(any))
           .thenAnswer((final _) async => TestPlatform.credentials);
 
-      await DefaultCredentialsManager(account, userAgent).get();
+      await DefaultCredentialsManager(account, userAgent).credentials();
 
       final verificationResult =
           verify(mockedPlatform.getCredentials(captureAny)).captured.single

--- a/auth0_flutter/test/web_authentication_test.dart
+++ b/auth0_flutter/test/web_authentication_test.dart
@@ -242,7 +242,7 @@ void main() {
       when(mockedCMPlatform.clearCredentials(any))
           .thenAnswer((final _) async => true);
       final mockCm = MockCredentialsManager();
-      when(mockCm.clear())
+      when(mockCm.clearCredentials())
           .thenAnswer((final _) async => true);
 
       await Auth0('test-domain', 'test-clientId')
@@ -252,7 +252,7 @@ void main() {
       // Verify it doesn't call our own Platform Interface when providing a custom CredentialsManager
       verifyNever(mockedCMPlatform.clearCredentials(any));
 
-      verify(mockCm.clear()).called(1);
+      verify(mockCm.clearCredentials()).called(1);
     });
   });
 }

--- a/auth0_flutter/test/web_authentication_test.dart
+++ b/auth0_flutter/test/web_authentication_test.dart
@@ -125,7 +125,7 @@ void main() {
           .thenAnswer((final _) async => true);
       final mockCm = MockCredentialsManager();
 
-      when(mockCm.set(any))
+      when(mockCm.storeCredentials(any))
           .thenAnswer((final _) async => true);
 
       await Auth0('test-domain', 'test-clientId')
@@ -142,7 +142,9 @@ void main() {
       verifyNever(mockedCMPlatform.saveCredentials(any));
 
       final verificationResult =
-          verify(mockCm.set(captureAny)).captured.single as Credentials;
+          verify(mockCm.storeCredentials(captureAny))
+          .captured
+          .single as Credentials;
 
       expect(
           verificationResult.accessToken, TestPlatform.loginResult.accessToken);

--- a/auth0_flutter/test/web_authentication_test.mocks.dart
+++ b/auth0_flutter/test/web_authentication_test.mocks.dart
@@ -97,7 +97,7 @@ class MockCredentialsManager extends _i1.Mock
               returnValue: Future<_i2.Credentials>.value(_FakeCredentials_0()))
           as _i4.Future<_i2.Credentials>);
   @override
-  _i4.Future<bool> set(_i2.Credentials? credentials) =>
+  _i4.Future<bool> storeCredentials(_i2.Credentials? credentials) =>
       (super.noSuchMethod(Invocation.method(#set, [credentials]),
           returnValue: Future<bool>.value(true),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<bool>);

--- a/auth0_flutter/test/web_authentication_test.mocks.dart
+++ b/auth0_flutter/test/web_authentication_test.mocks.dart
@@ -87,7 +87,7 @@ class MockCredentialsManager extends _i1.Mock
   }
 
   @override
-  _i4.Future<_i2.Credentials> get(
+  _i4.Future<_i2.Credentials> credentials(
           {int? minTtl = 0,
           Set<String>? scopes = const {},
           Map<String, String>? parameters = const {}}) =>

--- a/auth0_flutter/test/web_authentication_test.mocks.dart
+++ b/auth0_flutter/test/web_authentication_test.mocks.dart
@@ -107,7 +107,8 @@ class MockCredentialsManager extends _i1.Mock
           Invocation.method(#hasValidCredentials, [], {#minTtl: minTtl}),
           returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
   @override
-  _i4.Future<bool> clear() => (super.noSuchMethod(Invocation.method(#clear, []),
+  _i4.Future<bool> clearCredentials() =>
+      (super.noSuchMethod(Invocation.method(#clear, []),
       returnValue: Future<bool>.value(true),
       returnValueForMissingStub: Future<void>.value()) as _i4.Future<bool>);
 }


### PR DESCRIPTION
### Description

This PR renames the following Credentials Manager methods:

- `get()` to `credentials()`
- `set()` to `storeCredentials()`
- `clear()` to `clearCredentials()`

The `hasValidCredentials()` method was left as-is.

#### Why

In the case of `get()`, the Dart design guidelines instruct (1) to [avoid starting a method name](https://dart.dev/guides/language/effective-dart/design#avoid-starting-a-method-name-with-get) with `get`, and (2) to [have the code read like a sentence](https://dart.dev/guides/language/effective-dart/design#consider-making-the-code-read-like-a-sentence). 

<img width="1007" alt="Screen Shot 2022-07-13 at 22 48 07" src="https://user-images.githubusercontent.com/5055789/178883863-fecff745-7090-43a3-8477-f3d04162f148.png">

<img width="973" alt="Screen Shot 2022-07-13 at 23 08 06" src="https://user-images.githubusercontent.com/5055789/178883458-a39e1761-9ef3-43bd-bfea-354ed0b950e0.png">

Previously, getting credentials required the following code:

```dart
final credentials = await auth0.webAuthentication.credentialsManager.get() // Get what?
```

Now it changes to:

```dart
final credentials = await auth0.webAuthentication.credentialsManager.credentials()
```

After changing `get()` to `credentials()`, we now have:

- `credentials()` to get credentials
- `set()` to store credentials
- `hasValidCredentials()` to check if there are valid credentials stored
- `clear()` to delete the stored credentials

But, the Dart design guidelines also instruct to [use terms consistently](https://dart.dev/guides/language/effective-dart/design#do-use-terms-consistently).

<img width="961" alt="Screen Shot 2022-07-13 at 23 31 13" src="https://user-images.githubusercontent.com/5055789/178885537-0cebd36f-fb49-40b1-9b05-424bb6a9ea6e.png">

Thus `set()` was renamed to `storeCredentials()` and `clear()` to `clearCredentials()`, to follow after `credentials()` and `hasValidCredentials()`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
