### PR TITLE
Enable the Credentials Manager in the example app

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -26,7 +26,7 @@ class _ExampleAppState extends State<ExampleApp> {
   void initState() {
     super.initState();
     auth0 = Auth0(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
-    webAuth = auth0.webAuthentication(useCredentialsManager: false);
+    webAuth = auth0.webAuthentication();
   }
 
   Future<void> webAuthLogin() async {


### PR DESCRIPTION
### Description

This PR removes `useCredentialsManager: false` from the example app, now that both Credentials Manager implementations were merged.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
