### PR TITLE
Remove `Auth0APIError` extension [SDK-3498]

### DIFF
--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -55,20 +55,6 @@ extension Auth0APIError {
     }
 }
 
-extension Auth0APIError {
-    var isPasswordLeaked: Bool {
-        return self.code == "password_leaked"
-    }
-
-    var isLoginRequired: Bool {
-        return self.code == "login_required"
-    }
-
-    var isNetworkError: Bool {
-        return (self.cause as? URLError)?.code == URLError.Code.notConnectedToInternet
-    }
-}
-
 extension Credentials {
     convenience init?(from dictionary: [String: Any]) {
         guard let accessToken = dictionary[CredentialsProperty.accessToken] as? String,

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Auth0', '~> 2.0'
+  s.dependency 'Auth0', '~> 2.2'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The errors `isPasswordLeaked`, `isLoginRequired`, and `isNetworkError` were recently added to Auth0.swift. The changes are now out in the [2.2.0](https://github.com/auth0/Auth0.swift/releases/tag/2.2.0) release.

This PR raises the minimum Auth0.swift version to 2.2.0, and removes the `Auth0APIError` extension from the Swift code in the Flutter SDK, as it's not needed anymore.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
