### PR TITLE
Move the Credentials Manager instance to `Auth0`

### DIFF
--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -34,8 +34,8 @@ class Auth0 {
   /// Creates an intance of an Auth0 client with the provided [domain] and [clientId] properties.
   ///
   /// [domain] and [clientId] are both values that can be retrieved from the application in your [Auth0 Dashboard](https://manage.auth0.com).
-  /// Uses the [DefaultCredentialsManager] by default. If you want to use your own implementation to handle credential storage, provide your own [CredentialsManager] implementation
-  /// by setting [credentialsManager].
+  /// If you want to use your own implementation to handle credential storage, provide your own [CredentialsManager] implementation
+  /// by setting [credentialsManager]. A [DefaultCredentialsManager] instance is used by default.
   /// If you want to use biometrics or pass-phrase when using the [DefaultCredentialsManager], set [localAuthentication]` to an instance of [LocalAuthenticationOptions].
   /// Note however that this setting has no effect when specifying a custom [credentialsManager].
   Auth0(final String domain, final String clientId,

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -22,8 +22,6 @@ class WebAuthentication {
   final UserAgent _userAgent;
   final CredentialsManager? _credentialsManager;
 
-  CredentialsManager? get credentialsManager => _credentialsManager;
-
   WebAuthentication(this._account, this._userAgent, this._credentialsManager);
 
   /// Redirects the user to the [Auth0 Universal Login page](https://auth0.com/docs/authenticate/login/auth0-universal-login) for authentication. If successful, it returns

--- a/auth0_flutter/test/credentials_manager_test.dart
+++ b/auth0_flutter/test/credentials_manager_test.dart
@@ -37,7 +37,7 @@ void main() {
     reset(mockedPlatform);
   });
 
-  group('get', () {
+  group('credentials', () {
     test('passes through properties to the platform', () async {
       when(mockedPlatform.getCredentials(any))
           .thenAnswer((final _) async => TestPlatform.credentials);
@@ -72,7 +72,7 @@ void main() {
     });
   });
 
-  group('set', () {
+  group('storeCredentials', () {
     test('passes through properties to the platform', () async {
       when(mockedPlatform.saveCredentials(any))
           .thenAnswer((final _) async => true);
@@ -148,7 +148,7 @@ void main() {
     });
   });
 
-  group('clear', () {
+  group('clearCredentials', () {
     test('calls the platform', () async {
       when(mockedPlatform.clearCredentials(any))
           .thenAnswer((final _) async => true);

--- a/auth0_flutter/test/web_authentication_test.dart
+++ b/auth0_flutter/test/web_authentication_test.dart
@@ -125,11 +125,10 @@ void main() {
           .thenAnswer((final _) async => true);
       final mockCm = MockCredentialsManager();
 
-      when(mockCm.storeCredentials(any))
-          .thenAnswer((final _) async => true);
+      when(mockCm.storeCredentials(any)).thenAnswer((final _) async => true);
 
-      await Auth0('test-domain', 'test-clientId')
-          .webAuthentication(customCredentialsManager: mockCm)
+      await Auth0('test-domain', 'test-clientId', credentialsManager: mockCm)
+          .webAuthentication()
           .login(
               audience: 'test-audience',
               scopes: {'a', 'b'},
@@ -141,8 +140,7 @@ void main() {
       // Verify it doesn't call our own Platform Interface when providing a custom CredentialsManager
       verifyNever(mockedCMPlatform.saveCredentials(any));
 
-      final verificationResult =
-          verify(mockCm.storeCredentials(captureAny))
+      final verificationResult = verify(mockCm.storeCredentials(captureAny))
           .captured
           .single as Credentials;
 
@@ -170,7 +168,7 @@ void main() {
       expect(verificationResult.options.parameters, {});
       expect(result, TestPlatform.loginResult);
     });
-  
+
     test('does not use EphemeralSession by default', () async {
       when(mockedPlatform.login(any))
           .thenAnswer((final _) async => TestPlatform.loginResult);
@@ -242,11 +240,10 @@ void main() {
       when(mockedCMPlatform.clearCredentials(any))
           .thenAnswer((final _) async => true);
       final mockCm = MockCredentialsManager();
-      when(mockCm.clearCredentials())
-          .thenAnswer((final _) async => true);
+      when(mockCm.clearCredentials()).thenAnswer((final _) async => true);
 
-      await Auth0('test-domain', 'test-clientId')
-          .webAuthentication(customCredentialsManager: mockCm)
+      await Auth0('test-domain', 'test-clientId', credentialsManager: mockCm)
+          .webAuthentication()
           .logout(returnTo: 'abc');
 
       // Verify it doesn't call our own Platform Interface when providing a custom CredentialsManager


### PR DESCRIPTION
### Description

This PR moves the Credentials Manager parameter and instance from `webAuthentication()` to the `Auth0` constructor, along with the local authentication options.

#### 1. Makes it easier to use the Credentials Manager with username/password authentication (API client)

With the current implementation, if a developer wants to use username/password authentication through the API client, there is no straightforward way for them to call the built-in Credentials Manager instance to store the resulting credentials. They'd have to call `webAuthentication().credentialsManager`, even if they don't use Web Auth at all.

**Before**

```dart
final credentials = await auth0.api.login(
    usernameOrEmail: 'jane.smith@example.com',
    password: 'secret-password',
    connectionOrRealm: 'Username-Password-Authentication');

auth0.webAuthentication().credentialsManager.storeCredentials(credentials);
```

**After**

```dart
final credentials = await auth0.api.login(
    usernameOrEmail: 'jane.smith@example.com',
    password: 'secret-password',
    connectionOrRealm: 'Username-Password-Authentication');

auth0.credentialsManager.storeCredentials(credentials);
```

We'll be documenting that only Web Auth stores/renews the credentials automatically, though (in the upcoming READMEs PR).

#### 2. Makes it easier to use a single instance of the Credentials Manager

By placing the Credentials Manager instance in the top-level `Auth0` object, it becomes a matter of simply instantiating this object once and reusing it to always use the same Credentials Manager instance. Not making this the path of least resistance could lead to developers using different instances without realizing it, resulting in concurrency issues. 

**Before**

```dart
final auth0 = Auth0('domain', 'client-id');
// Every call to webAuthentication() returns a new instance
auth0.webAuthentication().credentialsManager.credentials();
```

**After**

```dart
final auth0 = Auth0('domain', 'client-id');
auth0.credentialsManager.credentials(); // Same instance
```

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`