### PR TITLE
Have the iOS `hasvalidCredentials()` match the behavior of the Android one

### DIFF
--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHasValidMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHasValidMethodHandlerTests.swift
@@ -50,6 +50,22 @@ extension CredentialsManagerHasValidMethodHandlerTests {
         wait(for: [expectation])
     }
 
+    func testProducesTrueWithRefreshToken() {
+        let credentials = Credentials(refreshToken: "foo")
+        let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
+        let expectation = self.expectation(description: "Produced true")
+        let emptyStorage = SpyCredentialsStorage()
+        emptyStorage.getEntryReturnValue = nil
+        let credentialsManager = CredentialsManager(authentication: SpyAuthentication(), storage: emptyStorage)
+        sut = CredentialsManagerHasValidMethodHandler(credentialsManager: credentialsManager, credentialsStorage: spy)
+        spy.getEntryReturnValue = data
+        sut.handle(with: arguments()) { result in
+            XCTAssertEqual(result as? Bool, true)
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
     func testProducesFalseWithNoValidCredentials() {
         let expectation = self.expectation(description: "Produced false")
         spy.getEntryReturnValue = nil

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,5 +1,6 @@
 import Flutter
 import Auth0
+import SimpleKeychain
 
 struct CredentialsManagerHasValidMethodHandler: MethodHandler {
     enum Argument: String {
@@ -7,10 +8,24 @@ struct CredentialsManagerHasValidMethodHandler: MethodHandler {
     }
 
     let credentialsManager: CredentialsManager
+    let credentialsStorage: CredentialsStorage
+    let credentialsKey = "credentials"
+
+    init(credentialsManager: CredentialsManager, credentialsStorage: CredentialsStorage = A0SimpleKeychain()) {
+        self.credentialsManager = credentialsManager
+        self.credentialsStorage = credentialsStorage
+    }
 
     func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
         guard let minTTL = arguments[Argument.minTtl] as? Int else {
             return callback(FlutterError(from: .requiredArgumentMissing(Argument.minTtl.rawValue)))
+        }
+
+        // So it behaves the same as the Credentials Manager from Auth0.Android
+        if let data = self.credentialsStorage.getEntry(forKey: credentialsKey),
+           let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data),
+           credentials.refreshToken != nil {
+            return callback(true)
         }
 
         callback(credentialsManager.hasValid(minTTL: minTTL))


### PR DESCRIPTION
### Description

The manual testing of the Credentials Manager implementations unveiled that there is a difference in behavior in the `hasValid(_:)` method of the [Auth0.swift Credentials Manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift#L170) and the [Auth0.Android one](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/authentication/storage/SecureCredentialsManager.kt#L391).

The Auth0.swift one will not take into account the presence of the refresh token, as having a refresh token does not mean that there are valid credentials stored. The Auth0.Android one does.

This PR modifies `CredentialsManagerHasValidMethodHandler` to have it behave like the Android `hasvalidCredentials()`, to provide a consistent behavior in both platforms. 

### Testing

Besides adding a unit test, the implementation was tested manually using an iPhone 13 simulator running iOS 15.5 with Xcode 13.4.1 (13F100).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
