### PR TITLE
Make `LocalAuthenticationOptions` constructor `const`

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/options/local_authentication_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/options/local_authentication_options.dart
@@ -12,6 +12,6 @@ class LocalAuthenticationOptions {
   /// (iOS only): Fallback message to display on the local authentication prompt after a failed match.
   final String? fallbackTitle;
 
-  LocalAuthenticationOptions(
+  const LocalAuthenticationOptions(
       {this.title, this.description, this.cancelTitle, this.fallbackTitle});
 }


### PR DESCRIPTION
### Description

This PR has the `LocalAuthenticationOptions` constructor be a `const` constructor, like the one of the analogous `IdTokenValidationConfig`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
