### PR TITLE
Fix most Android warnings

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandler.kt
@@ -11,16 +11,16 @@ import io.flutter.plugin.common.MethodChannel.Result
 
 
 class Auth0FlutterAuthMethodCallHandler(private val requestHandlers: List<ApiRequestHandler>) : MethodCallHandler {
-    lateinit var activity: Activity;
+    lateinit var activity: Activity
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        var requestHandler = requestHandlers.find { it.method == call.method };
+        val requestHandler = requestHandlers.find { it.method == call.method }
 
         if (requestHandler != null) {
-            val request = MethodCallRequest.fromCall(call);
-            val api = AuthenticationAPIClient(request.account);
+            val request = MethodCallRequest.fromCall(call)
+            val api = AuthenticationAPIClient(request.account)
 
-            requestHandler.handle(api, request, result);
+            requestHandler.handle(api, request, result)
         } else {
             result.notImplemented()
         }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -66,7 +66,7 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     authCallHandler.activity = binding.activity
     credentialsManagerCallHandler.activity = binding.activity
 
-    binding.addActivityResultListener(credentialsManagerCallHandler);
+    binding.addActivityResultListener(credentialsManagerCallHandler)
   }
 
   override fun onDetachedFromActivityForConfigChanges() {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterWebAuthMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterWebAuthMethodCallHandler.kt
@@ -12,10 +12,10 @@ class Auth0FlutterWebAuthMethodCallHandler(private val requestHandlers: List<Web
     lateinit var activity: Activity
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        var requestHandler = requestHandlers.find { it.method == call.method };
+        val requestHandler = requestHandlers.find { it.method == call.method }
 
         if (requestHandler != null) {
-            val request = MethodCallRequest.fromCall(call);
+            val request = MethodCallRequest.fromCall(call)
 
             requestHandler.handle(activity, request, result)
         } else {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
@@ -15,36 +15,35 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 
 class CredentialsManagerMethodCallHandler(private val requestHandlers: List<CredentialsManagerRequestHandler>) : MethodCallHandler, PluginRegistry.ActivityResultListener {
-    lateinit var activity: Activity;
+    lateinit var activity: Activity
 
-    var credentialsManager: SecureCredentialsManager? = null;
+    var credentialsManager: SecureCredentialsManager? = null
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        var requestHandler = requestHandlers.find { it.method == call.method };
+        val requestHandler = requestHandlers.find { it.method == call.method }
 
         if (requestHandler != null) {
-            val request = MethodCallRequest.fromCall(call);
+            val request = MethodCallRequest.fromCall(call)
 
-            val api = AuthenticationAPIClient(request.account);
-            val storage = SharedPreferencesStorage(activity);
-            credentialsManager = credentialsManager ?: SecureCredentialsManager(activity, api, storage);
+            val api = AuthenticationAPIClient(request.account)
+            val storage = SharedPreferencesStorage(activity)
+            credentialsManager = credentialsManager ?: SecureCredentialsManager(activity, api, storage)
 
-            val credentialsManager = credentialsManager as SecureCredentialsManager;
-
-            var localAuthentication = request.data.get("localAuthentication") as Map<String, String>?;
+            val credentialsManager = credentialsManager as SecureCredentialsManager
+            val localAuthentication = request.data.get("localAuthentication") as Map<String, String>?
 
             if (localAuthentication != null) {
-                val title = localAuthentication["title"];
-                val description = localAuthentication["description"];
-                credentialsManager.requireAuthentication(activity, RequestCodes.AUTH_REQ_CODE, title, description);
+                val title = localAuthentication["title"]
+                val description = localAuthentication["description"]
+                credentialsManager.requireAuthentication(activity, RequestCodes.AUTH_REQ_CODE, title, description)
             }
-            requestHandler.handle(credentialsManager, activity, request, result);
+            requestHandler.handle(credentialsManager, activity, request, result)
         } else {
             result.notImplemented()
         }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        return credentialsManager?.checkAuthenticationResult(requestCode, resultCode) ?: true;
+        return credentialsManager?.checkAuthenticationResult(requestCode, resultCode) ?: true
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
@@ -3,7 +3,6 @@ package com.auth0.auth0_flutter
 import com.auth0.android.jwt.Claim
 import com.auth0.android.result.UserProfile
 import com.auth0.auth0_flutter.utils.getCustomClaims
-import com.auth0.android.jwt.JWT
 
 fun UserProfile.toMap(): Map<String, Any?> {
     return mapOf(
@@ -51,7 +50,7 @@ fun createUserProfileFromClaims(claims: Map<String, Claim>): UserProfile {
         appMetadata = mapOf(),
         userMetadata = mapOf(),
         createdAt = null
-    );
+    )
 }
 
 val UserProfile.sub: String

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
@@ -6,18 +6,18 @@ import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodCall
 
 class MethodCallRequest {
-    var account: Auth0;
-    var data: HashMap<*, *>;
+    var account: Auth0
+    var data: HashMap<*, *>
 
     constructor(account: Auth0, data: HashMap<*, *>) {
-        this.data = data;
-        this.account = account;
+        this.data = data
+        this.account = account
 
     }
 
     companion object {
         fun fromCall(call: MethodCall): MethodCallRequest {
-            val args = call.arguments as HashMap<*, *>;
+            val args = call.arguments as HashMap<*, *>
 
             assertHasProperties(
                 listOf(
@@ -28,21 +28,21 @@ class MethodCallRequest {
                     "_userAgent.name",
                     "_userAgent.version"
                 ), args
-            );
+            )
 
-            val accountMap = args["_account"] as Map<String, String>;
+            val accountMap = args["_account"] as Map<String, String>
             val account = Auth0(
                 accountMap["clientId"] as String,
                 accountMap["domain"] as String
             )
 
-            val userAgentMap = args["_userAgent"] as Map<String, String>;
+            val userAgentMap = args["_userAgent"] as Map<String, String>
             account.auth0UserAgent = Auth0UserAgent(
                 name = userAgentMap["name"] as String,
                 version = userAgentMap["version"] as String,
             )
 
-            return MethodCallRequest(account, args);
+            return MethodCallRequest(account, args)
         }
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ApiRequestHandler.kt
@@ -8,4 +8,3 @@ interface ApiRequestHandler {
     val method: String
     fun handle(api: AuthenticationAPIClient, request: MethodCallRequest, result: MethodChannel.Result)
 }
-

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -1,6 +1,5 @@
 package com.auth0.auth0_flutter.request_handlers.api
 
-import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
@@ -13,7 +12,6 @@ import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.HashMap
 
 private const val AUTH_LOGIN_METHOD = "auth#login"
 
@@ -25,16 +23,16 @@ class LoginApiRequestHandler : ApiRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        val args = request.data;
+        val args = request.data
 
-        assertHasProperties(listOf("usernameOrEmail", "password", "connectionOrRealm"), args);
+        assertHasProperties(listOf("usernameOrEmail", "password", "connectionOrRealm"), args)
 
         val loginBuilder = api
             .login(
                 args["usernameOrEmail"] as String,
                 args["password"] as String,
                 args["connectionOrRealm"] as String
-            );
+            )
 
         val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
         loginBuilder.setScope(scopes.joinToString(separator = " "))
@@ -53,7 +51,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
                     exception.getCode(),
                     exception.getDescription(),
                     exception.toMap()
-                );
+                )
             }
 
             override fun onSuccess(credentials: Credentials) {
@@ -76,6 +74,6 @@ class LoginApiRequestHandler : ApiRequestHandler {
                     )
                 )
             }
-        });
+        })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -23,9 +23,9 @@ class RenewApiRequestHandler : ApiRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        assertHasProperties(listOf("refreshToken"), request.data);
+        assertHasProperties(listOf("refreshToken"), request.data)
 
-        var renewAuthBuilder = api.renewAuth(request.data["refreshToken"] as String);
+        val renewAuthBuilder = api.renewAuth(request.data["refreshToken"] as String)
 
         val scopes = request.data.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
@@ -43,7 +43,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
                     exception.getCode(),
                     exception.getDescription(),
                     exception.toMap()
-                );
+                )
             }
 
             override fun onSuccess(credentials: Credentials) {
@@ -67,6 +67,6 @@ class RenewApiRequestHandler : ApiRequestHandler {
                     )
                 )
             }
-        });
+        })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ResetPasswordApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ResetPasswordApiRequestHandler.kt
@@ -19,7 +19,7 @@ class ResetPasswordApiRequestHandler : ApiRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        assertHasProperties(listOf("email", "connection"), request.data);
+        assertHasProperties(listOf("email", "connection"), request.data)
 
         val builder = api.resetPassword(
             email = request.data["email"] as String,
@@ -36,12 +36,12 @@ class ResetPasswordApiRequestHandler : ApiRequestHandler {
                     exception.getCode(),
                     exception.getDescription(),
                     exception.toMap()
-                );
+                )
             }
 
             override fun onSuccess(res: Void?) {
-                result.success(null);
+                result.success(null)
             }
-        });
+        })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SignupApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SignupApiRequestHandler.kt
@@ -15,7 +15,7 @@ class SignupApiRequestHandler : ApiRequestHandler {
     override val method: String = AUTH_SIGNUP_METHOD
 
     override fun handle(api: AuthenticationAPIClient, request: MethodCallRequest, result: MethodChannel.Result) {
-        assertHasProperties(listOf("email", "password", "connection"), request.data);
+        assertHasProperties(listOf("email", "password", "connection"), request.data)
 
         val builder = api.createUser(
                 email = request.data["email"] as String,
@@ -23,7 +23,7 @@ class SignupApiRequestHandler : ApiRequestHandler {
                 username = request.data["username"] as String?,
                 connection = request.data["connection"] as String,
                 userMetadata = request.data["userMetadata"] as Map<String, String>?
-            );
+            )
 
         if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
             builder.addParameters(request.data["parameters"] as Map<String, String>)
@@ -35,7 +35,7 @@ class SignupApiRequestHandler : ApiRequestHandler {
                     exception.getCode(),
                     exception.getDescription(),
                     exception.toMap()
-                );
+                )
             }
 
             override fun onSuccess(user: DatabaseUser) {
@@ -47,6 +47,6 @@ class SignupApiRequestHandler : ApiRequestHandler {
                     )
                 )
             }
-        });
+        })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/UserInfoApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/UserInfoApiRequestHandler.kt
@@ -19,9 +19,9 @@ class UserInfoApiRequestHandler : ApiRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        assertHasProperties(listOf("accessToken"), request.data);
+        assertHasProperties(listOf("accessToken"), request.data)
 
-        val builder = api.userInfo(request.data["accessToken"] as String);
+        val builder = api.userInfo(request.data["accessToken"] as String)
 
         if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
             builder.addParameters(request.data["parameters"] as Map<String, String>)
@@ -34,12 +34,12 @@ class UserInfoApiRequestHandler : ApiRequestHandler {
                         exception.getCode(),
                         exception.getDescription(),
                         exception.toMap()
-                    );
+                    )
                 }
 
                 override fun onSuccess(res: UserProfile) {
                     result.success(res.toMap())
                 }
-            });
+            })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearCredentialsRequestHandler.kt
@@ -6,7 +6,7 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel
 
 class ClearCredentialsRequestHandler : CredentialsManagerRequestHandler {
-    override val method: String = "credentialsManager#clearCredentials";
+    override val method: String = "credentialsManager#clearCredentials"
 
     override fun handle(
         credentialsManager: SecureCredentialsManager,
@@ -14,7 +14,7 @@ class ClearCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        credentialsManager.clearCredentials();
-        result.success(true);
+        credentialsManager.clearCredentials()
+        result.success(true)
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -14,7 +14,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
-    override val method: String = "credentialsManager#getCredentials";
+    override val method: String = "credentialsManager#getCredentials"
 
     override fun handle(
         credentialsManager: SecureCredentialsManager,
@@ -22,20 +22,20 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        var scope: String? = null;
+        var scope: String? = null
 
         val scopes = request.data.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
-            scope = scopes.joinToString(separator = " ");
+            scope = scopes.joinToString(separator = " ")
         }
 
-        var minTtl = request.data.get("minTtl") as Int? ?: 0;
-        var parameters = request.data.get("parameters") as Map<String, String>? ?: mapOf();
+        val minTtl = request.data.get("minTtl") as Int? ?: 0
+        val parameters = request.data.get("parameters") as Map<String, String>? ?: mapOf()
 
         credentialsManager.getCredentials(scope, minTtl, parameters, object:
             Callback<Credentials, CredentialsManagerException> {
             override fun onFailure(exception: CredentialsManagerException) {
-                result.error(exception.message ?: "UNKNOWN ERROR", exception.message, exception);
+                result.error(exception.message ?: "UNKNOWN ERROR", exception.message, exception)
             }
 
             override fun onSuccess(credentials: Credentials) {
@@ -59,6 +59,6 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
                     )
                 )
             }
-        });
+        })
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/HasValidCredentialsRequestHandler.kt
@@ -4,10 +4,9 @@ import android.content.Context
 import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel
-import java.util.ArrayList
 
 class HasValidCredentialsRequestHandler : CredentialsManagerRequestHandler {
-    override val method: String = "credentialsManager#hasValidCredentials";
+    override val method: String = "credentialsManager#hasValidCredentials"
 
     override fun handle(
         credentialsManager: SecureCredentialsManager,
@@ -15,9 +14,9 @@ class HasValidCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        val minTtl = request.data.get("minTtl") as Int? ?: 0;
+        val minTtl = request.data.get("minTtl") as Int? ?: 0
 
-        result.success(credentialsManager.hasValidCredentials(minTtl.toLong()));
+        result.success(credentialsManager.hasValidCredentials(minTtl.toLong()))
     }
 
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 
 class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
-    override val method: String = "credentialsManager#saveCredentials";
+    override val method: String = "credentialsManager#saveCredentials"
 
     override fun handle(
         credentialsManager: SecureCredentialsManager,
@@ -19,20 +19,20 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        assertHasProperties(listOf("credentials"), request.data);
+        assertHasProperties(listOf("credentials"), request.data)
 
-        val credentials = request.data.get("credentials") as HashMap<*, *>;
+        val credentials = request.data.get("credentials") as HashMap<*, *>
 
-        assertHasProperties(listOf("accessToken", "idToken" , "tokenType", "expiresAt"), credentials, "credentials");
+        assertHasProperties(listOf("accessToken", "idToken" , "tokenType", "expiresAt"), credentials, "credentials")
 
-        var scope: String? = null;
+        var scope: String? = null
         val scopes = credentials.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
-            scope = scopes.joinToString(separator = " ");
+            scope = scopes.joinToString(separator = " ")
         }
 
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault());
-        var date = format.parse(credentials.get("expiresAt") as String);
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val date = format.parse(credentials.get("expiresAt") as String)
 
         credentialsManager.saveCredentials(Credentials(
             credentials.get("idToken") as String,
@@ -41,7 +41,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
             credentials.get("refreshToken") as String?,
             date,
             scope,
-        ));
-        result.success(true);
+        ))
+        result.success(true)
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -14,14 +14,14 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
-    override val method: String = "webAuth#login";
+    override val method: String = "webAuth#login"
 
     override fun handle(
         context: Context,
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        val builder = builderResolver(request);
+        val builder = builderResolver(request)
         val args = request.data
         val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
@@ -8,11 +8,11 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel
 
 class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.LogoutBuilder) : WebAuthRequestHandler {
-    override val method: String = "webAuth#logout";
+    override val method: String = "webAuth#logout"
 
     override fun handle(context: Context, request: MethodCallRequest, result: MethodChannel.Result) {
-        val builder = builderResolver(request);
-        var args = request.data;
+        val builder = builderResolver(request)
+        val args = request.data
 
         if (args.getOrDefault("scheme", null) is String) {
             builder.withScheme(args["scheme"] as String)
@@ -24,11 +24,11 @@ class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallReques
 
         builder.start(context, object: Callback<Void?, AuthenticationException> {
             override fun onFailure(exception: AuthenticationException) {
-                result.error(exception.getCode(), exception.getDescription(), exception);
+                result.error(exception.getCode(), exception.getDescription(), exception)
             }
 
             override fun onSuccess(res: Void?) {
-                result.success(null);
+                result.success(null)
             }
         })
     }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/assertHasProperties.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/assertHasProperties.kt
@@ -2,18 +2,18 @@ package com.auth0.auth0_flutter.utils
 
 fun tryGetByKey(data: Any?, key: String): Any? {
     if (data is Map<*, *>) {
-        return data[key];
+        return data[key]
     }
 
-    return null;
+    return null
 }
 
 fun assertHasProperties(requiredProperties: List<String>, data: Map<*, *>, prefix: String? = null) {
-    var missingProperties =
+    val missingProperties =
         requiredProperties.filter {
             it.split('.')
                 .fold(data) { acc: Any?, key: String -> tryGetByKey(acc, key) } == null
-        };
+        }
 
     missingProperties
         .map { if (prefix != null) "$prefix.$it" else it }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/getCustomClaims.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/getCustomClaims.kt
@@ -42,5 +42,5 @@ fun getCustomClaims(claims: Map<String, Any>): Map<String, Any> {
 
     return filteredClaims.filterNot {
         standardClaims.contains(it.key)
-    };
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes the most innocuous warnings reported by Android Studio:
- Unused imports
- Semicolons
- Usage of `var` for values that are never modified (instead of `val`)

The remaining warnings were left untouched, for example:

<img width="1018" alt="Screen Shot 2022-07-20 at 23 23 11" src="https://user-images.githubusercontent.com/5055789/180117168-06c0544b-598f-457d-b212-ad1d05a64638.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
