### PR TITLE
Update Auth0.swift to 2.3.0

### DIFF
--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerExtensionsTests.swift
@@ -9,6 +9,7 @@ class CredentialsManagerExtensionsTests: XCTestCase {
             "NO_CREDENTIALS": .noCredentials,
             "NO_REFRESH_TOKEN": .noRefreshToken,
             "RENEW_FAILED": .renewFailed,
+            "STORE_FAILED": .storeFailed,
             "BIOMETRICS_FAILED": .biometricsFailed,
             "REVOKE_FAILED": .revokeFailed,
             "LARGE_MIN_TTL": .largeMinTTL

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHasValidMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHasValidMethodHandlerTests.swift
@@ -54,10 +54,8 @@ extension CredentialsManagerHasValidMethodHandlerTests {
         let credentials = Credentials(refreshToken: "foo")
         let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
         let expectation = self.expectation(description: "Produced true")
-        let emptyStorage = SpyCredentialsStorage()
-        emptyStorage.getEntryReturnValue = nil
-        let credentialsManager = CredentialsManager(authentication: SpyAuthentication(), storage: emptyStorage)
-        sut = CredentialsManagerHasValidMethodHandler(credentialsManager: credentialsManager, credentialsStorage: spy)
+        let credentialsManager = CredentialsManager(authentication: SpyAuthentication(), storage: spy)
+        sut = CredentialsManagerHasValidMethodHandler(credentialsManager: credentialsManager)
         spy.getEntryReturnValue = data
         sut.handle(with: arguments()) { result in
             XCTAssertEqual(result as? Bool, true)

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
@@ -5,6 +5,6 @@ struct CredentialsManagerClearMethodHandler: MethodHandler {
     let credentialsManager: CredentialsManager
 
     func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
-        callback(credentialsManager.clear())
+        callback(self.credentialsManager.clear())
     }
 }

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
@@ -8,6 +8,7 @@ extension FlutterError {
         case .noCredentials: code = "NO_CREDENTIALS"
         case .noRefreshToken: code = "NO_REFRESH_TOKEN"
         case .renewFailed: code = "RENEW_FAILED"
+        case .storeFailed: code = "STORE_FAILED"
         case .biometricsFailed: code = "BIOMETRICS_FAILED"
         case .revokeFailed: code = "REVOKE_FAILED"
         case .largeMinTTL: code = "LARGE_MIN_TTL"

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
@@ -21,7 +21,7 @@ struct CredentialsManagerGetMethodHandler: MethodHandler {
             return callback(FlutterError(from: .requiredArgumentMissing(Argument.parameters.rawValue)))
         }
 
-        credentialsManager.credentials(withScope: scopes.isEmpty ? nil : scopes.asSpaceSeparatedString,
+        self.credentialsManager.credentials(withScope: scopes.isEmpty ? nil : scopes.asSpaceSeparatedString,
                                        minTTL: minTTL,
                                        parameters: parameters) {
             switch $0 {

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,6 +1,5 @@
 import Flutter
 import Auth0
-import SimpleKeychain
 
 struct CredentialsManagerHasValidMethodHandler: MethodHandler {
     enum Argument: String {
@@ -8,13 +7,6 @@ struct CredentialsManagerHasValidMethodHandler: MethodHandler {
     }
 
     let credentialsManager: CredentialsManager
-    let credentialsStorage: CredentialsStorage
-    let credentialsKey = "credentials"
-
-    init(credentialsManager: CredentialsManager, credentialsStorage: CredentialsStorage = A0SimpleKeychain()) {
-        self.credentialsManager = credentialsManager
-        self.credentialsStorage = credentialsStorage
-    }
 
     func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
         guard let minTTL = arguments[Argument.minTtl] as? Int else {
@@ -22,12 +14,6 @@ struct CredentialsManagerHasValidMethodHandler: MethodHandler {
         }
 
         // So it behaves the same as the Credentials Manager from Auth0.Android
-        if let data = self.credentialsStorage.getEntry(forKey: credentialsKey),
-           let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data),
-           credentials.refreshToken != nil {
-            return callback(true)
-        }
-
-        callback(credentialsManager.hasValid(minTTL: minTTL))
+        callback(self.credentialsManager.canRenew() || self.credentialsManager.hasValid(minTTL: minTTL))
     }
 }

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
@@ -14,6 +14,6 @@ struct CredentialsManagerSaveMethodHandler: MethodHandler {
             return callback(FlutterError(from: .requiredArgumentMissing(Argument.credentials.rawValue)))
         }
 
-        callback(credentialsManager.store(credentials: credentials))
+        callback(self.credentialsManager.store(credentials: credentials))
     }
 }

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Auth0', '~> 2.2'
+  s.dependency 'Auth0', '~> 2.3'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
### Description

This PR updates Auth0.swift to 2.3.0, and sets it as the minimum required version.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`