### PR TITLE
Keep a single instance of iOS Credentials Manager [SDK-3519]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Auth0 SDK for Android / iOS Flutter apps.
 
-> ⚠️ This library is currently in First Availability. We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
+> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
 
 | Package                                                                 | Description                                   |
 |:------------------------------------------------------------------------|:----------------------------------------------|

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -6,7 +6,7 @@
 
 Auth0 SDK for Android / iOS Flutter apps.
 
-> ⚠️ This library is currently in First Availability. We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
+> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
 
 ---
 
@@ -63,7 +63,7 @@ Auth0 SDK for Android / iOS Flutter apps.
 | :--------- | :-------------- | :---------------- |
 | SDK 3.0+   | Android API 21+ | iOS 12+           |
 | Dart 2.17+ | Java 8+         | Swift 5.3+        |
-|            |                 | Xcode 12.x / 13.x |
+|            |                 | Xcode 13.x / 14.x |
 
 ## Installation
 
@@ -263,7 +263,7 @@ final credentials = await auth0.credentialsManager.credentials();
 <details>
   <summary>Add a custom scheme value (Android-only)</summary>
 
-On Android, `https` is used by default as the callback URL scheme. This works best for Android API 23+ if you're using [Android App Links](https://auth0.com/docs/get-started/applications/enable-android-app-links-support), but in previous Android versions, this \_may show the intent chooser dialog prompting the user to choose either your app or the browser. You can change this behavior by using a custom unique scheme so that Android opens the link directly with your app. Note that schemes [can only have lowercase letters](https://developer.android.com/guide/topics/manifest/data-element).
+On Android, `https` is used by default as the callback URL scheme. This works best for Android API 23+ if you're using [Android App Links](https://auth0.com/docs/get-started/applications/enable-android-app-links-support), but in previous Android versions, this may show the intent chooser dialog prompting the user to choose either your app or the browser. You can change this behavior by using a custom unique scheme so that Android opens the link directly with your app. Note that schemes [can only have lowercase letters](https://developer.android.com/guide/topics/manifest/data-element).
 
 1. Update the `auth0Scheme` manifest placeholder on the `android/build.gradle` file.
 2. Update the **Allowed Callback URLs** in the settings page of your [Auth0 application](https://manage.auth0.com/#/applications/).

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
@@ -206,6 +206,22 @@ extension CredentialsManagerHandlerTests {
         wait(for: [expectation])
     }
 
+    // MARK: CredentialsManagerProvider
+
+    func testCallsCredentialsManagerProvider() {
+        let methodName = CredentialsManagerHandler.Method.save.rawValue
+        let expectation = self.expectation(description: "Called credentials manager provider")
+        sut.apiClientProvider = { _, _ in
+            return SpyAuthentication()
+        }
+        sut.credentialsManagerProvider = { _, _ in
+            expectation.fulfill()
+            return CredentialsManager(authentication: SpyAuthentication())
+        }
+        sut.handle(FlutterMethodCall(methodName: methodName, arguments: arguments())) { _ in }
+        wait(for: [expectation])
+    }
+
     // MARK: CredentialsManagerMethodHandlerProvider
 
     func testCallsMethodHandlerProvider() {

--- a/auth0_flutter_platform_interface/README.md
+++ b/auth0_flutter_platform_interface/README.md
@@ -8,7 +8,7 @@ This package provides the common interface for platform implementations.
 
 **[API documentation ↗](https://pub.dev/documentation/auth0_flutter_platform_interface/latest/)**
 
-> ⚠️ This library is currently in First Availability. We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
+> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
 
 ## Issue Reporting
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The current implementation of the iOS Credentials Manager will create a new instance every time a Credentials Manager method is called from Dart code. This PR makes sure only a single instance is used.
