### PR TITLE
Move `scheme` to `webAuthentication()`

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -26,7 +26,8 @@ class _ExampleAppState extends State<ExampleApp> {
   void initState() {
     super.initState();
     auth0 = Auth0(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
-    webAuth = auth0.webAuthentication();
+    webAuth =
+        auth0.webAuthentication(scheme: dotenv.env['AUTH0_CUSTOM_SCHEME']);
   }
 
   Future<void> webAuthLogin() async {
@@ -35,9 +36,7 @@ class _ExampleAppState extends State<ExampleApp> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
-      final result = await webAuth
-          .login(scheme: dotenv.env['AUTH0_CUSTOM_SCHEME']);
-
+      final result = await webAuth.login();
       output = result.idToken;
 
       setState(() {
@@ -62,9 +61,7 @@ class _ExampleAppState extends State<ExampleApp> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
-      await webAuth
-          .logout(scheme: dotenv.env['AUTH0_CUSTOM_SCHEME']);
-
+      await webAuth.logout();
       output = 'Logged out.';
 
       setState(() {

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -78,10 +78,10 @@ class Auth0 {
   /// final result = await auth0.webAuthentication().login();
   /// final accessToken = result.accessToken;
   /// ```
-  /// By default, the credentials will be stored in the [CredentialsManager].
-  /// In case you want to opt-out of using the [CredentialsManager], set [useCredentialsManager] to `false`.
+  /// By default, the credentials will be stored in the [CredentialsManager]. In case you want to opt-out of using the [CredentialsManager], set [useCredentialsManager] to `false`.
+  /// (Android only): specify [scheme] if you're using a custom URL scheme for your app. This value must match the value used to configure the `auth0Scheme` manifest placeholder, for the Redirect intent filter to work
   WebAuthentication webAuthentication(
-          {final bool useCredentialsManager = true}) =>
-      WebAuthentication(_account, _userAgent,
+          {final String? scheme, final bool useCredentialsManager = true}) =>
+      WebAuthentication(_account, _userAgent, scheme,
           useCredentialsManager ? credentialsManager : null);
 }

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -20,9 +20,11 @@ import '../auth0_flutter.dart';
 class WebAuthentication {
   final Account _account;
   final UserAgent _userAgent;
+  final String? _scheme;
   final CredentialsManager? _credentialsManager;
 
-  WebAuthentication(this._account, this._userAgent, this._credentialsManager);
+  WebAuthentication(
+      this._account, this._userAgent, this._scheme, this._credentialsManager);
 
   /// Redirects the user to the [Auth0 Universal Login page](https://auth0.com/docs/authenticate/login/auth0-universal-login) for authentication. If successful, it returns
   /// a set of tokens, as well as the user's profile (constructed from ID token claims).
@@ -35,7 +37,6 @@ class WebAuthentication {
   /// Additonal notes:
   ///
   /// * (iOS only): [useEphemeralSession] controls whether shared persistent storage is used for cookies. [Read more on the effects this setting has](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md#1-how-can-i-disable-the-login-alert-box)
-  /// * (Android only): specify [scheme] if you're using a custom URL scheme for your app. This value must match the value used to configure the `auth0Scheme` manifest placeholder, for the Redirect intent filter to work
   /// * [audience] relates to the API Identifier you want to reference in your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings))
   /// * [scopes] defaults to `openid profile email offline_access`. You can override these scopes, but `openid` is always requested regardless of this setting.
   /// * Arbitrary [parameters] can be specified and then picked up in a custom Auth0 [Action](https://auth0.com/docs/customize/actions) or [Rule](https://auth0.com/docs/customize/rules).
@@ -52,7 +53,6 @@ class WebAuthentication {
     final String? redirectUrl,
     final String? organizationId,
     final String? invitationUrl,
-    final String? scheme,
     final bool useEphemeralSession = false,
     final Map<String, String> parameters = const {},
     final IdTokenValidationConfig idTokenValidationConfig =
@@ -67,7 +67,7 @@ class WebAuthentication {
             invitationUrl: invitationUrl,
             parameters: parameters,
             idTokenValidationConfig: idTokenValidationConfig,
-            scheme: scheme,
+            scheme: _scheme,
             useEphemeralSession: useEphemeralSession)));
 
     await _credentialsManager?.storeCredentials(credentials);
@@ -78,13 +78,11 @@ class WebAuthentication {
   /// Redirects the user to the Auth0 Logout endpoint to remove their authentication session, and log out. The user is immediately redirected back to the application
   /// once logout is complete.
   ///
-  /// If [returnTo] is not specified, a default URL is used that incorporates the `domain` value specified to [Auth0.new], and [scheme] on Android, or the
+  /// If [returnTo] is not specified, a default URL is used that incorporates the `domain` value specified to [Auth0.new], and the custom scheme on Android, or the
   /// bundle identifier in iOS. [returnTo] must appear in your **Allowed Logout URLs** list for the Auth0 app. [Read more about redirecting users after logout](https://auth0.com/docs/authenticate/login/logout#redirect-users-after-logout).
-  ///
-  /// (Android only): [scheme] must match the scheme that was used to configure the `auth0Scheme` manifest placeholder
-  Future<void> logout({final String? returnTo, final String? scheme}) async {
+  Future<void> logout({final String? returnTo}) async {
     await Auth0FlutterWebAuthPlatform.instance.logout(_createWebAuthRequest(
-      WebAuthLogoutOptions(returnTo: returnTo, scheme: scheme),
+      WebAuthLogoutOptions(returnTo: returnTo, scheme: _scheme),
     ));
     await _credentialsManager?.clearCredentials();
   }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

⚠️ **This PR contains breaking changes**

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently, Web Auth methods (login and logout) take a `scheme` parameter separately. Unlike the rest of the parameters, this one is not specific to each Web Auth method, but is something that applies to Web Auth in general (in Android). One would never specify a different value for `login()` than for `logout()`.

Thus this parameter belongs to the Web Auth instance itself. `webAuthentication()` already takes a `useCredentialsManager` parameter for the same reasons. So having `scheme` in `login()` and `logout()` would be inconsistent, and become a potential source of confusion.

This PR moves `scheme` out of `login()` and `logout()`, up into `webAuthentication()`.

**Before/after (usage)**

<img width="1263" alt="Screen Shot 2022-08-23 at 00 36 29" src="https://user-images.githubusercontent.com/5055789/186066464-2a9c29ba-ce27-4f2a-92b8-5f4ae7c64b67.png">