### PR TITLE
Rename `LocalAuthenticationOptions` to `LocalAuthentication`

### DIFF
--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -14,7 +14,7 @@ export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
         UserProfile,
         DatabaseUser,
         CredentialsManagerException,
-        LocalAuthenticationOptions;
+        LocalAuthentication;
 
 export 'src/authentication_api.dart';
 export 'src/credentials_manager.dart';
@@ -37,10 +37,10 @@ class Auth0 {
   /// [domain] and [clientId] are both values that can be retrieved from the application in your [Auth0 Dashboard](https://manage.auth0.com).
   /// If you want to use your own implementation to handle credential storage, provide your own [CredentialsManager] implementation
   /// by setting [credentialsManager]. A [DefaultCredentialsManager] instance is used by default.
-  /// If you want to use biometrics or pass-phrase when using the [DefaultCredentialsManager], set [localAuthentication]` to an instance of [LocalAuthenticationOptions].
+  /// If you want to use biometrics or pass-phrase when using the [DefaultCredentialsManager], set [localAuthentication]` to an instance of [LocalAuthentication].
   /// Note however that this setting has no effect when specifying a custom [credentialsManager].
   Auth0(final String domain, final String clientId,
-      {final LocalAuthenticationOptions? localAuthentication,
+      {final LocalAuthentication? localAuthentication,
       final CredentialsManager? credentialsManager})
       : _account = Account(domain, clientId) {
     _credentialsManager = credentialsManager ??

--- a/auth0_flutter/lib/src/credentials_manager.dart
+++ b/auth0_flutter/lib/src/credentials_manager.dart
@@ -22,10 +22,10 @@ abstract class CredentialsManager {
 class DefaultCredentialsManager extends CredentialsManager {
   final Account _account;
   final UserAgent _userAgent;
-  final LocalAuthenticationOptions? _localAuthentication;
+  final LocalAuthentication? _localAuthentication;
 
   DefaultCredentialsManager(this._account, this._userAgent,
-      {final LocalAuthenticationOptions? localAuthentication})
+      {final LocalAuthentication? localAuthentication})
       : _localAuthentication = localAuthentication;
 
   /// Retrieves the credentials from the storage and refreshes them if they have already expired.

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -29,7 +29,7 @@ class WebAuthentication {
   /// Redirects the user to the [Auth0 Universal Login page](https://auth0.com/docs/authenticate/login/auth0-universal-login) for authentication. If successful, it returns
   /// a set of tokens, as well as the user's profile (constructed from ID token claims).
   ///
-  /// If [redirectUrl] is not specified, a default URL is used that incorporates the `domain` value specified to [Auth0.new], and [scheme] on Android, or the
+  /// If [redirectUrl] is not specified, a default URL is used that incorporates the `domain` value specified to [Auth0.new], and scheme on Android, or the
   /// bundle identifier in iOS. [redirectUrl] must appear in your **Allowed Callback URLs** list for the Auth0 app. [Read more about redirecting users](https://auth0.com/docs/authenticate/login/redirect-users-after-login).
   ///
   /// How the ID token is validated can be configured using [idTokenValidationConfig], but in general the defaults for this are adequate.

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -13,7 +13,7 @@ export 'src/credentials-manager/credentials_manager_platform.dart';
 export 'src/credentials-manager/method_channel_credentials_manager.dart';
 export 'src/credentials-manager/options/get_credentials_options.dart';
 export 'src/credentials-manager/options/has_valid_credentials_options.dart';
-export 'src/credentials-manager/options/local_authentication_options.dart';
+export 'src/credentials-manager/options/local_authentication.dart';
 export 'src/credentials-manager/options/save_credentials_options.dart';
 export 'src/credentials.dart';
 export 'src/database_user.dart';

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/options/local_authentication.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/options/local_authentication.dart
@@ -1,5 +1,5 @@
-/// Configuration settings for local authentication prompts.
-class LocalAuthenticationOptions {
+/// Settings for local authentication prompts.
+class LocalAuthentication {
   /// Title to display on the local authentication prompt. Defaults to **Please authenticate to continue** on iOS, `null` on Android.
   final String? title;
 
@@ -12,6 +12,6 @@ class LocalAuthenticationOptions {
   /// (iOS only): Fallback message to display on the local authentication prompt after a failed match.
   final String? fallbackTitle;
 
-  const LocalAuthenticationOptions(
+  const LocalAuthentication(
       {this.title, this.description, this.cancelTitle, this.fallbackTitle});
 }

--- a/auth0_flutter_platform_interface/lib/src/request/request.dart
+++ b/auth0_flutter_platform_interface/lib/src/request/request.dart
@@ -18,7 +18,7 @@ abstract class BaseRequest<TOptions extends RequestOptions?> {
 
 class CredentialsManagerRequest<TOptions extends RequestOptions?>
     extends BaseRequest<TOptions?> {
-  final LocalAuthenticationOptions? localAuthentication;
+  final LocalAuthentication? localAuthentication;
 
   CredentialsManagerRequest({
     required final Account account,

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -100,7 +100,7 @@ void main() {
       expect(verificationResult.arguments['parameters'], isEmpty);
     });
 
-    test('correctly includes the local authentication options', () async {
+    test('correctly includes the local authentication settings', () async {
       when(mocked.methodCallHandler(any))
           .thenAnswer((final _) async => MethodCallHandler.credentials);
 
@@ -109,7 +109,7 @@ void main() {
               account: const Account('', ''),
               userAgent: UserAgent(name: '', version: ''),
               options: GetCredentialsOptions(),
-              localAuthentication: const LocalAuthenticationOptions(
+              localAuthentication: const LocalAuthentication(
                   title: 'test-title',
                   description: 'test-description',
                   cancelTitle: 'test-cancel-title',


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

⚠️ **This PR contains breaking changes**

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR renames the `LocalAuthenticationOptions` class to just `LocalAuthentication`. This class is used as follows:

```dart
const options =
    LocalAuthenticationOptions(title: 'Please authenticate to continue');
final auth0 = Auth0('YOUR_AUTH0_DOMAIN', 'YOUR_AUTH0_CLIENT_ID',
    localAuthentication: options);
final credentials = await auth0.credentialsManager.credentials();
```

Setting it will enable the local authentication feature, which is disabled by default. So it's actually modeling the local authentication feature itself, instead of simply holding settings for a feature that is already in use. As such, it should be called just `LocalAuthentication`, without the `Options` suffix.

Compare it to the `IdTokenValidationConfig` class, which is used as follows:

```dart
const config = IdTokenValidationConfig(leeway: 10);
final credentials =
    await auth0.webAuthentication().login(idTokenValidationConfig: config);
```

The ID token validation feature is always enabled. This class merely allows to configure it, so it has `Config` as part of the class name, and also as part of the parameter name. It is not modeling the feature itself. 

`Config` and `Options` have pretty much the same meaning in this context, yet are being used in classes that have different roles and achieve different results, which is inconsistent and might be confusing.