### PR TITLE
af: Release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-![Stage: First Availability Release](https://img.shields.io/badge/stage-fa-yellow)
 [![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-flutter)](https://circleci.com/gh/auth0/auth0-flutter)
 [![Codecov](https://codecov.io/gh/auth0/auth0-flutter/branch/main/graph/badge.svg)](https://codecov.io/gh/auth0/auth0-flutter)
 
-# Auth0 SDK for Flutter (First Availability)
+# Auth0 SDK for Flutter
 
 Auth0 SDK for Android / iOS Flutter apps.
-
-> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
 
 | Package                                                                 | Description                                   |
 |:------------------------------------------------------------------------|:----------------------------------------------|

--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Change Log
 
+## [1.0.0](https://github.com/auth0/auth0-flutter/tree/1.0.0) (2022-08-25)
+
+This is the General Availability release of the **Auth0 Flutter SDK**! 🎉
+
+This release marks the first stable release of the SDK and is fully supported for use in production environments.
+
+## :warning: Breaking changes
+
+There are a small number of breaking changes from `1.0.0-fa.0` in this release:
+
+**Renamed properties**
+The following properties were renamed to comply with [Dart's API guidelines](https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words).
+
+See #146
+
+- `UserProfile.profileURL` to `UserProfile.profileUrl`
+- `UserProfile.pictureURL` to `UserProfile.pictureUrl`
+- `UserProfile.websiteURL` to `UserProfile.websiteUrl`
+- `ApiException.isInvalidAuthorizeURL` to `ApiException.isInvalidAuthorizeUrl`
+- `ApiException.isPKCENotAvailable` to `ApiException.isPkceNotAvailable`
+
+**Scheme registration**
+
+The `scheme` option of `webAuthentication().login` and `webAuthentication().logout()` was moved up a level to become an option of `webAuthentication()` instead.
+
+Before:
+
+```dart
+auth0.webAuthentication().login(scheme: 'custom-scheme');
+auth0.webAuthentication().logout(scheme: 'custom-scheme');
+```
+
+After:
+
+```dart
+auth0.webAuthentication(scheme: 'custom-scheme').login();
+auth0.webAuthentication(scheme: 'custom-scheme').logout();
+```
+
+See #150
+
+**Renamed `LocalAuthenticationOptions`**
+
+`LocalAuthenticationOptions` was renamed to `LocalAuthentication` to fix up some confusion about how the class was to be used.
+
+See #152 for details.
+
 ## [1.0.0-fa.0](https://github.com/auth0/auth0-flutter/tree/1.0.0-fa.0) (2022-07-22)
 
 This is a [First Availability](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#first-availability) release of the **Auth0 Flutter SDK**! 🎉 

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -1,12 +1,10 @@
-# Auth0 SDK for Flutter (First Availability)
+# Auth0 SDK for Flutter
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/auth0-flutter.svg)](https://circleci.com/gh/auth0/auth0-flutter/tree/main)
 [![Codecov](https://codecov.io/gh/auth0/auth0-flutter/branch/main/graph/badge.svg)](https://codecov.io/gh/auth0/auth0-flutter)
 [![Package](https://img.shields.io/pub/v/auth0_flutter.svg)](https://pub.dartlang.org/packages/auth0_flutter)
 
 Auth0 SDK for Android / iOS Flutter apps.
-
-> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
 
 ---
 

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '1.0.0-fa.0';
+const String version = '1.0.0';

--- a/auth0_flutter/pubspec.lock
+++ b/auth0_flutter/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: auth0_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-fa.0"
+    version: "1.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter
-version: 1.0.0-fa.0
+version: 1.0.0
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  auth0_flutter_platform_interface: 1.0.0-fa.0
+  auth0_flutter_platform_interface: 1.0.0
   flutter:
     sdk: flutter
 

--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.0.0](https://github.com/auth0/auth0-flutter/tree/1.0.0) (2022-08-25)
 
-This is the [General Availability] release of the **Auth0 Flutter SDK**! 🎉
+This is the General Availability release of the **Auth0 Flutter SDK**! 🎉
 
 This release marks the first stable release of the SDK and is fully supported for use in production environments.
 

--- a/auth0_flutter_platform_interface/README.md
+++ b/auth0_flutter_platform_interface/README.md
@@ -8,8 +8,6 @@ This package provides the common interface for platform implementations.
 
 **[API documentation ↗](https://pub.dev/documentation/auth0_flutter_platform_interface/latest/)**
 
-> ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move toward General Availability, please be aware that releases may contain breaking changes.
-
 ## Issue Reporting
 
 For general support or usage questions, use the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums or raise a [support ticket](https://support.auth0.com/). Only [raise an issue](https://github.com/auth0/auth0_flutter/issues) if you have found a bug or want to request a feature.


### PR DESCRIPTION
This is the General Availability release of the **Auth0 Flutter SDK**! 🎉

This release marks the first stable release of the SDK and is fully supported for use in production environments.

## :warning: Breaking changes

There are a small number of breaking changes from `1.0.0-fa.0` in this release:

**Renamed properties**
The following properties were renamed to comply with [Dart's API guidelines](https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words).

See #146

- `UserProfile.profileURL` to `UserProfile.profileUrl`
- `UserProfile.pictureURL` to `UserProfile.pictureUrl`
- `UserProfile.websiteURL` to `UserProfile.websiteUrl`
- `ApiException.isInvalidAuthorizeURL` to `ApiException.isInvalidAuthorizeUrl`
- `ApiException.isPKCENotAvailable` to `ApiException.isPkceNotAvailable`

**Scheme registration**

The `scheme` option of `webAuthentication().login` and `webAuthentication().logout()` was moved up a level to become an option of `webAuthentication()` instead.

Before:

```dart
auth0.webAuthentication().login(scheme: 'custom-scheme');
auth0.webAuthentication().logout(scheme: 'custom-scheme');
```

After:

```dart
auth0.webAuthentication(scheme: 'custom-scheme').login();
auth0.webAuthentication(scheme: 'custom-scheme').logout();
```

See #150

**Renamed `LocalAuthenticationOptions`**

`LocalAuthenticationOptions` was renamed to `LocalAuthentication` to fix up some confusion about how the class was to be used.

See #152 for details.