### PR TITLE
Fix timezone issue in Android Credentials Manager handler

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -32,6 +32,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
         }
 
         val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        format.timeZone = TimeZone.getTimeZone("UTC")
         val date = format.parse(credentials.get("expiresAt") as String)
 
         credentialsManager.saveCredentials(Credentials(

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
@@ -171,7 +171,8 @@ class SaveCredentialsRequestHandlerTest {
             "expiresAt" to "2022-01-01T00:00:00.000Z",
             "scopes" to arrayListOf("a", "b")
         )
-        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        format.timeZone = TimeZone.getTimeZone("UTC")
         val date = format.parse(credentialsMap["expiresAt"] as String) as Date
         var scope: String? = null
         val scopes = credentialsMap.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
@@ -206,6 +207,11 @@ class SaveCredentialsRequestHandlerTest {
         verify(mockCredentialsManager).saveCredentials(captor.capture())
 
         assertThat((captor.firstValue).accessToken, equalTo(credentials.accessToken))
+        assertThat((captor.firstValue).idToken, equalTo(credentials.idToken))
+        assertThat((captor.firstValue).refreshToken, equalTo(credentials.refreshToken))
+        assertThat((captor.firstValue).type, equalTo(credentials.type))
+        assertThat((captor.firstValue).expiresAt, equalTo(credentials.expiresAt))
+        assertThat((captor.firstValue).scope, equalTo(credentials.scope))
     }
 
     @Test


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The Android `SaveCredentialsRequestHandler` receives an `expiresAt` UTC string date from the Dart layer. This date string should be parsed as UTC, but instead it gets parsed using the default timezone. Thus, the default timezone's offset gets added to the date, resulting in an incorrect `Credentials.expiresAt` value.

This happens because no timezone was specified for the `SimpleDateFormat` parser, and as such `TimeZone.getDefault()` gets used by default.

This PR ensures the `SaveCredentialsRequestHandler` parses this date as UTC, by setting "UTC" as the parser's timezone.

#### Before

<img width="644" alt="Screen Shot 2022-09-13 at 22 48 58" src="https://user-images.githubusercontent.com/5055789/190047023-df46f5ed-8093-488f-8d03-e96854d42b6f.png">

#### After

<img width="437" alt="Screen Shot 2022-09-13 at 22 52 20" src="https://user-images.githubusercontent.com/5055789/190047065-6d834f01-9eb3-4cdb-8ddc-fbb036221e9d.png">

### 📎 References

Fixes https://github.com/auth0/auth0-flutter/issues/160

### 🎯 Testing

Asserts were added to an existing unit test.