### PR TITLE
af: Replace usages of `getOrDefault()`

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterAuthMethodCallHandler.kt
@@ -1,6 +1,5 @@
 package com.auth0.auth0_flutter
 
-import android.app.Activity
 import androidx.annotation.NonNull
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.auth0_flutter.request_handlers.api.*

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -34,14 +34,14 @@ class LoginApiRequestHandler : ApiRequestHandler {
                 args["connectionOrRealm"] as String
             )
 
-        val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (args["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         loginBuilder.setScope(scopes.joinToString(separator = " "))
 
-        if (args.getOrDefault("audience", null) is String) {
+        if (args["audience"] is String) {
             loginBuilder.setAudience(args["audience"] as String)
         }
 
-        if (args.getOrDefault("parameters", null) is HashMap<*, *>) {
+        if (args["parameters"] is HashMap<*, *>) {
             loginBuilder.addParameters(args["parameters"] as Map<String, String>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -27,12 +27,12 @@ class RenewApiRequestHandler : ApiRequestHandler {
 
         val renewAuthBuilder = api.renewAuth(request.data["refreshToken"] as String)
 
-        val scopes = request.data.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (request.data["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             renewAuthBuilder.addParameter("scope", scopes.joinToString(separator = " "))
         }
 
-        if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
+        if (request.data["parameters"] is HashMap<*, *>) {
             renewAuthBuilder.addParameters(request.data["parameters"] as Map<String, String>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ResetPasswordApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/ResetPasswordApiRequestHandler.kt
@@ -26,7 +26,7 @@ class ResetPasswordApiRequestHandler : ApiRequestHandler {
             connection = request.data["connection"] as String
         )
 
-        if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
+        if (request.data["parameters"] is HashMap<*, *>) {
             builder.addParameters(request.data["parameters"] as Map<String, String>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SignupApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SignupApiRequestHandler.kt
@@ -25,7 +25,7 @@ class SignupApiRequestHandler : ApiRequestHandler {
                 userMetadata = request.data["userMetadata"] as Map<String, String>?
             )
 
-        if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
+        if (request.data["parameters"] is HashMap<*, *>) {
             builder.addParameters(request.data["parameters"] as Map<String, String>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/UserInfoApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/UserInfoApiRequestHandler.kt
@@ -23,7 +23,7 @@ class UserInfoApiRequestHandler : ApiRequestHandler {
 
         val builder = api.userInfo(request.data["accessToken"] as String)
 
-        if (request.data.getOrDefault("parameters", null) is HashMap<*, *>) {
+        if (request.data["parameters"] is HashMap<*, *>) {
             builder.addParameters(request.data["parameters"] as Map<String, String>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -24,7 +24,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
     ) {
         var scope: String? = null
 
-        val scopes = request.data.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (request.data["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             scope = scopes.joinToString(separator = " ")
         }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -26,7 +26,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
         assertHasProperties(listOf("accessToken", "idToken" , "tokenType", "expiresAt"), credentials, "credentials")
 
         var scope: String? = null
-        val scopes = credentials.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (credentials["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             scope = scopes.joinToString(separator = " ")
         }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -23,43 +23,43 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
     ) {
         val builder = builderResolver(request)
         val args = request.data
-        val scopes = args.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (args["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
 
         builder.withScope(scopes.joinToString(separator = " "))
 
-        if (args.getOrDefault("audience", null) is String) {
+        if (args["audience"] is String) {
             builder.withAudience(args["audience"] as String)
         }
 
-        if (args.getOrDefault("redirectUrl", null) is String) {
+        if (args["redirectUrl"] is String) {
             builder.withRedirectUri(args["redirectUrl"] as String)
         }
 
-        if (args.getOrDefault("organizationId", null) is String) {
+        if (args["organizationId"] is String) {
             builder.withOrganization(args["organizationId"] as String)
         }
 
-        if (args.getOrDefault("invitationUrl", null) is String) {
+        if (args["invitationUrl"] is String) {
             builder.withInvitationUrl(args["invitationUrl"] as String)
         }
 
-        if (args.getOrDefault("leeway", null) is Int) {
+        if (args["leeway"] is Int) {
             builder.withIdTokenVerificationLeeway(args["leeway"] as Int)
         }
 
-        if (args.getOrDefault("maxAge", null) is Int) {
+        if (args["maxAge"] is Int) {
             builder.withMaxAge(args["maxAge"] as Int)
         }
 
-        if (args.getOrDefault("issuer", null) is String) {
+        if (args["issuer"] is String) {
             builder.withIdTokenVerificationIssuer(args["issuer"] as String)
         }
 
-        if (args.getOrDefault("scheme", null) is String) {
+        if (args["scheme"] is String) {
             builder.withScheme(args["scheme"] as String)
         }
 
-        if (args.getOrDefault("parameters", null) is Map<*, *>) {
+        if (args["parameters"] is Map<*, *>) {
             builder.withParameters(args["parameters"] as Map<String, *>)
         }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
@@ -14,11 +14,11 @@ class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallReques
         val builder = builderResolver(request)
         val args = request.data
 
-        if (args.getOrDefault("scheme", null) is String) {
+        if (args["scheme"] is String) {
             builder.withScheme(args["scheme"] as String)
         }
 
-        if (args.getOrDefault("returnTo", null) is String) {
+        if (args["returnTo"] is String) {
             builder.withReturnToUrl(args["returnTo"] as String)
         }
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
@@ -175,7 +175,7 @@ class SaveCredentialsRequestHandlerTest {
         format.timeZone = TimeZone.getTimeZone("UTC")
         val date = format.parse(credentialsMap["expiresAt"] as String) as Date
         var scope: String? = null
-        val scopes = credentialsMap.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (credentialsMap["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             scope = scopes.joinToString(separator = " ")
         }
@@ -226,7 +226,7 @@ class SaveCredentialsRequestHandlerTest {
         val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val date = format.parse(credentialsMap["expiresAt"] as String) as Date
         var scope: String? = null
-        val scopes = credentialsMap.getOrDefault("scopes", arrayListOf<String>()) as ArrayList<*>
+        val scopes = (credentialsMap["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
         if (scopes.isNotEmpty()) {
             scope = scopes.joinToString(separator = " ")
         }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR removes or replaces all usages of the `getOrDefault()` on the Kotlin code, as this method is only available on Android API 24+: https://developer.android.com/reference/java/util/Map#getOrDefault(java.lang.Object,%20V)

For the cases where there was a non-null default value, the Elvis operator was used to provide the default value.

For the cases where the default value was simply `null`, there was no need to do anything else as the map already returns `null` if the value is not present:

<img width="723" alt="Screen Shot 2022-10-28 at 20 38 33" src="https://user-images.githubusercontent.com/5055789/198753465-706a635c-378a-485b-afb0-9137fafa058f.png">

Also, an unused import was removed.

### 📎 References

Fixes https://github.com/auth0/auth0-flutter/issues/178