### PR TITLE
af: Update Podspec

### DIFF
--- a/auth0_flutter/.shiprc
+++ b/auth0_flutter/.shiprc
@@ -3,6 +3,9 @@
     "lib/src/version.dart": [],
     "pubspec.yaml": [
       "version: {MAJOR}.{MINOR}.{PATCH}"
+    ],
+    "ios/auth0_flutter.podspec": [
+      "= '{MAJOR}.{MINOR}.{PATCH}'"
     ]
   },
   "prebump": "flutter analyze",

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -3,20 +3,21 @@
 # Run `pod lib lint auth0_flutter.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
-  s.name             = 'auth0_flutter'
-  s.version          = '1.0.1'
-  s.summary          = 'Auth0 SDK for Flutter'
-  s.description      = 'Auth0 SDK for Flutter Android and iOS apps.'
-  s.homepage         = 'https://auth0.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Auth0' => 'support@auth0.com' }
+  s.name         = 'auth0_flutter'
+  s.version      = '1.0.1'
+  s.summary      = 'Auth0 SDK for Flutter'
+  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.homepage     = 'https://auth0.com'
+  s.license      = { :file => '../LICENSE' }
+  s.author       = { 'Auth0' => 'support@auth0.com' }
   s.source       = { :path => '.' }
   s.source_files = 'Classes/**/*'
+  s.platform     = :ios, '12.0'
+
   s.dependency 'Flutter'
   s.dependency 'Auth0', '~> 2.3'
-  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = ['5.3', '5.4', '5.5', '5.6', '5.7']
+  s.swift_version       = ['5.3', '5.4', '5.5', '5.6', '5.7']
 end

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,15 +4,13 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'auth0_flutter'
-  s.version          = ' 1.0.0-fa.0'
-  s.summary          = 'A new flutter plugin project.'
-  s.description      = <<-DESC
-A new flutter plugin project.
-                       DESC
-  s.homepage         = 'http://example.com'
+  s.version          = '1.0.1'
+  s.summary          = 'Auth0 SDK for Flutter'
+  s.description      = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.homepage         = 'https://auth0.com'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Auth0' => 'email@auth0.com' }
-  s.source           = { :path => '.' }
+  s.author           = { 'Auth0' => 'support@auth0.com' }
+  s.source       = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'Auth0', '~> 2.3'
@@ -20,5 +18,5 @@ A new flutter plugin project.
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = ['5.3', '5.4', '5.5', '5.6']
+  s.swift_version = ['5.3', '5.4', '5.5', '5.6', '5.7']
 end


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the version number in the Podspec, which was still `1.0.0-fa.0`, and formats it. Even though we don't publish this Podspec to Cocoapods, that version number still shows up on the console when the developer runs `pod install`. So it must show the current version number.

The .shiprc file was updated as well so the version number in the Podspec gets bumped when creating a new release PR.