### PR TITLE
af: Fix Apple login connection crash in Android

### DIFF
--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -65,8 +65,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     //noinspection GradleDynamicVersion
     implementation 'com.auth0.android:auth0:2.+'
-    //noinspection GradleDynamicVersion
-    implementation 'com.auth0.android:jwtdecode:2.+'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
@@ -1,6 +1,5 @@
 package com.auth0.auth0_flutter
 
-import com.auth0.android.jwt.Claim
 import com.auth0.android.result.UserProfile
 import com.auth0.auth0_flutter.utils.getCustomClaims
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
@@ -30,29 +30,6 @@ fun UserProfile.toMap(): Map<String, Any?> {
     )
 }
 
-fun createUserProfileFromClaims(claims: Map<String, Claim>): UserProfile {
-    // Map all claim values to their underlying type as Any
-    val claims = claims.mapValues { it.value.asObject(Any::class.java) }
-        .filter { it.value != null } as Map<String, Any>
-
-    return UserProfile(
-        id = claims["sub"] as String?,
-        name = claims["name"] as String?,
-        givenName = claims["given_name"] as String?,
-        familyName = claims["family_name"] as String?,
-        nickname = claims["nickname"] as String?,
-        pictureURL = claims["picture"] as String?,
-        email = claims["email"] as String?,
-        isEmailVerified = claims["email_verified"] as Boolean?,
-        extraInfo = claims,
-        // The following properties are required by Auth0.Android but would never be part of the claims Map.
-        identities = listOf(),
-        appMetadata = mapOf(),
-        userMetadata = mapOf(),
-        createdAt = null
-    )
-}
-
 val UserProfile.sub: String
     get() = getExtraInfo()["sub"] as String
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -3,9 +3,7 @@ package com.auth0.auth0_flutter.request_handlers.api
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.jwt.JWT
 import com.auth0.android.result.Credentials
-import com.auth0.auth0_flutter.createUserProfileFromClaims
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
@@ -56,8 +54,6 @@ class LoginApiRequestHandler : ApiRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
-                val jwt = JWT(credentials.idToken)
-                val userProfile = createUserProfileFromClaims(jwt.claims)
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
 
@@ -67,7 +63,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
                         "accessToken" to credentials.accessToken,
                         "idToken" to credentials.idToken,
                         "refreshToken" to credentials.refreshToken,
-                        "userProfile" to userProfile.toMap(),
+                        "userProfile" to credentials.user.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scope,
                         "tokenType" to credentials.type

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -3,9 +3,7 @@ package com.auth0.auth0_flutter.request_handlers.api
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.jwt.JWT
 import com.auth0.android.result.Credentials
-import com.auth0.auth0_flutter.createUserProfileFromClaims
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
@@ -44,8 +42,6 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
-                val jwt = JWT(credentials.idToken)
-                val userProfile = createUserProfileFromClaims(jwt.claims)
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
 
@@ -55,7 +51,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
                         "accessToken" to credentials.accessToken,
                         "idToken" to credentials.idToken,
                         "refreshToken" to credentials.refreshToken,
-                        "userProfile" to userProfile.toMap(),
+                        "userProfile" to credentials.user.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scope,
                         "tokenType" to credentials.type

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -3,9 +3,7 @@ package com.auth0.auth0_flutter.request_handlers.api
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.jwt.JWT
 import com.auth0.android.result.Credentials
-import com.auth0.auth0_flutter.createUserProfileFromClaims
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
@@ -52,15 +50,13 @@ class RenewApiRequestHandler : ApiRequestHandler {
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
 
                 val formattedDate = sdf.format(credentials.expiresAt)
-                val jwt = JWT(credentials.idToken)
-                val userProfile = createUserProfileFromClaims(jwt.claims)
 
                 result.success(
                     mapOf(
                         "accessToken" to credentials.accessToken,
                         "idToken" to credentials.idToken,
                         "refreshToken" to credentials.refreshToken,
-                        "userProfile" to userProfile.toMap(),
+                        "userProfile" to credentials.user.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scope,
                         "tokenType" to credentials.type

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -4,9 +4,7 @@ import android.content.Context
 import com.auth0.android.authentication.storage.CredentialsManagerException
 import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.android.callback.Callback
-import com.auth0.android.jwt.JWT
 import com.auth0.android.result.Credentials
-import com.auth0.auth0_flutter.createUserProfileFromClaims
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
@@ -40,8 +38,6 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
-                val jwt = JWT(credentials.idToken)
-                val userProfile = createUserProfileFromClaims(jwt.claims)
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
 
@@ -52,7 +48,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
                         "accessToken" to credentials.accessToken,
                         "idToken" to credentials.idToken,
                         "refreshToken" to credentials.refreshToken,
-                        "userProfile" to userProfile.toMap(),
+                        "userProfile" to credentials.user.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scopes,
                         "tokenType" to credentials.type

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -3,7 +3,6 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.jwt.JWT
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -6,7 +6,6 @@ import com.auth0.android.callback.Callback
 import com.auth0.android.jwt.JWT
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
-import com.auth0.auth0_flutter.createUserProfileFromClaims
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
@@ -71,10 +70,6 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
             override fun onSuccess(credentials: Credentials) {
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
-                val jwt = JWT(credentials.idToken)
-
-                // Map all claim values to their underlying type as Any
-                val userProfile = createUserProfileFromClaims(jwt.claims)
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
 
@@ -85,7 +80,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                         "accessToken" to credentials.accessToken,
                         "idToken" to credentials.idToken,
                         "refreshToken" to credentials.refreshToken,
-                        "userProfile" to userProfile.toMap(),
+                        "userProfile" to credentials.user.toMap(),
                         "expiresAt" to formattedDate,
                         "scopes" to scopes,
                         "tokenType" to credentials.type

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
@@ -112,12 +112,4 @@ class UserProfileExtensionsTest {
         assertThat(user.updatedAt, equalTo("2022-04-22"))
         assertThat(user.address?.get("street"), equalTo("test-street"))
     }
-
-    @Test
-    fun `should create an instance when calling createUserProfileFromClaims`() {
-        val jwt = JWT(JwtTestUtils.createJwt(claims = mapOf("name" to "test-name")))
-        val user = createUserProfileFromClaims(jwt.claims)
-
-        assertThat(user.name, equalTo("test-name"))
-    }
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
@@ -1,6 +1,5 @@
 package com.auth0.auth0_flutter
 
-import com.auth0.android.jwt.JWT
 import com.auth0.android.result.UserProfile
 
 import org.hamcrest.CoreMatchers.equalTo


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)


### 📋 Changes

`auth0-flutter` does claims parsing independently from `Auth0.Android`. This causes issues that have been handled on the Android side. To fix this we use `UserProfile` from `Auth0.Android` instead of recreating it.

### 📎 References

https://github.com/auth0/auth0-flutter/issues/186

### 🎯 Testing

This has been tested manually. Since the changes are consumed from `Auth0.Android` there is no need for coverage.
