### PR TITLE
af: [SDK-3958] Support SFSafariViewController

### DIFF
--- a/auth0_flutter/FAQ.md
+++ b/auth0_flutter/FAQ.md
@@ -108,7 +108,8 @@ If you choose to use `SFSafariViewController`, you need to perform an additional
 override func application(_ app: UIApplication,
                  open url: URL,
                  options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-    return WebAuthentication.resume(with: url)
+    WebAuthentication.resume(with: url)
+    return super.application(application, open: url, options: options);
 }
 ```
 </details>

--- a/auth0_flutter/FAQ.md
+++ b/auth0_flutter/FAQ.md
@@ -72,12 +72,23 @@ You still need to call `logout()` on Android, though, as `useEphemeralSession` i
 
 > ⚠️ `useEphemeralSession` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
 
+### Use ephemeral sessions
+
+If you don't need SSO, you can disable this behavior by using the `useEphemeralSession` option in the login call. This will configure `ASWebAuthenticationSession` to not store the session cookie in the shared cookie jar, as if using an incognito browser window. With no shared cookie, `ASWebAuthenticationSession` will not prompt the user for consent.
+
+```dart
+await webAuth.login(useEphemeralSession: true);
+```
+
+> **Note**
+> `useEphemeralSession` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+ and macOS](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
+
 ### Use `SFSafariViewController`
 
 An alternative is to use `SFSafariViewController` instead of `ASWebAuthenticationSession`. You can do so by setting the `safariViewController` property during login:
 
 ```dart
-await webAuth.login(safariViewController: const SafariViewController();
+await webAuth.login(safariViewController: const SafariViewController());
 ```
 
 > **Note**

--- a/auth0_flutter/FAQ.md
+++ b/auth0_flutter/FAQ.md
@@ -80,6 +80,9 @@ If you don't need SSO, you can disable this behavior by using the `useEphemeralS
 await webAuth.login(useEphemeralSession: true);
 ```
 
+Note that with `useEphemeralSession` you don't need to call `logout()` at all. Just clearing the credentials from the app will suffice. What `logout` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession` there will be no shared cookie to remove.
+
+
 > **Note**
 > `useEphemeralSession` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+ and macOS](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
 

--- a/auth0_flutter/FAQ.md
+++ b/auth0_flutter/FAQ.md
@@ -112,17 +112,6 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 ```
 </details>
 
-<details>
-  <summary>Using the SwiftUI app lifecycle</summary>
-
-```swift
-SomeView()
-    .onOpenURL { url in
-        WebAuthentication.resume(with: url)
-    }
-```
-</details>
-
 ## 3. How can I disable the iOS _logout_ alert box?
 
 ![ios-sso-alert](assets/ios-sso-alert.png)

--- a/auth0_flutter/FAQ.md
+++ b/auth0_flutter/FAQ.md
@@ -91,7 +91,7 @@ If you choose to use `SFSafariViewController`, you need to perform an additional
 ```swift
 // AppDelegate.swift
 
-func application(_ app: UIApplication,
+override func application(_ app: UIApplication,
                  open url: URL,
                  options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
     return WebAuthentication.resume(with: url)

--- a/auth0_flutter/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/auth0_flutter/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/auth0_flutter/example/ios/Podfile
+++ b/auth0_flutter/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/auth0_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/auth0_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -467,6 +467,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -503,6 +504,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/auth0_flutter/example/ios/Runner/AppDelegate.swift
+++ b/auth0_flutter/example/ios/Runner/AppDelegate.swift
@@ -20,6 +20,7 @@ import Auth0
         _ application: UIApplication,
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-            return WebAuthentication.resume(with: url)
+                WebAuthentication.resume(with: url)
+            return super.application(application, open: url, options: options);
         }
 }

--- a/auth0_flutter/example/ios/Runner/AppDelegate.swift
+++ b/auth0_flutter/example/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import Auth0
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -14,4 +15,11 @@ import Flutter
         }
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
+    
+    override func application(
+        _ application: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+            return WebAuthentication.resume(with: url)
+        }
 }

--- a/auth0_flutter/example/ios/Runner/Base.lproj/Main.storyboard
+++ b/auth0_flutter/example/ios/Runner/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Flutter View Controller-->
@@ -14,13 +16,14 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-26" y="-76"/>
         </scene>
     </scenes>
 </document>

--- a/auth0_flutter/example/ios/Runner/Info.plist
+++ b/auth0_flutter/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/auth0_flutter/example/ios/Runner/Info.plist
+++ b/auth0_flutter/example/ios/Runner/Info.plist
@@ -47,5 +47,18 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>auth0</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
@@ -8,10 +8,12 @@ fileprivate typealias Argument = WebAuthLoginMethodHandler.Argument
 class WebAuthLoginHandlerTests: XCTestCase {
     var spy: SpyWebAuth!
     var sut: WebAuthLoginMethodHandler!
+    var spySafariProvider: SpySafariProvider!
 
     override func setUpWithError() throws {
         spy = SpyWebAuth()
-        sut = WebAuthLoginMethodHandler(client: spy)
+        spySafariProvider = SpySafariProvider()
+        sut = WebAuthLoginMethodHandler(client: spy, safariProvider: spySafariProvider.provider)
     }
 }
 
@@ -185,6 +187,12 @@ extension WebAuthLoginHandlerTests {
     func testDoesNotAddSafariViewController() {
         sut.handle(with: arguments(without: SafariViewController.key)) { _ in }
         XCTAssertNil(spy.provider)
+    }
+    
+    func testAddSafariViewControllerWithStyle() {
+        let value = [SafariViewControllerProperty.presentationStyle.rawValue: 2]
+        sut.handle(with: arguments(withKey: SafariViewController.key, value: value)) { _ in }
+        XCTAssertEqual(spySafariProvider.presentationStyle, UIModalPresentationStyle.formSheet)
     }
 }
 

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
@@ -174,6 +174,18 @@ extension WebAuthLoginHandlerTests {
         sut.handle(with: arguments(without: Argument.maxAge)) { _ in }
         XCTAssertNil(spy.maxAgeValue)
     }
+    
+    // MARK: safariViewController
+    
+    func testAddsSafariViewController() {
+        sut.handle(with: arguments(withKey: SafariViewController.key, value: [String: Any]())) { _ in }
+        XCTAssertNotNil(spy.provider)
+    }
+    
+    func testDoesNotAddSafariViewController() {
+        sut.handle(with: arguments(without: SafariViewController.key)) { _ in }
+        XCTAssertNil(spy.provider)
+    }
 }
 
 // MARK: - Login Result

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthLoginMethodHandlerTests.swift
@@ -178,7 +178,7 @@ extension WebAuthLoginHandlerTests {
     // MARK: safariViewController
     
     func testAddsSafariViewController() {
-        sut.handle(with: arguments(withKey: SafariViewController.key, value: [String: Any]())) { _ in }
+        sut.handle(with: arguments()) { _ in }
         XCTAssertNotNil(spy.provider)
     }
     
@@ -238,7 +238,8 @@ extension WebAuthLoginHandlerTests {
             Argument.invitationUrl.rawValue: "https://example.com",
             Argument.leeway.rawValue: 1,
             Argument.issuer.rawValue: "",
-            Argument.maxAge.rawValue: 1
+            Argument.maxAge.rawValue: 1,
+            Argument.safariViewController.rawValue: [:],
         ]
     }
 }

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
@@ -38,6 +38,7 @@ class SpyWebAuth: WebAuth {
     private(set) var useEmphemeralSessionValue: Bool?
     private(set) var invitationURLValue: URL?
     private(set) var organizationValue: String?
+    private(set) var provider: WebAuthProvider?
 
     init() {}
 
@@ -108,6 +109,7 @@ class SpyWebAuth: WebAuth {
     }
 
     func provider(_ provider: @escaping WebAuthProvider) -> Self {
+        self.provider = provider
         return self
     }
 

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
@@ -143,7 +143,7 @@ class SpyWebAuth: WebAuth {
     }
 }
 
-class SpyWebAuthUserAgent: WebAuthUserAgent {
+class MockWebAuthUserAgent: WebAuthUserAgent {
     func start() {
     }
     
@@ -161,7 +161,7 @@ class SpySafariProvider {
         self.presentationStyle = style
         
         return { (_: URL, _: @escaping (WebAuthResult<Void>) -> Void) -> (WebAuthUserAgent) in
-            return SpyWebAuthUserAgent()
+            return MockWebAuthUserAgent()
         }
     }
 }

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthSpies.swift
@@ -142,3 +142,26 @@ class SpyWebAuth: WebAuth {
         callback(logoutResult)
     }
 }
+
+class SpyWebAuthUserAgent: WebAuthUserAgent {
+    func start() {
+    }
+    
+    func finish(with result: Auth0.WebAuthResult<Void>) {
+    }
+}
+
+
+class SpySafariProvider {
+    var presentationStyle: UIModalPresentationStyle? = nil
+    
+    init() {}
+    
+    func provider(_ style: UIModalPresentationStyle) -> WebAuthProvider {
+        self.presentationStyle = style
+        
+        return { (_: URL, _: @escaping (WebAuthResult<Void>) -> Void) -> (WebAuthUserAgent) in
+            return SpyWebAuthUserAgent()
+        }
+    }
+}

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -37,10 +37,7 @@ class _ExampleAppState extends State<ExampleApp> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
-      final result = await webAuth.login(
-          safariViewController: const SafariViewController(
-              presentationStyle:
-                  SafariViewControllerPresentationStyle.formSheet));
+      final result = await webAuth.login();
 
       output = result.idToken;
 

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -26,6 +26,7 @@ class _ExampleAppState extends State<ExampleApp> {
   void initState() {
     super.initState();
     auth0 = Auth0(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
+
     webAuth =
         auth0.webAuthentication(scheme: dotenv.env['AUTH0_CUSTOM_SCHEME']);
   }
@@ -36,7 +37,11 @@ class _ExampleAppState extends State<ExampleApp> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
-      final result = await webAuth.login();
+      final result = await webAuth.login(
+          safariViewController: const SafariViewController(
+              presentationStyle:
+                  SafariViewControllerPresentationStyle.formSheet));
+
       output = result.idToken;
 
       setState(() {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
@@ -18,3 +18,4 @@ extension FlutterError {
         self.init(code: code, message: String(describing: webAuthError), details: webAuthError.details)
     }
 }
+

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -68,7 +68,7 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         
         if let safariViewControllerDictionary = arguments[SafariViewController.key] as? [String: Any?] {
             let safariViewController = SafariViewController(from: safariViewControllerDictionary)
-            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: safariViewController.presentationStyle ?? UIModalPresentationStyle.fullScreen))
+            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: safariViewController.presentationStyle))
         }
 
         webAuth.start {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -14,7 +14,6 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         case leeway
         case issuer
         case maxAge
-        case useSafariViewController
     }
 
     let client: WebAuth
@@ -69,7 +68,6 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         
         if let safariViewControllerDictionary = arguments[SafariViewController.key] as? [String: Any?] {
             let safariViewController = SafariViewController(from: safariViewControllerDictionary)
-            
             webAuth = webAuth.provider(WebAuthentication.safariProvider(style: safariViewController.presentationStyle ?? UIModalPresentationStyle.fullScreen))
         }
 

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -20,7 +20,7 @@ struct WebAuthLoginMethodHandler: MethodHandler {
     }
 
     let client: WebAuth
-    let safariProvider: (UIModalPresentationStyle) -> WebAuthProvider
+    let safariProvider: WebAuthProviderFunction
         
     init(client: WebAuth, safariProvider: @escaping WebAuthProviderFunction = WebAuthentication.safariProvider) {
         self.client = client

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -14,6 +14,8 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         case leeway
         case issuer
         case maxAge
+        case safariViewControllerPresentationStyle
+        case useSafariViewController
     }
 
     let client: WebAuth
@@ -64,6 +66,11 @@ struct WebAuthLoginMethodHandler: MethodHandler {
 
         if let maxAge = arguments[Argument.maxAge] as? Int {
             webAuth = webAuth.maxAge(maxAge)
+        }
+        
+        if arguments[Argument.useSafariViewController] as? Bool == true,
+           let presentationStyle = UIModalPresentationStyle.init(rawValue: arguments[Argument.safariViewControllerPresentationStyle] as? Int ?? 0) {
+            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: presentationStyle))
         }
 
         webAuth.start {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -2,6 +2,8 @@ import Foundation
 import Flutter
 import Auth0
 
+typealias WebAuthProviderFunction = (UIModalPresentationStyle) -> WebAuthProvider
+
 struct WebAuthLoginMethodHandler: MethodHandler {
     enum Argument: String {
         case scopes
@@ -18,6 +20,12 @@ struct WebAuthLoginMethodHandler: MethodHandler {
     }
 
     let client: WebAuth
+    let safariProvider: (UIModalPresentationStyle) -> WebAuthProvider
+        
+    init(client: WebAuth, safariProvider: @escaping WebAuthProviderFunction = WebAuthentication.safariProvider) {
+        self.client = client
+        self.safariProvider = safariProvider
+    }
 
     func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
         guard let useEphemeralSession = arguments[Argument.useEphemeralSession] as? Bool else {
@@ -69,7 +77,7 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         
         if let safariViewControllerDictionary = arguments[SafariViewController.key] as? [String: Any?] {
             let safariViewController = SafariViewController(from: safariViewControllerDictionary)
-            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: safariViewController.presentationStyle))
+            webAuth = webAuth.provider(self.safariProvider(safariViewController.presentationStyle))
         }
 
         webAuth.start {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -14,6 +14,7 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         case leeway
         case issuer
         case maxAge
+        case safariViewController
     }
 
     let client: WebAuth

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -14,7 +14,6 @@ struct WebAuthLoginMethodHandler: MethodHandler {
         case leeway
         case issuer
         case maxAge
-        case safariViewControllerPresentationStyle
         case useSafariViewController
     }
 
@@ -68,9 +67,10 @@ struct WebAuthLoginMethodHandler: MethodHandler {
             webAuth = webAuth.maxAge(maxAge)
         }
         
-        if arguments[Argument.useSafariViewController] as? Bool == true,
-           let presentationStyle = UIModalPresentationStyle.init(rawValue: arguments[Argument.safariViewControllerPresentationStyle] as? Int ?? 0) {
-            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: presentationStyle))
+        if let safariViewControllerDictionary = arguments[SafariViewController.key] as? [String: Any?] {
+            let safariViewController = SafariViewController(from: safariViewControllerDictionary)
+            
+            webAuth = webAuth.provider(WebAuthentication.safariProvider(style: safariViewController.presentationStyle ?? UIModalPresentationStyle.fullScreen))
         }
 
         webAuth.start {

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -1,0 +1,35 @@
+/*enum LocalAuthenticationProperty: String, CaseIterable {
+    case title
+    case cancelTitle
+    case fallbackTitle
+}
+
+struct LocalAuthentication {
+    let title: String
+    let cancelTitle: String?
+    let fallbackTitle: String?
+
+    static let key = "localAuthentication"
+
+    init(from dictionary: [String: String?]) {
+        self.title = dictionary[LocalAuthenticationProperty.title] as? String ?? "Please authenticate to continue"
+        self.cancelTitle = dictionary[LocalAuthenticationProperty.cancelTitle] as? String
+        self.fallbackTitle = dictionary[LocalAuthenticationProperty.fallbackTitle] as? String
+    }
+}*/
+
+enum SafariViewControllerProperty: String, CaseIterable {
+    case presentationStyle
+}
+
+struct SafariViewController {
+    var presentationStyle: UIModalPresentationStyle?
+    
+    static let key = "safariViewController";
+    
+    init(from dictionary: [String: Any?]) {
+        if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int {
+           self.presentationStyle = UIModalPresentationStyle.init(rawValue: presentationStyle)
+        }
+    }
+}

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -3,13 +3,13 @@ enum SafariViewControllerProperty: String, CaseIterable {
 }
 
 struct SafariViewController {
-    var presentationStyle: UIModalPresentationStyle?
+    var presentationStyle: UIModalPresentationStyle = UIModalPresentationStyle.fullScreen
     
     static let key = "safariViewController";
     
     init(from dictionary: [String: Any?]) {
         if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int {
-           self.presentationStyle = UIModalPresentationStyle(rawValue: presentationStyle)
+            self.presentationStyle = UIModalPresentationStyle(rawValue: presentationStyle) ?? UIModalPresentationStyle.fullScreen
         }
     }
 }

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -9,7 +9,7 @@ struct SafariViewController {
     
     init(from dictionary: [String: Any?]) {
         if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int {
-           self.presentationStyle = UIModalPresentationStyle.init(rawValue: presentationStyle)
+           self.presentationStyle = UIModalPresentationStyle(rawValue: presentationStyle)
         }
     }
 }

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -9,8 +9,8 @@ struct SafariViewController {
     
     init(from dictionary: [String: Any?]) {
         if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int,
-            let uiModelPresentationStyle = UIModalPresentationStyle(rawValue: presentationStyle) {
-            self.presentationStyle = uiModelPresentationStyle
+            let uiModalPresentationStyle = UIModalPresentationStyle(rawValue: presentationStyle) {
+            self.presentationStyle = uiModalPresentationStyle
         }
     }
 }

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -1,23 +1,3 @@
-/*enum LocalAuthenticationProperty: String, CaseIterable {
-    case title
-    case cancelTitle
-    case fallbackTitle
-}
-
-struct LocalAuthentication {
-    let title: String
-    let cancelTitle: String?
-    let fallbackTitle: String?
-
-    static let key = "localAuthentication"
-
-    init(from dictionary: [String: String?]) {
-        self.title = dictionary[LocalAuthenticationProperty.title] as? String ?? "Please authenticate to continue"
-        self.cancelTitle = dictionary[LocalAuthenticationProperty.cancelTitle] as? String
-        self.fallbackTitle = dictionary[LocalAuthenticationProperty.fallbackTitle] as? String
-    }
-}*/
-
 enum SafariViewControllerProperty: String, CaseIterable {
     case presentationStyle
 }

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -8,8 +8,9 @@ struct SafariViewController {
     static let key = "safariViewController";
     
     init(from dictionary: [String: Any?]) {
-        if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int {
-            self.presentationStyle = UIModalPresentationStyle(rawValue: presentationStyle) ?? UIModalPresentationStyle.fullScreen
+        if let presentationStyle = dictionary[SafariViewControllerProperty.presentationStyle] as? Int,
+            let uiModelPresentationStyle = UIModalPresentationStyle(rawValue: presentationStyle) {
+            self.presentationStyle = uiModelPresentationStyle
         }
     }
 }

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -10,6 +10,8 @@ export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
         WebAuthenticationException,
         ApiException,
         IdTokenValidationConfig,
+        SafariViewController,
+        SafariViewControllerPresentationStyle,
         Credentials,
         UserProfile,
         DatabaseUser,

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -43,7 +43,7 @@ class WebAuthentication {
   /// * If you want to log into a specific organization, provide the [organizationId]. Provide [invitationUrl] if a user has been invited to
   ///   join an organization.
   /// * (iOS only): [safariViewController] causes [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) to be used when opening the
-  /// Universal Login Page, as an alternative to the default `ASWebAuthenticationSession`. You will also need to [configure your iOS app to automatically resume](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#use-sfsafariviewcontroller) the Web Auth operation after login.
+  /// Universal Login page, as an alternative to the default `ASWebAuthenticationSession`. You will also need to [configure your iOS app to automatically resume](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#use-sfsafariviewcontroller) the Web Auth operation after login.
   Future<Credentials> login(
       {final String? audience,
       final Set<String> scopes = const {

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -42,6 +42,8 @@ class WebAuthentication {
   /// * Arbitrary [parameters] can be specified and then picked up in a custom Auth0 [Action](https://auth0.com/docs/customize/actions) or [Rule](https://auth0.com/docs/customize/rules).
   /// * If you want to log into a specific organization, provide the [organizationId]. Provide [invitationUrl] if a user has been invited to
   ///   join an organization.
+  /// * (iOS only): [safariViewController] causes [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) to be used when opening the
+  /// Universal Login Page, as an alternative to the default `ASWebAuthenticationSession`. You will also need to [configure your iOS app to automatically resume](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#use-sfsafariviewcontroller) the Web Auth operation after login.
   Future<Credentials> login(
       {final String? audience,
       final Set<String> scopes = const {

--- a/auth0_flutter/lib/src/web_authentication.dart
+++ b/auth0_flutter/lib/src/web_authentication.dart
@@ -42,22 +42,22 @@ class WebAuthentication {
   /// * Arbitrary [parameters] can be specified and then picked up in a custom Auth0 [Action](https://auth0.com/docs/customize/actions) or [Rule](https://auth0.com/docs/customize/rules).
   /// * If you want to log into a specific organization, provide the [organizationId]. Provide [invitationUrl] if a user has been invited to
   ///   join an organization.
-  Future<Credentials> login({
-    final String? audience,
-    final Set<String> scopes = const {
-      'openid',
-      'profile',
-      'email',
-      'offline_access'
-    },
-    final String? redirectUrl,
-    final String? organizationId,
-    final String? invitationUrl,
-    final bool useEphemeralSession = false,
-    final Map<String, String> parameters = const {},
-    final IdTokenValidationConfig idTokenValidationConfig =
-        const IdTokenValidationConfig(),
-  }) async {
+  Future<Credentials> login(
+      {final String? audience,
+      final Set<String> scopes = const {
+        'openid',
+        'profile',
+        'email',
+        'offline_access'
+      },
+      final String? redirectUrl,
+      final String? organizationId,
+      final String? invitationUrl,
+      final bool useEphemeralSession = false,
+      final Map<String, String> parameters = const {},
+      final IdTokenValidationConfig idTokenValidationConfig =
+          const IdTokenValidationConfig(),
+      final SafariViewController? safariViewController}) async {
     final credentials = await Auth0FlutterWebAuthPlatform.instance.login(
         _createWebAuthRequest(WebAuthLoginOptions(
             audience: audience,
@@ -68,7 +68,8 @@ class WebAuthentication {
             parameters: parameters,
             idTokenValidationConfig: idTokenValidationConfig,
             scheme: _scheme,
-            useEphemeralSession: useEphemeralSession)));
+            useEphemeralSession: useEphemeralSession,
+            safariViewController: safariViewController)));
 
     await _credentialsManager?.storeCredentials(credentials);
 

--- a/auth0_flutter/pubspec.lock
+++ b/auth0_flutter/pubspec.lock
@@ -5,30 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "6824874a3ddeb1530a8b59c8f3cb1181f38717d0c88ff920962125ffbd65babe"
+      url: "https://pub.dev"
     source: hosted
     version: "41.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "33f7fdac2d5f7cd0a34adb9ec09282edd45c87135b176174dbf3c83388a9934e"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   auth0_flutter_platform_interface:
     dependency: "direct main"
     description:
@@ -40,154 +44,168 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "29a03af98de60b4eb9136acd56608a54e989f6da238a80af739415b05589d6df"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "9aae031a54ab0beebc30a888c93e900d15ae2fd8883d031dbfbd5ebdb57f5a4c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "56942f8114731d1e79942cd981cfef29501937ff1bccf4dbdce0273f31f13640"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "8f4772ec1e72822da7213627a0db16029085a8d709a9032e77b9a049209b6cb2"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: bdb1ab29be158c4784d7f9b7b693745a0719c5899e31c01112782bb1cb871e80
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "17cf9a839208acaed741b1f00ac87cd1fde00548198ba57205cca45c749cb379"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "8aff82f9b26fd868992e5430335a9d773bfef01e1d852d7ba71bf4c5d9349351"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -199,7 +217,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -211,210 +230,240 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   functional_data:
     dependency: transitive
     description:
       name: functional_data
-      url: "https://pub.dartlang.org"
+      sha256: "950f886463a7531a3b77904e0eb89e8e06dda78c4e3f5a84686445a2290cce18"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json2yaml:
     dependency: transitive
     description:
       name: json2yaml
-      url: "https://pub.dartlang.org"
+      sha256: "1bd23a492025254aa14a760db94c8d52142c774ab3f2ab935e31742796bf505d"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: cb314f00b2488de7bc575207e54402cd2f92363f333a7933fd1b0631af226baa
+      url: "https://pub.dev"
     source: hosted
     version: "4.6.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      url: "https://pub.dartlang.org"
+      sha256: a8a1ba34be3ef1056efd32b3f2e8f9266711bd3edf30dc7107d903f70da788f5
+      url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   plain_optional:
     dependency: transitive
     description:
       name: plain_optional
-      url: "https://pub.dartlang.org"
+      sha256: e5856f4c3e5a5e5f47e9c3d13ccbb674d822f95c408869a19ee9a4391cc2e820
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   plugin_platform_interface:
     dependency: "direct dev"
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "075f927ebbab4262ace8d0b283929ac5410c0ac4e7fc123c76429564facfb757"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "3686efe4a4613a4449b1a4ae08670aadbd3376f2e78d93e3f8f0919db02a7256"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   pubspec_yaml:
     dependency: "direct dev"
     description:
       name: pubspec_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "312424c243f98a74b912c028cbedb4776a47f80bf7d8b8791291c4486dc3f02a"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: f27c6406c89ab3921ed4a3bbdc38d48676f8b78fe537cbdbeb0d2c0f661026d7
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   sky_engine:
@@ -426,149 +475,170 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "00f8b6b586f724a8c769c96f1d517511a41661c0aede644544d8d86a1ab11142"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   sum_types:
     dependency: transitive
     description:
       name: sum_types
-      url: "https://pub.dartlang.org"
+      sha256: b65119dcfe38dbd1b4e764c6cc28f0df5ef13badff803b1f38984181ca3d923f
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.1"
+    version: "1.22.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.16"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.20"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e686ae49284939abc06972e25f634ccdb5007d5664c4dfa1995002e8b6aa27a9
+      url: "https://pub.dev"
     source: hosted
     version: "8.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: f66577ed748712574b076e48a300aa3d8bc7aba93e83490c679707187e135ee4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/auth0_flutter/test/web_authentication_test.dart
+++ b/auth0_flutter/test/web_authentication_test.dart
@@ -60,7 +60,10 @@ void main() {
               invitationUrl: 'invitation_url',
               organizationId: 'org_123',
               redirectUrl: 'redirect_url',
-              useEphemeralSession: true);
+              useEphemeralSession: true,
+              safariViewController: const SafariViewController(
+                  presentationStyle:
+                      SafariViewControllerPresentationStyle.formSheet));
 
       final verificationResult = verify(mockedPlatform.login(captureAny))
           .captured
@@ -73,6 +76,12 @@ void main() {
       expect(verificationResult.options.organizationId, 'org_123');
       expect(verificationResult.options.redirectUrl, 'redirect_url');
       expect(verificationResult.options.useEphemeralSession, true);
+      expect(
+          verificationResult.options.safariViewController,
+          const SafariViewController(
+              presentationStyle:
+                  SafariViewControllerPresentationStyle.formSheet));
+
       expect(result, TestPlatform.loginResult);
     });
 

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -25,6 +25,7 @@ export 'src/request/request_options.dart';
 export 'src/user_agent.dart';
 export 'src/user_profile.dart';
 export 'src/web-auth/id_token_validation_config.dart';
+export 'src/web-auth/safariviewcontroller.dart';
 export 'src/web-auth/web_auth_login_options.dart';
 export 'src/web-auth/web_auth_logout_options.dart';
 export 'src/web-auth/web_authentication_exception.dart';

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -25,7 +25,7 @@ export 'src/request/request_options.dart';
 export 'src/user_agent.dart';
 export 'src/user_profile.dart';
 export 'src/web-auth/id_token_validation_config.dart';
-export 'src/web-auth/safariviewcontroller.dart';
+export 'src/web-auth/safari_view_controller.dart';
 export 'src/web-auth/web_auth_login_options.dart';
 export 'src/web-auth/web_auth_logout_options.dart';
 export 'src/web-auth/web_authentication_exception.dart';

--- a/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
@@ -24,9 +24,6 @@ class SafariViewController {
 
   const SafariViewController({this.presentationStyle});
 
-  Map<String, dynamic> toMap() => {
-        ...presentationStyle != null
-            ? {'presentationStyle': presentationStyle?.value}
-            : <String, dynamic>{}
-      };
+  Map<String, dynamic> toMap() =>
+      {'presentationStyle': presentationStyle?.value};
 }

--- a/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
@@ -1,4 +1,3 @@
-
 enum SafariViewControllerPresentationStyle {
   automatic(-2),
   none(-1),
@@ -19,4 +18,10 @@ class SafariViewController {
   final SafariViewControllerPresentationStyle? presentationStyle;
 
   const SafariViewController({this.presentationStyle});
+
+  Map<String, dynamic> toMap() => {
+        ...presentationStyle != null
+            ? {'presentationStyle': presentationStyle?.value}
+            : <String, dynamic>{}
+      };
 }

--- a/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
@@ -1,3 +1,6 @@
+/// Presentation styles for when using SFSafariViewController on iOS.
+/// For the full description of what each option does, please see the
+/// [UIModelPresentationStyle docs](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle).
 enum SafariViewControllerPresentationStyle {
   automatic(-2),
   none(-1),
@@ -14,7 +17,9 @@ enum SafariViewControllerPresentationStyle {
   final int value;
 }
 
+/// Configuration for using `SFSafariViewController` on iOS.
 class SafariViewController {
+  /// The presentation style used when opening the browser window. Defaults to `fullScreen`.
   final SafariViewControllerPresentationStyle? presentationStyle;
 
   const SafariViewController({this.presentationStyle});

--- a/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/safari_view_controller.dart
@@ -1,3 +1,4 @@
+
 enum SafariViewControllerPresentationStyle {
   automatic(-2),
   none(-1),

--- a/auth0_flutter_platform_interface/lib/src/web-auth/safariviewcontroller.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/safariviewcontroller.dart
@@ -1,0 +1,21 @@
+enum SafariViewControllerPresentationStyle {
+  automatic(-2),
+  none(-1),
+  fullScreen(0),
+  pageSheet(1),
+  formSheet(2),
+  currentContext(3),
+  custom(4),
+  overFullScreen(5),
+  overCurrentContext(6),
+  popover(7);
+
+  const SafariViewControllerPresentationStyle(this.value);
+  final int value;
+}
+
+class SafariViewController {
+  final SafariViewControllerPresentationStyle? presentationStyle;
+
+  const SafariViewController({this.presentationStyle});
+}

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../request/request_options.dart';
 import 'id_token_validation_config.dart';
-import 'safariviewcontroller.dart';
+import 'safari_view_controller.dart';
 
 class WebAuthLoginOptions implements RequestOptions {
   final IdTokenValidationConfig? idTokenValidationConfig;

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -43,16 +43,7 @@ class WebAuthLoginOptions implements RequestOptions {
       'parameters': parameters,
       'scheme': scheme,
       ...safariViewController != null
-          ? {
-              'safariViewController': {
-                ...safariViewController?.presentationStyle != null
-                    ? {
-                        'presentationStyle':
-                            safariViewController?.presentationStyle?.value
-                      }
-                    : <String, dynamic>{}
-              }
-            }
+          ? {'safariViewController': safariViewController?.toMap()}
           : <String, dynamic>{}
     };
 

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -29,22 +29,33 @@ class WebAuthLoginOptions implements RequestOptions {
       this.safariViewController});
 
   @override
-  Map<String, dynamic> toMap() => {
-        'leeway': idTokenValidationConfig?.leeway,
-        'issuer': idTokenValidationConfig?.issuer,
-        'maxAge': idTokenValidationConfig?.maxAge,
-        'audience': audience,
-        'scopes': scopes.toList(),
-        'redirectUrl': redirectUrl,
-        'organizationId': organizationId,
-        'invitationUrl': invitationUrl,
-        'useEphemeralSession': useEphemeralSession,
-        'parameters': parameters,
-        'scheme': scheme,
-        'useSafariViewController': safariViewController != null,
-        'safariViewControllerPresentationStyle':
-            safariViewController?.presentationStyle != null
-                ? safariViewController!.presentationStyle!.value
-                : null
-      };
+  Map<String, dynamic> toMap() {
+    final map = {
+      'leeway': idTokenValidationConfig?.leeway,
+      'issuer': idTokenValidationConfig?.issuer,
+      'maxAge': idTokenValidationConfig?.maxAge,
+      'audience': audience,
+      'scopes': scopes.toList(),
+      'redirectUrl': redirectUrl,
+      'organizationId': organizationId,
+      'invitationUrl': invitationUrl,
+      'useEphemeralSession': useEphemeralSession,
+      'parameters': parameters,
+      'scheme': scheme,
+      ...safariViewController != null
+          ? {
+              'safariViewController': {
+                ...safariViewController?.presentationStyle != null
+                    ? {
+                        'presentationStyle':
+                            safariViewController?.presentationStyle?.value
+                      }
+                    : <String, dynamic>{}
+              }
+            }
+          : <String, dynamic>{}
+    };
+
+    return map;
+  }
 }

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/foundation.dart';
+
 import '../request/request_options.dart';
 import 'id_token_validation_config.dart';
+import 'safariviewcontroller.dart';
 
 class WebAuthLoginOptions implements RequestOptions {
   final IdTokenValidationConfig? idTokenValidationConfig;
@@ -11,6 +14,7 @@ class WebAuthLoginOptions implements RequestOptions {
   final bool useEphemeralSession;
   final Map<String, String> parameters;
   final String? scheme;
+  final SafariViewController? safariViewController;
 
   WebAuthLoginOptions(
       {this.idTokenValidationConfig,
@@ -21,7 +25,8 @@ class WebAuthLoginOptions implements RequestOptions {
       this.invitationUrl,
       this.scheme,
       this.useEphemeralSession = false,
-      this.parameters = const {}});
+      this.parameters = const {},
+      this.safariViewController});
 
   @override
   Map<String, dynamic> toMap() => {
@@ -35,6 +40,11 @@ class WebAuthLoginOptions implements RequestOptions {
         'invitationUrl': invitationUrl,
         'useEphemeralSession': useEphemeralSession,
         'parameters': parameters,
-        'scheme': scheme
+        'scheme': scheme,
+        'useSafariViewController': safariViewController != null,
+        'safariViewControllerPresentationStyle':
+            safariViewController?.presentationStyle != null
+                ? safariViewController!.presentationStyle!.value
+                : null
       };
 }

--- a/auth0_flutter_platform_interface/pubspec.lock
+++ b/auth0_flutter_platform_interface/pubspec.lock
@@ -5,182 +5,200 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "6824874a3ddeb1530a8b59c8f3cb1181f38717d0c88ff920962125ffbd65babe"
+      url: "https://pub.dev"
     source: hosted
     version: "41.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "33f7fdac2d5f7cd0a34adb9ec09282edd45c87135b176174dbf3c83388a9934e"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "29a03af98de60b4eb9136acd56608a54e989f6da238a80af739415b05589d6df"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "9aae031a54ab0beebc30a888c93e900d15ae2fd8883d031dbfbd5ebdb57f5a4c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "56942f8114731d1e79942cd981cfef29501937ff1bccf4dbdce0273f31f13640"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "8f4772ec1e72822da7213627a0db16029085a8d709a9032e77b9a049209b6cb2"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: bdb1ab29be158c4784d7f9b7b693745a0719c5899e31c01112782bb1cb871e80
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "17cf9a839208acaed741b1f00ac87cd1fde00548198ba57205cca45c749cb379"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "8aff82f9b26fd868992e5430335a9d773bfef01e1d852d7ba71bf4c5d9349351"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -192,7 +210,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -204,182 +223,208 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: cb314f00b2488de7bc575207e54402cd2f92363f333a7933fd1b0631af226baa
+      url: "https://pub.dev"
     source: hosted
     version: "4.6.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      url: "https://pub.dartlang.org"
+      sha256: a8a1ba34be3ef1056efd32b3f2e8f9266711bd3edf30dc7107d903f70da788f5
+      url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   plugin_platform_interface:
     dependency: "direct main"
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "075f927ebbab4262ace8d0b283929ac5410c0ac4e7fc123c76429564facfb757"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "3686efe4a4613a4449b1a4ae08670aadbd3376f2e78d93e3f8f0919db02a7256"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: f27c6406c89ab3921ed4a3bbdc38d48676f8b78fe537cbdbeb0d2c0f661026d7
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   sky_engine:
@@ -391,142 +436,162 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "00f8b6b586f724a8c769c96f1d517511a41661c0aede644544d8d86a1ab11142"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.1"
+    version: "1.22.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.16"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.20"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e686ae49284939abc06972e25f634ccdb5007d5664c4dfa1995002e8b6aa27a9
+      url: "https://pub.dev"
     source: hosted
     version: "8.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: f66577ed748712574b076e48a300aa3d8bc7aba93e83490c679707187e135ee4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -169,6 +169,30 @@ void main() {
       expect(result.refreshToken, isNull);
     });
 
+    test('correctly includes SafariViewController options when specified',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.loginResult);
+
+      await MethodChannelAuth0FlutterWebAuth().login(
+          WebAuthRequest<WebAuthLoginOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: WebAuthLoginOptions(
+                  useEphemeralSession: true,
+                  safariViewController: const SafariViewController(
+                      presentationStyle:
+                          SafariViewControllerPresentationStyle.formSheet))));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+
+      expect(
+          verificationResult.arguments['safariViewController']
+              ['presentationStyle'],
+          2);
+    });
+
     test(
         'throws an WebAuthenticationException when method channel returns null',
         () async {

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -127,6 +127,7 @@ void main() {
       expect(verificationResult.arguments['scheme'], isNull);
       expect(verificationResult.arguments['useEphemeralSession'], false);
       expect(verificationResult.arguments['idTokenValidationConfig'], isNull);
+      expect(verificationResult.arguments['safariViewController'], isNull);
     });
 
     test('correctly returns the response from the Method Channel', () async {
@@ -169,7 +170,7 @@ void main() {
       expect(result.refreshToken, isNull);
     });
 
-    test('correctly includes SafariViewController options when specified',
+    test('correctly includes safariViewController options when specified',
         () async {
       when(mocked.methodCallHandler(any))
           .thenAnswer((final _) async => MethodCallHandler.loginResult);
@@ -179,7 +180,6 @@ void main() {
               account: const Account('test-domain', 'test-clientId'),
               userAgent: UserAgent(name: 'test-name', version: 'test-version'),
               options: WebAuthLoginOptions(
-                  useEphemeralSession: true,
                   safariViewController: const SafariViewController(
                       presentationStyle:
                           SafariViewControllerPresentationStyle.formSheet))));
@@ -191,6 +191,24 @@ void main() {
           verificationResult.arguments['safariViewController']
               ['presentationStyle'],
           2);
+    });
+
+    test('excludes safariViewController from the map when not specified',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.loginResult);
+
+      await MethodChannelAuth0FlutterWebAuth().login(
+          WebAuthRequest<WebAuthLoginOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: WebAuthLoginOptions()));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+
+      expect(verificationResult.arguments.containsKey('safariViewController'),
+          false);
     });
 
     test(

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -190,7 +190,7 @@ void main() {
       expect(
           verificationResult.arguments['safariViewController']
               ['presentationStyle'],
-          2);
+          SafariViewControllerPresentationStyle.formSheet.value);
     });
 
     test('excludes safariViewController from the map when not specified',


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR adds support for [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) on iOS as an alternative to the default `ASWebAuthenticationSession`. Developers can optionally pass `presentationStyle` to control the behaviour.

Usage:

```dart
await webAuth.login(
          safariViewController: const SafariViewController(
              presentationStyle: SafariViewControllerPresentationStyle.formSheet));
```

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Unit tests have been added, plus manual testing on an iOS simulator.
