### PR TITLE
Release 1.1.0 (bump version)

### DIFF
--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 1.0.1
+version: 1.1.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION
This corrects an issue from the [previous release PR](https://github.com/auth0/auth0-flutter/pull/200), and bump the version number.