### PR TITLE
fix Arabic date parsing issue in Android

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -54,17 +54,29 @@ class Credentials {
     required this.tokenType,
   });
 
+  static DateTime parseArabicDate(final String arabicDateString) {
+    final String englishDateString = arabicDateString.replaceAllMapped(
+      RegExp('[٠١٢٣٤٥٦٧٨٩]'),
+      (final match) =>
+          String.fromCharCode(match.group(0)!.codeUnitAt(0) - 1632 + 48),
+    );
+
+    final DateTime date = DateTime.parse(englishDateString);
+    return date;
+  }
+
   factory Credentials.fromMap(final Map<dynamic, dynamic> result) =>
       Credentials(
         idToken: result['idToken'] as String,
         accessToken: result['accessToken'] as String,
         refreshToken: result['refreshToken'] as String?,
-        expiresAt: DateTime.parse(result['expiresAt'] as String),
+        expiresAt: Credentials.parseArabicDate(result['expiresAt'] as String),
         scopes: Set<String>.from(result['scopes'] as List<Object?>),
         user: UserProfile.fromMap(Map<String, dynamic>.from(
             result['userProfile'] as Map<dynamic, dynamic>)),
         tokenType: result['tokenType'] as String,
       );
+
 
   Map<String, dynamic> toMap() => {
         'idToken': idToken,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

I recently submitted a pull request on the Auth0 repository on GitHub regarding an issue with parsing Arabic dates in the auth0_flutter package. The issue was that the package was unable to parse Arabic dates, leading to a FormatException when attempting to convert them to DateTime objects.

To solve this issue, I added a method to the Credentials class that converts Arabic date strings to their English equivalents before parsing them as DateTime objects. This solution allows the package to properly handle Arabic dates, which is particularly important for apps that may be used in Arabic-speaking countries.


<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

The auth0_flutter_platform_interface version should be updated or you should override dependencies at ` pubspec.yaml` 

```
dependency_overrides:
  auth0_flutter_platform_interface:
    path: ../../auth0_flutter_platform_interface
```
May required:

`publish_to: "none"
`
When using it directly as :

```
dependencies:
  auth0_flutter_platform_interface:
    path: ../auth0_flutter_platform_interface

```