### PR TITLE
Add `credentials()` and `hasValidCredentials()` [SDK-3997]

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -28,15 +28,17 @@ class _ExampleAppState extends State<ExampleApp> {
   @override
   void initState() {
     super.initState();
-    auth0 = Auth0(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
 
+    auth0 = Auth0(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
     auth0Web =
         Auth0Web(dotenv.env['AUTH0_DOMAIN']!, dotenv.env['AUTH0_CLIENT_ID']!);
-
     webAuth =
         auth0.webAuthentication(scheme: dotenv.env['AUTH0_CUSTOM_SCHEME']);
 
-    auth0Web.onLoad();
+    auth0Web.onLoad().then((final credentials) => setState(() {
+          _output = credentials.idToken;
+          _isLoggedIn = true;
+        }));
   }
 
   Future<void> webAuthLogin() async {
@@ -46,19 +48,18 @@ class _ExampleAppState extends State<ExampleApp> {
     // We also handle the message potentially returning null.
     try {
       if (kIsWeb) {
-        await auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
-      } else {
-        final result = await webAuth.login();
-
-        output = result.idToken;
-
-        setState(() {
-          _isLoggedIn = true;
-        });
+        return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
-    } on WebAuthenticationException catch (e) {
+
+      final result = await webAuth.login();
+      output = result.idToken;
+    } catch (e) {
       output = e.toString();
     }
+
+    setState(() {
+      _isLoggedIn = true;
+    });
 
     // If the widget was removed from the tree while the asynchronous platform
     // message was in flight, we want to discard the reply rather than calling

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -10,16 +10,19 @@ class Auth0Web {
   Auth0Web(final String domain, final String clientId)
       : _account = Account(domain, clientId);
 
-  Future<Credentials?> onLoad() async {
+  Future<Credentials> onLoad() async {
     await Auth0FlutterWebPlatform.instance.initialize(_account);
-
-    // Get credentials here and return them on load?
-
-    return null;
+    return credentials();
   }
 
   Future<void> loginWithRedirect(
           {final String? audience, final String? redirectUrl}) =>
       Auth0FlutterWebPlatform.instance.loginWithRedirect(
           LoginOptions(audience: audience, redirectUrl: redirectUrl));
+
+  Future<Credentials> credentials() =>
+      Auth0FlutterWebPlatform.instance.credentials();
+
+  Future<bool> hasValidCredentials() =>
+      Auth0FlutterWebPlatform.instance.hasValidCredentials();
 }

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
@@ -9,8 +9,6 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
     throw UnsupportedError('initialize is only supported on the web platform');
   }
 
-  // methods, e.g. loginWithRedirect()
-  // here they should throw an UnsupportedError
   @override
   Future<void> loginWithRedirect(final LoginOptions? options) {
     throw UnsupportedError(
@@ -18,8 +16,13 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
-  Future<Credentials?> handleRedirectCallback() {
+  Future<Credentials> credentials() {
+    throw UnsupportedError('credentials is only supported on the web platform');
+  }
+
+  @override
+  Future<bool> hasValidCredentials() {
     throw UnsupportedError(
-        'handleRedirectCallback is only supported on the web platform');
+        'hasValidCredentials is only supported on the web platform');
   }
 }

--- a/auth0_flutter/lib/src/web/credentials_extension.dart
+++ b/auth0_flutter/lib/src/web/credentials_extension.dart
@@ -1,0 +1,21 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+
+import 'js_interop.dart';
+import 'jwt_decode.dart';
+import 'user_profile_extension.dart';
+
+extension CredentialsExtension on Credentials {
+  static Credentials fromWeb(final WebCredentials webCredentials) {
+    final expiresIn = webCredentials.expires_in as int;
+    final expiresAt = DateTime.now().add(Duration(seconds: expiresIn));
+    final claims = JWT.decode(webCredentials.id_token);
+    final user = UserProfileExtension.fromClaims(claims);
+
+    return Credentials(
+        idToken: webCredentials.id_token,
+        accessToken: webCredentials.access_token,
+        expiresAt: expiresAt,
+        user: user,
+        tokenType: 'Bearer');
+  }
+}

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -1,6 +1,3 @@
-// Here go the annotations –from the js package– that allow calling JS code
-// See https://pub.dev/packages/js#usage
-
 // ignore_for_file: non_constant_identifier_names
 
 @JS('auth0')
@@ -10,7 +7,7 @@ import 'package:js/js.dart';
 
 @JS()
 @anonymous
-abstract class AuthorizationParams {
+class AuthorizationParams {
   external String? get audience;
   external String? get redirect_uri;
 
@@ -36,9 +33,44 @@ class Auth0ClientOptions {
 }
 
 @JS()
+@anonymous
+class GetTokenSilentlyOptions {
+  external AuthorizationParams? get authorizationParams;
+  external String? get cacheMode;
+  external num? get timeoutInSeconds;
+  external bool get detailedResponse;
+
+  external factory GetTokenSilentlyOptions(
+      {final AuthorizationParams authorizationParams,
+      final String cacheMode,
+      final num timeoutInSeconds,
+      final bool detailedResponse});
+}
+
+@JS()
+@anonymous
+class WebCredentials {
+  external String get access_token;
+  external String get id_token;
+  external num expires_in;
+  external String? get refresh_token;
+  external String? get scope;
+
+  external factory WebCredentials(
+      {final String access_token,
+      final String id_token,
+      final num expires_in,
+      final String? refresh_token,
+      final String? scope});
+}
+
+@JS()
 class Auth0Client {
   external Auth0Client(final Auth0ClientOptions options);
   external Future<void> loginWithRedirect([final RedirectLoginOptions options]);
   external Future<void> handleRedirectCallback([final String? url]);
   external Future<void> checkSession();
+  external Future<WebCredentials> getTokenSilently(
+      [final GetTokenSilentlyOptions options]);
+  external Future<bool> isAuthenticated();
 }

--- a/auth0_flutter/lib/src/web/jwt_decode.dart
+++ b/auth0_flutter/lib/src/web/jwt_decode.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'jwt_decode_exception.dart';
+
+class JWT {
+  static Map<String, dynamic> decode(final String jwt) {
+    final parts = jwt.split('.');
+
+    if (parts.length != 3) {
+      throw JWTDecodeException.invalidPartCount(jwt, parts.length);
+    }
+
+    final String stringPayload;
+
+    try {
+      final decodedPayload = base64.decode(base64.normalize(parts[1]));
+      stringPayload = utf8.decode(decodedPayload);
+    } catch (error) {
+      throw JWTDecodeException.invalidBase64URL(parts[1]);
+    }
+
+    try {
+      return jsonDecode(stringPayload) as Map<String, dynamic>;
+    } catch (error) {
+      throw JWTDecodeException.invalidJSON(parts[1]);
+    }
+  }
+}

--- a/auth0_flutter/lib/src/web/jwt_decode_exception.dart
+++ b/auth0_flutter/lib/src/web/jwt_decode_exception.dart
@@ -1,0 +1,26 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+
+class JWTDecodeException extends Auth0Exception {
+  static const _invalidPartCount = 'INVALID_PART_COUNT';
+  static const _invalidBase64URL = 'INVALID_BASE64URL';
+  static const _invalidJSON = 'INVALID_JSON';
+
+  const JWTDecodeException(final String code, final String message)
+      : super(code, message, const {});
+
+  // When either the header or body parts cannot be Base64URL-decoded.
+  const JWTDecodeException.invalidBase64URL(final String value)
+      : this(JWTDecodeException._invalidBase64URL,
+            'Failed to decode Base64URL value $value.');
+
+  // When either the decoded header or body is not a valid JSON object.
+  const JWTDecodeException.invalidJSON(final String value)
+      : this(JWTDecodeException._invalidJSON,
+            'Failed to parse JSON from Base64URL value $value.');
+
+  // When the JWT doesn't have the required amount of parts (header, body, and
+  // signature).
+  const JWTDecodeException.invalidPartCount(final String jwt, final int parts)
+      : this(JWTDecodeException._invalidPartCount,
+            'The JWT $jwt has $parts parts when it should have 3 parts.');
+}

--- a/auth0_flutter/lib/src/web/user_profile_extension.dart
+++ b/auth0_flutter/lib/src/web/user_profile_extension.dart
@@ -1,0 +1,86 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+
+extension UserProfileExtension on UserProfile {
+  static final _registeredClaims = [
+    'aud',
+    'iss',
+    'iat',
+    'exp',
+    'nbf',
+    'nonce',
+    'azp',
+    'auth_time',
+    's_hash',
+    'at_hash',
+    'c_hash'
+  ];
+
+  static final _publicClaims = [
+    'sub',
+    'name',
+    'given_name',
+    'family_name',
+    'middle_name',
+    'nickname',
+    'preferred_username',
+    'profile',
+    'picture',
+    'website',
+    'email',
+    'email_verified',
+    'gender',
+    'birthdate',
+    'zoneinfo',
+    'locale',
+    'phone_number',
+    'phone_number_verified',
+    'address',
+    'updated_at'
+  ];
+
+  static UserProfile fromClaims(final Map<String, dynamic> claims) {
+    final customClaims = {...claims};
+    final claimsToRemove = [
+      ...UserProfileExtension._registeredClaims,
+      ...UserProfileExtension._publicClaims
+    ];
+
+    for (final key in claimsToRemove) {
+      customClaims.remove(key);
+    }
+
+    return UserProfile(
+      sub: claims['sub'] as String,
+      name: claims['name'] as String?,
+      givenName: claims['given_name'] as String?,
+      familyName: claims['family_name'] as String?,
+      middleName: claims['middle_name'] as String?,
+      nickname: claims['nickname'] as String?,
+      preferredUsername: claims['preferred_username'] as String?,
+      profileUrl: claims['profile'] != null
+          ? Uri.parse(claims['profile'] as String)
+          : null,
+      pictureUrl: claims['picture'] != null
+          ? Uri.parse(claims['picture'] as String)
+          : null,
+      websiteUrl: claims['website'] != null
+          ? Uri.parse(claims['website'] as String)
+          : null,
+      email: claims['email'] as String?,
+      isEmailVerified: claims['email_verified'] as bool?,
+      gender: claims['gender'] as String?,
+      birthdate: claims['birthdate'] as String?,
+      zoneinfo: claims['zoneinfo'] as String?,
+      locale: claims['locale'] as String?,
+      phoneNumber: claims['phone_number'] as String?,
+      isPhoneNumberVerified: claims['phone_number_verified'] as bool?,
+      address: claims['address'] != null
+          ? Map<String, String>.from(claims['address'] as Map<dynamic, dynamic>)
+          : null,
+      updatedAt: claims['updated_at'] != null
+          ? DateTime.parse(claims['updated_at'] as String)
+          : null,
+      customClaims: customClaims.isNotEmpty ? customClaims : null,
+    );
+  }
+}

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
@@ -24,6 +24,12 @@ abstract class Auth0FlutterWebPlatform extends PlatformInterface {
     throw UnimplementedError('web.loginWithRedirect has not been implemented');
   }
 
-  // methods, e.g. loginWithRedirect()
-  // here they should throw an UnimplementedError
+  Future<Credentials> credentials() {
+    throw UnimplementedError('web.credentials has not been implemented');
+  }
+
+  Future<bool> hasValidCredentials() {
+    throw UnimplementedError(
+        'web.hasValidCredentials has not been implemented');
+  }
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds support for fetching the credentials, and for checking if there are any valid credentials stored. The following public methods were added:

- `credentials()` -> calls `getTokenSilently()` from the SPA SDK.
- `hasValidCredentials()` -> calls `isAuthenticated()` from the SPA SDK.

### 🎯 Testing

The changes were tested manually. Unit tests will be added in a future PR.

https://user-images.githubusercontent.com/5055789/221452162-4a7a8972-7c2e-4d9f-a109-776c204b4f9d.mov