### PR TITLE
[SDK-4002] Add support for loginWithPopup

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -54,7 +54,7 @@ class _ExampleAppState extends State<ExampleApp> {
         // return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
         final creds = await auth0Web.loginWithPopup();
 
-        output = creds?.idToken ?? '';
+        output = creds.idToken;
       } else {
         final result = await webAuth.login();
         output = result.idToken;

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -51,8 +51,9 @@ class _ExampleAppState extends State<ExampleApp> {
     try {
       if (kIsWeb) {
         // return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
-        final creds = await auth0Web.loginWithPopup();
+        final creds = await auth0Web.loginWithPopup(audience: 'js-quickstart');
         output = creds?.idToken ?? '';
+        print(creds?.accessToken);
       } else {
         final result = await webAuth.login();
         output = result.idToken;

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:html';
 
 import 'package:auth0_flutter/auth0_flutter.dart';
 import 'package:auth0_flutter/auth0_flutter_web.dart';
@@ -51,9 +52,9 @@ class _ExampleAppState extends State<ExampleApp> {
     try {
       if (kIsWeb) {
         // return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
-        final creds = await auth0Web.loginWithPopup(audience: 'js-quickstart');
+        final creds = await auth0Web.loginWithPopup();
+
         output = creds?.idToken ?? '';
-        print(creds?.accessToken);
       } else {
         final result = await webAuth.login();
         output = result.idToken;

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -50,11 +50,13 @@ class _ExampleAppState extends State<ExampleApp> {
     // We also handle the message potentially returning null.
     try {
       if (kIsWeb) {
-        return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
+        // return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
+        final creds = await auth0Web.loginWithPopup();
+        output = creds?.idToken ?? '';
+      } else {
+        final result = await webAuth.login();
+        output = result.idToken;
       }
-
-      final result = await webAuth.login();
-      output = result.idToken;
     } catch (e) {
       output = e.toString();
     }

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -48,14 +48,11 @@ class _ExampleAppState extends State<ExampleApp> {
     // We also handle the message potentially returning null.
     try {
       if (kIsWeb) {
-        // return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
-        final creds = await auth0Web.loginWithPopup();
-
-        output = creds.idToken;
-      } else {
-        final result = await webAuth.login();
-        output = result.idToken;
+        return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
+
+      final result = await webAuth.login();
+      output = result.idToken;
     } catch (e) {
       output = e.toString();
     }

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -1,12 +1,9 @@
 import 'dart:async';
-import 'dart:html';
-
 import 'package:auth0_flutter/auth0_flutter.dart';
 import 'package:auth0_flutter/auth0_flutter_web.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-
 import 'api_card.dart';
 import 'constants.dart';
 import 'web_auth_card.dart';

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -1,4 +1,5 @@
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'package:flutter/widgets.dart';
 import 'src/version.dart';
 
 export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart'
@@ -94,8 +95,18 @@ class Auth0Web {
           scopes: scopes ?? {},
           idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
 
-  Future<Credentials?> loginWithPopup() =>
-      Auth0FlutterWebPlatform.instance.loginWithPopup(null);
+  Future<Credentials?> loginWithPopup(
+          {final String? audience,
+          final String? organizationId,
+          final String? invitationUrl,
+          final int? maxAge,
+          final Set<String>? scopes}) =>
+      Auth0FlutterWebPlatform.instance.loginWithPopup(PopupLoginOptions(
+          audience: audience,
+          organizationId: organizationId,
+          invitationUrl: invitationUrl,
+          scopes: scopes ?? {},
+          idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
 
   /// Redirects the browser to the Auth0 logout endpoint to end the user's
   /// session.

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -94,6 +94,28 @@ class Auth0Web {
           scopes: scopes ?? {},
           idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
 
+  /// Opens a popup with the /authorize URL using the parameters provided as
+  /// arguments.
+  ///
+  /// Random and secure state and nonce parameters will be auto-generated. If
+  /// the response is successful, results will be valid according to
+  /// their expiration times.
+  ///
+  /// **Note**: This method should be called from an event handler that was
+  /// triggered by user interaction, such as a button click. Otherwise the
+  /// popup will be blocked in most browsers.
+  ///
+  /// Additonal notes:
+  ///
+  /// * [audience] relates to the API Identifier you want to reference in your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings)).
+  /// * [scopes] defaults to `openid profile email`. You can
+  /// override these scopes, but `openid` is always requested regardless of
+  /// this setting.
+  /// * If you want to log into a specific organization, provide the
+  /// [organizationId]. Provide [invitationUrl] if a user has been invited
+  /// to join an organization.
+  /// * To provide your own popup window, create it using the `window.open()`
+  /// HTML API and set [popupWindow] to the result.
   Future<Credentials?> loginWithPopup(
           {final String? audience,
           final String? organizationId,

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -94,6 +94,9 @@ class Auth0Web {
           scopes: scopes ?? {},
           idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
 
+  Future<Credentials?> loginWithPopup() =>
+      Auth0FlutterWebPlatform.instance.loginWithPopup(null);
+
   /// Redirects the browser to the Auth0 logout endpoint to end the user's
   /// session.
   ///

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -94,7 +94,7 @@ class Auth0Web {
           scopes: scopes ?? {},
           idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
 
-  /// Opens a popup with the /authorize URL using the parameters provided as
+  /// Opens a popup with the `/authorize` URL using the parameters provided as
   /// arguments.
   ///
   /// Random and secure state and nonce parameters will be auto-generated. If

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -115,8 +115,22 @@ class Auth0Web {
   /// * If you want to log into a specific organization, provide the
   /// [organizationId]. Provide [invitationUrl] if a user has been invited
   /// to join an organization.
-  /// * To provide your own popup window, create it using the `window.open()`
-  /// HTML API and set [popupWindow] to the result.
+  ///
+  ///
+  /// ### Using a custom popup
+  /// To provide your own popup window, create it using the `window.open()`
+  /// HTML API and set [popupWindow] to the result. You may want to do this
+  /// if certain browsers (e.g. Safari) block the popup by default; in this
+  /// scenario, creating your own and passing it to `loginWithPopup` may fix it.
+  ///
+  /// ```dart
+  /// final popup = window.open('', '', 'width=400,height=800');
+  /// final creds = await auth0Web.loginWithPopup(popupWindow: popup);
+  /// ```
+  ///
+  /// **Note:** This requires that `dart:html` be imported into the plugin
+  /// package, which may generate [a warning](https://dart-lang.github.io/linter/lints/avoid_web_libraries_in_flutter.html)
+  /// 'avoid_web_libraries_in_flutter'.
   Future<Credentials> loginWithPopup(
           {final String? audience,
           final String? organizationId,

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -1,5 +1,4 @@
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
-import 'package:flutter/widgets.dart';
 import 'src/version.dart';
 
 export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart'
@@ -100,7 +99,9 @@ class Auth0Web {
           final String? organizationId,
           final String? invitationUrl,
           final int? maxAge,
-          final Set<String>? scopes}) =>
+          final Set<String>? scopes,
+          final dynamic popupWindow,
+          final int? timeoutInSeconds}) =>
       Auth0FlutterWebPlatform.instance.loginWithPopup(PopupLoginOptions(
           audience: audience,
           organizationId: organizationId,

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -116,7 +116,7 @@ class Auth0Web {
   /// to join an organization.
   /// * To provide your own popup window, create it using the `window.open()`
   /// HTML API and set [popupWindow] to the result.
-  Future<Credentials?> loginWithPopup(
+  Future<Credentials> loginWithPopup(
           {final String? audience,
           final String? organizationId,
           final String? invitationUrl,
@@ -129,7 +129,9 @@ class Auth0Web {
           organizationId: organizationId,
           invitationUrl: invitationUrl,
           scopes: scopes ?? {},
-          idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge)));
+          idTokenValidationConfig: IdTokenValidationConfig(maxAge: maxAge),
+          popupWindow: popupWindow,
+          timeoutInSeconds: timeoutInSeconds));
 
   /// Redirects the browser to the Auth0 logout endpoint to end the user's
   /// session.

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -107,7 +107,8 @@ class Auth0Web {
   ///
   /// Additonal notes:
   ///
-  /// * [audience] relates to the API Identifier you want to reference in your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings)).
+  /// * [audience] relates to the API Identifier you want to reference in
+  /// your access tokens (see [API settings](https://auth0.com/docs/get-started/apis/api-settings)).
   /// * [scopes] defaults to `openid profile email`. You can
   /// override these scopes, but `openid` is always requested regardless of
   /// this setting.

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -120,7 +120,7 @@ class Auth0Web {
   /// ### Using a custom popup
   /// To provide your own popup window, create it using the `window.open()`
   /// HTML API and set [popupWindow] to the result. You may want to do this
-  /// if certain browsers (e.g. Safari) block the popup by default; in this
+  /// if certain browsers (like Safari) block the popup by default; in this
   /// scenario, creating your own and passing it to `loginWithPopup` may fix it.
   ///
   /// ```dart

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -58,7 +58,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
-  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) async {
+  Future<Credentials> loginWithPopup(final PopupLoginOptions? options) async {
     final client = _ensureClient();
 
     final authParams = JsInteropUtils.stripNulls(interop.AuthorizationParams(
@@ -78,13 +78,9 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
         interop.PopupLoginOptions(authorizationParams: authParams),
         popupConfig);
 
-    if (await client.isAuthenticated()) {
-      return CredentialsExtension.fromWeb(await client.getTokenSilently(
-          interop.GetTokenSilentlyOptions(
-              authorizationParams: authParams, detailedResponse: true)));
-    }
-
-    return null;
+    return CredentialsExtension.fromWeb(await client.getTokenSilently(
+        interop.GetTokenSilentlyOptions(
+            authorizationParams: authParams, detailedResponse: true)));
   }
 
   @override

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -70,8 +70,13 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
             ? options?.scopes.join(' ')
             : null));
 
+    final popupConfig = JsInteropUtils.stripNulls(interop.PopupConfigOptions(
+        popup: options?.popupWindow,
+        timeoutInSeconds: options?.timeoutInSeconds));
+
     await client.loginWithPopup(
-        interop.PopupLoginOptions(authorizationParams: authParams));
+        interop.PopupLoginOptions(authorizationParams: authParams),
+        popupConfig);
 
     if (await client.isAuthenticated()) {
       return CredentialsExtension.fromWeb(await client.getTokenSilently(

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:html';
-
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-
 import 'auth0_flutter_web_platform_proxy.dart';
 import 'extensions/client_options_extensions.dart';
 import 'extensions/credentials_extension.dart';
@@ -57,6 +55,19 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
         interop.RedirectLoginOptions(authorizationParams: authParams);
 
     return client.loginWithRedirect(loginOptions);
+  }
+
+  @override
+  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) async {
+    final client = _ensureClient();
+
+    await client.loginWithPopup();
+
+    if (await hasValidCredentials()) {
+      return credentials();
+    }
+
+    return null;
   }
 
   @override

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
@@ -21,6 +21,12 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
+  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) {
+    throw UnsupportedError(
+        'loginWithPopup is only supported on the web platform');
+  }
+
+  @override
   Future<Credentials> credentials() {
     throw UnsupportedError('credentials is only supported on the web platform');
   }

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
@@ -21,7 +21,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
-  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) {
+  Future<Credentials> loginWithPopup(final PopupLoginOptions? options) {
     throw UnsupportedError(
         'loginWithPopup is only supported on the web platform');
   }

--- a/auth0_flutter/lib/src/web/auth0_flutter_web_platform_proxy.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_web_platform_proxy.dart
@@ -9,6 +9,11 @@ class Auth0FlutterWebClientProxy {
   Future<void> loginWithRedirect(final RedirectLoginOptions options) =>
       promiseToFuture(client.loginWithRedirect(options));
 
+  Future<void> loginWithPopup(
+          [final PopupLoginOptions? options,
+          final PopupConfigOptions? config]) =>
+      promiseToFuture(client.loginWithPopup(options, config));
+
   Future<void> checkSession() => promiseToFuture(client.checkSession());
 
   Future<WebCredentials> getTokenSilently(

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -3,6 +3,8 @@
 @JS('auth0')
 library auth0;
 
+import 'dart:html';
+
 import 'package:js/js.dart';
 
 @JS()
@@ -156,10 +158,10 @@ class PopupLoginOptions {
 @anonymous
 class PopupConfigOptions {
   external dynamic get popup;
-  external int get timeoutInSeconds;
+  external int? get timeoutInSeconds;
 
   external factory PopupConfigOptions(
-      {final dynamic popup, final int timeoutInSeconds});
+      {final dynamic popup, final int? timeoutInSeconds});
 }
 
 @JS()

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -144,9 +144,30 @@ class LogoutOptions {
 }
 
 @JS()
+@anonymous
+class PopupLoginOptions {
+  external AuthorizationParams? get authorizationParams;
+
+  external factory PopupLoginOptions(
+      {final AuthorizationParams authorizationParams});
+}
+
+@JS()
+@anonymous
+class PopupConfigOptions {
+  external dynamic get popup;
+  external int get timeoutInSeconds;
+
+  external factory PopupConfigOptions(
+      {final dynamic popup, final int timeoutInSeconds});
+}
+
+@JS()
 class Auth0Client {
   external Auth0Client(final Auth0ClientOptions options);
   external Future<void> loginWithRedirect([final RedirectLoginOptions options]);
+  external Future<void> loginWithPopup(
+      [final PopupLoginOptions? options, final PopupConfigOptions? config]);
   external Future<void> handleRedirectCallback([final String? url]);
   external Future<void> checkSession();
   external Future<WebCredentials> getTokenSilently(

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -35,3 +35,4 @@ export 'src/web-auth/web_authentication_exception.dart';
 export 'src/web/cache_location.dart';
 export 'src/web/client_options.dart';
 export 'src/web/logout_options.dart';
+export 'src/web/popup_login_options.dart';

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
@@ -24,6 +24,10 @@ abstract class Auth0FlutterWebPlatform extends PlatformInterface {
     throw UnimplementedError('web.loginWithRedirect has not been implemented');
   }
 
+  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) {
+    throw UnimplementedError('web.loginWithPopup has not been implemented');
+  }
+
   Future<Credentials> credentials() {
     throw UnimplementedError('web.credentials has not been implemented');
   }

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
@@ -24,7 +24,7 @@ abstract class Auth0FlutterWebPlatform extends PlatformInterface {
     throw UnimplementedError('web.loginWithRedirect has not been implemented');
   }
 
-  Future<Credentials?> loginWithPopup(final PopupLoginOptions? options) {
+  Future<Credentials> loginWithPopup(final PopupLoginOptions? options) {
     throw UnimplementedError('web.loginWithPopup has not been implemented');
   }
 

--- a/auth0_flutter_platform_interface/lib/src/web/popup_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/popup_login_options.dart
@@ -1,7 +1,7 @@
 import '../../auth0_flutter_platform_interface.dart';
 
 class PopupLoginOptions extends LoginOptions {
-  final dynamic popup;
+  final dynamic popupWindow;
   final int? timeoutInSeconds;
 
   PopupLoginOptions(
@@ -12,6 +12,6 @@ class PopupLoginOptions extends LoginOptions {
       super.redirectUrl,
       super.scopes,
       super.parameters,
-      this.popup,
+      this.popupWindow,
       this.timeoutInSeconds});
 }

--- a/auth0_flutter_platform_interface/lib/src/web/popup_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/popup_login_options.dart
@@ -1,0 +1,17 @@
+import '../../auth0_flutter_platform_interface.dart';
+
+class PopupLoginOptions extends LoginOptions {
+  final dynamic popup;
+  final int? timeoutInSeconds;
+
+  PopupLoginOptions(
+      {super.audience,
+      super.idTokenValidationConfig,
+      super.organizationId,
+      super.invitationUrl,
+      super.redirectUrl,
+      super.scopes,
+      super.parameters,
+      this.popup,
+      this.timeoutInSeconds});
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This adds support for `loginWithPopup` in the client SDK.

Usage:

```dart
await auth0.loginWithPopup(
        audience: 'http://my.api',
        organizationId: 'org123',
        invitationUrl: 'http://invitation.url',
        scopes: {'openid'},
        maxAge: 20,
        popupWindow: window,
        timeoutInSeconds: 120);
```

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/766403/225373271-5d37717b-210c-4391-af60-43416a8b4ecb.png">
