### PR TITLE
[SDK-4046] WebException wrapper

### DIFF
--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -35,7 +35,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
       try {
         return await clientProxy!.handleRedirectCallback();
       } catch (e) {
-        throw WebExceptionExtentions.fromJsObject(e);
+        throw WebExceptionExtension.fromJsObject(e);
       }
     }
 
@@ -90,7 +90,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
           interop.GetTokenSilentlyOptions(
               authorizationParams: authParams, detailedResponse: true)));
     } catch (e) {
-      throw WebExceptionExtentions.fromJsObject(e);
+      throw WebExceptionExtension.fromJsObject(e);
     }
   }
 
@@ -112,7 +112,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
 
       return CredentialsExtension.fromWeb(result);
     } catch (e) {
-      throw WebExceptionExtentions.fromJsObject(e);
+      throw WebExceptionExtension.fromJsObject(e);
     }
   }
 

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -1,0 +1,10 @@
+import 'dart:js_util';
+
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'dart:js';
+
+extension WebExceptionExtentions on WebException {
+  static WebException fromJsObject(final Object jsException) => WebException(
+      getProperty(jsException, 'error'),
+      getProperty(jsException, 'error_description'));
+}

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -26,7 +26,8 @@ extension WebExceptionExtension on WebException {
       case 'unsupported_response_type':
       case 'unsupported_grant_type':
       case 'temporarily_unavailable':
-        return WebException.authenticationError(error, description);
+        return WebException.authenticationError(
+            error, description, {'state': details['state']});
       case 'mfa_required':
         return WebException.mfaError(
             description, getProperty(jsException, 'mfaToken'));
@@ -36,11 +37,6 @@ extension WebExceptionExtension on WebException {
         return WebException.popupClosed(description);
       case 'missing_refresh_token':
         return WebException.missingRefreshToken(description);
-    }
-
-    // Other rules
-    if (details.containsKey('state')) {
-      return WebException('AUTHENTICATION_ERROR', description, details);
     }
 
     return WebException(error, description, details);

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -4,5 +4,5 @@ import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
 extension WebExceptionExtension on WebException {
   static WebException fromJsObject(final Object jsException) => WebException(
       getProperty(jsException, 'error'),
-      getProperty(jsException, 'error_description'));
+      getProperty(jsException, 'error_description'), const {});
 }

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -1,7 +1,7 @@
 import 'dart:js_util';
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 
-extension WebExceptionExtentions on WebException {
+extension WebExceptionExtension on WebException {
   static WebException fromJsObject(final Object jsException) => WebException(
       getProperty(jsException, 'error'),
       getProperty(jsException, 'error_description'));

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -1,7 +1,5 @@
 import 'dart:js_util';
-
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
-import 'dart:js';
 
 extension WebExceptionExtentions on WebException {
   static WebException fromJsObject(final Object jsException) => WebException(

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -19,7 +19,6 @@ extension WebExceptionExtension on WebException {
             description, getProperty(jsException, 'mfaToken'));
     }
 
-    return WebException(getProperty(jsException, 'error'),
-        getProperty(jsException, 'error_description'), details);
+    return WebException(error, description, details);
   }
 }

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -1,4 +1,3 @@
-import 'dart:js';
 import 'dart:js_util';
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 
@@ -20,6 +19,17 @@ extension WebExceptionExtension on WebException {
 
       case 'timeout':
         return WebException.timeout(description);
+
+      case 'cancelled':
+        return WebException.popupClosed(description);
+
+      case 'missing_refresh_token':
+        return WebException.missingRefreshToken(description);
+    }
+
+    // Other rules
+    if (details.containsKey('state')) {
+      return WebException('AUTHENTICATION_ERROR', description, details);
     }
 
     return WebException(error, description, details);

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -17,6 +17,9 @@ extension WebExceptionExtension on WebException {
       case 'mfa_required':
         return WebException.mfaError(
             description, getProperty(jsException, 'mfaToken'));
+
+      case 'timeout':
+        return WebException.timeout(description);
     }
 
     return WebException(error, description, details);

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -1,8 +1,25 @@
+import 'dart:js';
 import 'dart:js_util';
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 
 extension WebExceptionExtension on WebException {
-  static WebException fromJsObject(final Object jsException) => WebException(
-      getProperty(jsException, 'error'),
-      getProperty(jsException, 'error_description'), const {});
+  static WebException fromJsObject(final Object jsException) {
+    final error = getProperty<String>(jsException, 'error');
+    final description = getProperty<String>(jsException, 'error_description');
+    final Map<String, dynamic> details = {};
+
+    objectKeys(jsException).forEach((final key) {
+      if (key == 'error' || key == 'error_description') return;
+      details[key as String] = getProperty<dynamic>(jsException, key);
+    });
+
+    switch (error) {
+      case 'mfa_required':
+        return WebException.mfaError(
+            description, getProperty(jsException, 'mfaToken'));
+    }
+
+    return WebException(getProperty(jsException, 'error'),
+        getProperty(jsException, 'error_description'), details);
+  }
 }

--- a/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/web_exception_extensions.dart
@@ -13,16 +13,27 @@ extension WebExceptionExtension on WebException {
     });
 
     switch (error) {
+      case 'invalid_request':
+      case 'invalid_scope':
+      case 'invalid_client':
+      case 'requires_validation':
+      case 'unauthorized_client':
+      case 'access_denied':
+      case 'invalid_grant':
+      case 'endpoint_disabled':
+      case 'method_not_allowed':
+      case 'too_many_requests':
+      case 'unsupported_response_type':
+      case 'unsupported_grant_type':
+      case 'temporarily_unavailable':
+        return WebException.authenticationError(error, description);
       case 'mfa_required':
         return WebException.mfaError(
             description, getProperty(jsException, 'mfaToken'));
-
       case 'timeout':
         return WebException.timeout(description);
-
       case 'cancelled':
         return WebException.popupClosed(description);
-
       case 'missing_refresh_token':
         return WebException.missingRefreshToken(description);
     }

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -96,8 +96,8 @@ void main() {
         () async => auth0.onLoad(),
         throwsA(predicate((final e) =>
             e is WebException &&
-            e.error == 'test' &&
-            e.errorDescription == 'test exception')));
+            e.code == 'test' &&
+            e.message == 'test exception')));
   });
 
   test('loginWithRedirect with all options', () async {
@@ -200,8 +200,8 @@ void main() {
         () async => auth0.credentials(),
         throwsA(predicate((final e) =>
             e is WebException &&
-            e.error == 'test' &&
-            e.errorDescription == 'test exception')));
+            e.code == 'test' &&
+            e.message == 'test exception')));
   });
 
   test('logout is called and succeeds', () async {
@@ -281,8 +281,8 @@ void main() {
         () async => auth0.loginWithPopup(),
         throwsA(predicate((final e) =>
             e is WebException &&
-            e.error == 'test' &&
-            e.errorDescription == 'test exception')));
+            e.code == 'test' &&
+            e.message == 'test exception')));
   });
 
   test('loginWithPopup throws the correct exception from getTokenSilently',
@@ -297,7 +297,7 @@ void main() {
         () async => auth0.loginWithPopup(),
         throwsA(predicate((final e) =>
             e is WebException &&
-            e.error == 'test' &&
-            e.errorDescription == 'test exception')));
+            e.code == 'test' &&
+            e.message == 'test exception')));
   });
 }

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -215,12 +215,6 @@ void main() {
     expect(params.returnTo, 'http://returnto.url');
   });
 
-  test('logout is called and throws', () async {
-    when(mockClientProxy.logout(any)).thenThrow(Exception());
-
-    expect(() async => auth0.logout(), throwsException);
-  });
-
   test('loginWithPopup is called and succeeds', () async {
     when(mockClientProxy.loginWithPopup(any, any))
         .thenAnswer((final _) => Future.value());

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -1,11 +1,15 @@
 @Tags(['browser'])
 
+import 'dart:js';
+import 'dart:js_util';
+
 import 'package:auth0_flutter/auth0_flutter_web.dart';
 import 'package:auth0_flutter/src/web/auth0_flutter_plugin_real.dart';
 import 'package:auth0_flutter/src/web/auth0_flutter_web_platform_proxy.dart';
 import 'package:auth0_flutter/src/web/js_interop.dart' as interop;
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -32,6 +36,13 @@ void main() {
     Auth0FlutterWebPlatform.instance = plugin;
     reset(mockClientProxy);
   });
+
+  Object createJsException(String error, String description) {
+    final jsObject = newObject<JsObject>();
+    setProperty(jsObject, 'error', error);
+    setProperty(jsObject, 'error_description', description);
+    return jsObject;
+  }
 
   test('onLoad is called without authenticated user and no callback', () async {
     when(mockClientProxy.isAuthenticated())
@@ -69,6 +80,24 @@ void main() {
     await auth0.onLoad();
     verify(mockClientProxy.handleRedirectCallback());
     verifyNever(mockClientProxy.checkSession());
+  });
+
+  test('onLoad throws the correct exception from handleRedirectCallback',
+      () async {
+    when(mockClientProxy.isAuthenticated())
+        .thenAnswer((final _) => Future.value(false));
+
+    when(mockClientProxy.handleRedirectCallback())
+        .thenThrow(createJsException('test', 'test exception'));
+
+    plugin.urlSearchProvider = () => '?code=abc&state=123';
+
+    expect(
+        () async => auth0.onLoad(),
+        throwsA(predicate((final e) =>
+            e is WebException &&
+            e.error == 'test' &&
+            e.errorDescription == 'test exception')));
   });
 
   test('loginWithRedirect with all options', () async {
@@ -164,9 +193,15 @@ void main() {
   });
 
   test('credentials is called and throws', () async {
-    when(mockClientProxy.getTokenSilently(any)).thenThrow(Exception());
+    when(mockClientProxy.getTokenSilently(any))
+        .thenThrow(createJsException('test', 'test exception'));
 
-    expect(() async => auth0.credentials(), throwsException);
+    expect(
+        () async => auth0.credentials(),
+        throwsA(predicate((final e) =>
+            e is WebException &&
+            e.error == 'test' &&
+            e.errorDescription == 'test exception')));
   });
 
   test('logout is called and succeeds', () async {
@@ -189,9 +224,6 @@ void main() {
   test('loginWithPopup is called and succeeds', () async {
     when(mockClientProxy.loginWithPopup(any, any))
         .thenAnswer((final _) => Future.value());
-
-    when(mockClientProxy.isAuthenticated())
-        .thenAnswer((final _) => Future.value(true));
 
     when(mockClientProxy.getTokenSilently(any))
         .thenAnswer((final _) => Future.value(webCredentials));
@@ -232,13 +264,8 @@ void main() {
     when(mockClientProxy.loginWithPopup(any, any))
         .thenAnswer((final _) => Future.value());
 
-    when(mockClientProxy.isAuthenticated())
-        .thenAnswer((final _) => Future.value(true));
-
     when(mockClientProxy.getTokenSilently(any))
         .thenAnswer((final _) => Future.value(webCredentials));
-
-    final window = Object();
 
     final credentials =
         await auth0.loginWithPopup(parameters: {'screen_hint': 'signup'});
@@ -249,5 +276,34 @@ void main() {
         verify(mockClientProxy.loginWithPopup(captureAny, captureAny)).captured;
 
     expect(capture.first.authorizationParams.screen_hint, 'signup');
+  });
+
+  test('loginWithPopup throws the correct exception from js.loginWithPopup',
+      () async {
+    when(mockClientProxy.loginWithPopup(any, any))
+        .thenThrow(createJsException('test', 'test exception'));
+
+    expect(
+        () async => auth0.loginWithPopup(),
+        throwsA(predicate((final e) =>
+            e is WebException &&
+            e.error == 'test' &&
+            e.errorDescription == 'test exception')));
+  });
+
+  test('loginWithPopup throws the correct exception from getTokenSilently',
+      () async {
+    when(mockClientProxy.loginWithPopup(any, any))
+        .thenAnswer((final _) => Future.value());
+
+    when(mockClientProxy.getTokenSilently(any))
+        .thenThrow(createJsException('test', 'test exception'));
+
+    expect(
+        () async => auth0.loginWithPopup(),
+        throwsA(predicate((final e) =>
+            e is WebException &&
+            e.error == 'test' &&
+            e.errorDescription == 'test exception')));
   });
 }

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Object createJsException(final String error, final String description,
-      {final Map<String, dynamic>? details}) {
+      {final Map<String, dynamic>? additionalProps}) {
     final jsObject = newObject<JsObject>();
     setProperty(jsObject, 'error', error);
     setProperty(jsObject, 'error_description', description);
 
-    if (details != null) {
-      for (final element in details.entries) {
+    if (additionalProps != null) {
+      for (final element in additionalProps.entries) {
         setProperty(jsObject, element.key, element.value);
       }
     }
@@ -21,9 +21,22 @@ void main() {
     return jsObject;
   }
 
+  test('additional props are added to the details collection', () {
+    final exception = createJsException(
+        'authentication_error', 'A test authentication error',
+        additionalProps: {'prop-1': 'Property 1', 'prop-2': 'Property 2'});
+
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'authentication_error');
+    expect(webException.message, 'A test authentication error');
+    expect(webException.details['prop-1'], 'Property 1');
+    expect(webException.details['prop-2'], 'Property 2');
+  });
+
   test('mfa_required exception is created', () {
     final exception = createJsException('mfa_required', 'MFA is required',
-        details: {'mfaToken': 'abc123'});
+        additionalProps: {'mfaToken': 'abc123'});
 
     final webException = WebExceptionExtension.fromJsObject(exception);
 

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -44,4 +44,13 @@ void main() {
     expect(webException.message, 'MFA is required');
     expect(webException.details['mfaToken'], 'abc123');
   });
+
+  test('timeout error is created', () {
+    final exception = createJsException('timeout', 'Timeout');
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'timeout');
+    expect(webException.message, 'Timeout');
+    expect(webException.details, <String, dynamic>{});
+  });
 }

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -99,4 +99,17 @@ void main() {
       expect(webException.details['code'], code);
     });
   }
+
+  test('AUTHENTICATION_ERROR is captured with state only', () {
+    final exception = createJsException('invalid_grant', 'Invalid grant',
+        additionalProps: {'state': '123', 'appState': '456'});
+
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'AUTHENTICATION_ERROR');
+    expect(webException.message, 'Invalid grant');
+    expect(webException.details['code'], 'invalid_grant');
+    expect(webException.details['state'], '123');
+    expect(webException.details['appState'], isNull);
+  });
 }

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -1,0 +1,34 @@
+@Tags(['browser'])
+
+import 'dart:js';
+import 'dart:js_util';
+import 'package:auth0_flutter/src/web/extensions/web_exception_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Object createJsException(final String error, final String description,
+      {final Map<String, dynamic>? details}) {
+    final jsObject = newObject<JsObject>();
+    setProperty(jsObject, 'error', error);
+    setProperty(jsObject, 'error_description', description);
+
+    if (details != null) {
+      for (final element in details.entries) {
+        setProperty(jsObject, element.key, element.value);
+      }
+    }
+
+    return jsObject;
+  }
+
+  test('mfa_required exception is created', () {
+    final exception = createJsException('mfa_required', 'MFA is required',
+        details: {'mfaToken': 'abc123'});
+
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'MFA_REQUIRED');
+    expect(webException.message, 'MFA is required');
+    expect(webException.details['mfaToken'], 'abc123');
+  });
+}

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -49,8 +49,27 @@ void main() {
     final exception = createJsException('timeout', 'Timeout');
     final webException = WebExceptionExtension.fromJsObject(exception);
 
-    expect(webException.code, 'timeout');
+    expect(webException.code, 'TIMEOUT');
     expect(webException.message, 'Timeout');
+    expect(webException.details, <String, dynamic>{});
+  });
+
+  test('missing_refresh_token is created', () {
+    final exception =
+        createJsException('missing_refresh_token', 'Missing refresh token');
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'MISSING_REFRESH_TOKEN');
+    expect(webException.message, 'Missing refresh token');
+    expect(webException.details, <String, dynamic>{});
+  });
+
+  test('popup cancelled is created', () {
+    final exception = createJsException('cancelled', 'Popup was closed');
+    final webException = WebExceptionExtension.fromJsObject(exception);
+
+    expect(webException.code, 'POPUP_CLOSED');
+    expect(webException.message, 'Popup was closed');
     expect(webException.details, <String, dynamic>{});
   });
 }

--- a/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/web_exception_extension_test.dart
@@ -72,4 +72,31 @@ void main() {
     expect(webException.message, 'Popup was closed');
     expect(webException.details, <String, dynamic>{});
   });
+
+  final codes = [
+    'invalid_request',
+    'invalid_scope',
+    'invalid_client',
+    'requires_validation',
+    'unauthorized_client',
+    'access_denied',
+    'invalid_grant',
+    'endpoint_disabled',
+    'method_not_allowed',
+    'too_many_requests',
+    'unsupported_response_type',
+    'unsupported_grant_type',
+    'temporarily_unavailable'
+  ];
+
+  for (final code in codes) {
+    test('$code is captured as AUTHENTICATION_ERROR', () {
+      final exception = createJsException(code, '$code was raised');
+      final webException = WebExceptionExtension.fromJsObject(exception);
+
+      expect(webException.code, 'AUTHENTICATION_ERROR');
+      expect(webException.message, '$code was raised');
+      expect(webException.details['code'], code);
+    });
+  }
 }

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -36,3 +36,4 @@ export 'src/web/cache_location.dart';
 export 'src/web/client_options.dart';
 export 'src/web/logout_options.dart';
 export 'src/web/popup_login_options.dart';
+export 'src/web/web_exception.dart';

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -4,6 +4,7 @@ import '../../auth0_flutter_platform_interface.dart';
 /// goes wrong.
 class WebException extends Auth0Exception {
   static const String _mfaRequired = 'MFA_REQUIRED';
+  static const String _timeout = 'TIMEOUT';
 
   const WebException(final String error, final String errorDescription,
       final Map<String, dynamic> details)
@@ -11,4 +12,7 @@ class WebException extends Auth0Exception {
 
   WebException.mfaError(final String message, final String mfaToken)
       : this(WebException._mfaRequired, message, {'mfaToken': mfaToken});
+
+  WebException.timeout(final String message)
+      : this(WebException._timeout, message, const {});
 }

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -1,9 +1,7 @@
-class WebException implements Exception {
-  final String error;
-  final String errorDescription;
+import '../../auth0_flutter_platform_interface.dart';
 
-  const WebException(this.error, this.errorDescription);
-
-  @override
-  String toString() => '$error: $errorDescription';
+class WebException extends Auth0Exception {
+  const WebException(final String error, final String errorDescription,
+      final Map<String, dynamic> details)
+      : super(error, errorDescription, details);
 }

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -5,6 +5,8 @@ import '../../auth0_flutter_platform_interface.dart';
 class WebException extends Auth0Exception {
   static const String _mfaRequired = 'MFA_REQUIRED';
   static const String _timeout = 'TIMEOUT';
+  static const String _missingRefreshToken = 'MISSING_REFRESH_TOKEN';
+  static const String _popupClosed = 'POPUP_CLOSED';
 
   const WebException(final String error, final String errorDescription,
       final Map<String, dynamic> details)
@@ -15,4 +17,10 @@ class WebException extends Auth0Exception {
 
   WebException.timeout(final String message)
       : this(WebException._timeout, message, const {});
+
+  WebException.missingRefreshToken(final String message)
+      : this(WebException._missingRefreshToken, message, const {});
+
+  WebException.popupClosed(final String message)
+      : this(WebException._popupClosed, message, const {});
 }

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -7,10 +7,14 @@ class WebException extends Auth0Exception {
   static const String _timeout = 'TIMEOUT';
   static const String _missingRefreshToken = 'MISSING_REFRESH_TOKEN';
   static const String _popupClosed = 'POPUP_CLOSED';
+  static const String _authenticationError = 'AUTHENTICATION_ERROR';
 
   const WebException(final String error, final String errorDescription,
       final Map<String, dynamic> details)
       : super(error, errorDescription, details);
+
+  WebException.authenticationError(final String error, final String message)
+      : this(WebException._authenticationError, message, {'code': error});
 
   WebException.mfaError(final String message, final String mfaToken)
       : this(WebException._mfaRequired, message, {'mfaToken': mfaToken});

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -1,0 +1,9 @@
+class WebException implements Exception {
+  final String error;
+  final String errorDescription;
+
+  const WebException(this.error, this.errorDescription);
+
+  @override
+  String toString() => '$error: $errorDescription';
+}

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -13,8 +13,10 @@ class WebException extends Auth0Exception {
       final Map<String, dynamic> details)
       : super(error, errorDescription, details);
 
-  WebException.authenticationError(final String error, final String message)
-      : this(WebException._authenticationError, message, {'code': error});
+  WebException.authenticationError(final String error, final String message,
+      [final Map<String, dynamic>? details])
+      : this(WebException._authenticationError, message,
+            {'code': error, ...details ?? {}});
 
   WebException.mfaError(final String message, final String mfaToken)
       : this(WebException._mfaRequired, message, {'mfaToken': mfaToken});

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -1,5 +1,7 @@
 import '../../auth0_flutter_platform_interface.dart';
 
+/// Exception thrown by [Auth0FlutterWebPlatform] when something
+/// goes wrong.
 class WebException extends Auth0Exception {
   const WebException(final String error, final String errorDescription,
       final Map<String, dynamic> details)

--- a/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/web_exception.dart
@@ -3,7 +3,12 @@ import '../../auth0_flutter_platform_interface.dart';
 /// Exception thrown by [Auth0FlutterWebPlatform] when something
 /// goes wrong.
 class WebException extends Auth0Exception {
+  static const String _mfaRequired = 'MFA_REQUIRED';
+
   const WebException(final String error, final String errorDescription,
       final Map<String, dynamic> details)
       : super(error, errorDescription, details);
+
+  WebException.mfaError(final String message, final String mfaToken)
+      : this(WebException._mfaRequired, message, {'mfaToken': mfaToken});
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR wraps incoming exceptions from the underlying SPA client to a `WebException` type that surfaces the `error` and `error_description` properties.
