### PR TITLE
[SDK-4110] Support options to `getTokenSilently`

### DIFF
--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -170,8 +170,20 @@ class Auth0Web {
       Auth0FlutterWebPlatform.instance
           .logout(LogoutOptions(federated: federated, returnTo: returnToUrl));
 
-  Future<Credentials> credentials() =>
-      Auth0FlutterWebPlatform.instance.credentials();
+  Future<Credentials> credentials(
+          {final String? redirectUrl,
+          final String? audience,
+          final num? timeoutInSeconds,
+          final Set<String>? scopes,
+          final CacheMode? cacheMode,
+          final Map<String, String> parameters = const {}}) =>
+      Auth0FlutterWebPlatform.instance.credentials(CredentialsOptions(
+          redirectUrl: redirectUrl,
+          audience: audience,
+          timeoutInSeconds: timeoutInSeconds,
+          scopes: scopes,
+          cacheMode: cacheMode,
+          parameters: parameters));
 
   Future<bool> hasValidCredentials() =>
       Auth0FlutterWebPlatform.instance.hasValidCredentials();

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -170,21 +170,43 @@ class Auth0Web {
       Auth0FlutterWebPlatform.instance
           .logout(LogoutOptions(federated: federated, returnTo: returnToUrl));
 
+  /// Retrieves a set of credentials for the user.
+  ///
+  /// By default, the credentials will be returned from an internal cache. If
+  /// the access token within 60 seconds of its expiry time, a new access token
+  /// will be retrieved from Auth0. Either an iframe will be used to fetch
+  /// this token, or a refresh token, depending on the `useRefreshTokens`
+  /// SDK configuration setting.
+  ///
+  /// **Note:** using an iframe to request tokens relies on third-party cookie
+  /// support in your browser if you are not using a [custom domains]().
+  ///
+  /// Additional notes:
+  /// * [audience] and [scopes] can be used to request an access token for a
+  /// different API than what was originally requested at login. This has
+  /// no effect when using refresh tokens.
+  /// * [cacheMode] allows you to control whether the cache is used to return
+  /// tokens or not. Please see [CacheMode] for more details.
+  /// * [timeoutInSeconds] is used to control the timeout specifically for
+  /// when an iframe is used to request new tokens, and has no effect when
+  /// using refresh tokens.
+  /// * Arbitrary [parameters] can be specified and then picked up in a custom
+  /// Auth0 [Action](https://auth0.com/docs/customize/actions) or
+  /// [Rule](https://auth0.com/docs/customize/rules).
   Future<Credentials> credentials(
-          {final String? redirectUrl,
-          final String? audience,
+          {final String? audience,
           final num? timeoutInSeconds,
           final Set<String>? scopes,
           final CacheMode? cacheMode,
           final Map<String, String> parameters = const {}}) =>
       Auth0FlutterWebPlatform.instance.credentials(CredentialsOptions(
-          redirectUrl: redirectUrl,
           audience: audience,
           timeoutInSeconds: timeoutInSeconds,
           scopes: scopes,
           cacheMode: cacheMode,
           parameters: parameters));
 
+  /// Indicates whether a user is currently authenticated.
   Future<bool> hasValidCredentials() =>
       Auth0FlutterWebPlatform.instance.hasValidCredentials();
 }

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -6,6 +6,7 @@ import 'auth0_flutter_web_platform_proxy.dart';
 import 'extensions/client_options_extensions.dart';
 import 'extensions/credentials_extension.dart';
 import 'extensions/logout_options.extension.dart';
+import 'extensions/credentials_options_extension.dart';
 import 'js_interop.dart' as interop;
 import 'js_interop_utils.dart';
 
@@ -82,7 +83,8 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
 
     return CredentialsExtension.fromWeb(await client.getTokenSilently(
         interop.GetTokenSilentlyOptions(
-            authorizationParams: authParams, detailedResponse: true)));
+            authorizationParams: authParams.toGetTokenSilentlyParams(),
+            detailedResponse: true)));
   }
 
   @override
@@ -94,11 +96,16 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
-  Future<Credentials> credentials() async {
+  Future<Credentials> credentials(final CredentialsOptions? options) async {
     final clientProxy = _ensureClient();
-    final options = interop.GetTokenSilentlyOptions(detailedResponse: true);
+    final tokenOptions = options?.toGetTokenSilentlyOptions() ??
+        interop.GetTokenSilentlyOptions();
 
-    final result = await clientProxy.getTokenSilently(options);
+    // Force this, as we always want the full detail back so that we can
+    // return a full Credentials instance.
+    tokenOptions.detailedResponse = true;
+
+    final result = await clientProxy.getTokenSilently(tokenOptions);
 
     return CredentialsExtension.fromWeb(result);
   }

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_stub.dart
@@ -27,7 +27,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   }
 
   @override
-  Future<Credentials> credentials() {
+  Future<Credentials> credentials(final CredentialsOptions? options) {
     throw UnsupportedError('credentials is only supported on the web platform');
   }
 

--- a/auth0_flutter/lib/src/web/extensions/credentials_options_extension.dart
+++ b/auth0_flutter/lib/src/web/extensions/credentials_options_extension.dart
@@ -9,9 +9,7 @@ extension CredentialsOptionsExtension on CredentialsOptions {
           authorizationParams: JsInteropUtils.stripNulls(
               JsInteropUtils.addCustomParams(
                   GetTokenSilentlyAuthParams(
-                      redirect_uri: redirectUrl,
-                      scope: scopes?.join(' '),
-                      audience: audience),
+                      scope: scopes?.join(' '), audience: audience),
                   parameters)),
           cacheMode: cacheMode.toString(),
           timeoutInSeconds: timeoutInSeconds,

--- a/auth0_flutter/lib/src/web/extensions/credentials_options_extension.dart
+++ b/auth0_flutter/lib/src/web/extensions/credentials_options_extension.dart
@@ -1,0 +1,19 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+
+import '../js_interop.dart';
+import '../js_interop_utils.dart';
+
+extension CredentialsOptionsExtension on CredentialsOptions {
+  GetTokenSilentlyOptions toGetTokenSilentlyOptions() =>
+      GetTokenSilentlyOptions(
+          authorizationParams: JsInteropUtils.stripNulls(
+              JsInteropUtils.addCustomParams(
+                  GetTokenSilentlyAuthParams(
+                      redirect_uri: redirectUrl,
+                      scope: scopes?.join(' '),
+                      audience: audience),
+                  parameters)),
+          cacheMode: cacheMode.toString(),
+          timeoutInSeconds: timeoutInSeconds,
+          detailedResponse: detailedResponse);
+}

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -98,14 +98,11 @@ class Auth0ClientOptions {
 @JS()
 @anonymous
 class GetTokenSilentlyAuthParams {
-  external String? redirect_uri;
   external String? scope;
   external String? audience;
 
   external factory GetTokenSilentlyAuthParams(
-      {final String? redirect_uri,
-      final String? audience,
-      final String? scope});
+      {final String? audience, final String? scope});
 }
 
 @JS()

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -97,17 +97,30 @@ class Auth0ClientOptions {
 
 @JS()
 @anonymous
+class GetTokenSilentlyAuthParams {
+  external String? redirect_uri;
+  external String? scope;
+  external String? audience;
+
+  external factory GetTokenSilentlyAuthParams(
+      {final String? redirect_uri,
+      final String? audience,
+      final String? scope});
+}
+
+@JS()
+@anonymous
 class GetTokenSilentlyOptions {
-  external AuthorizationParams? get authorizationParams;
+  external GetTokenSilentlyAuthParams? get authorizationParams;
   external String? get cacheMode;
   external num? get timeoutInSeconds;
-  external bool get detailedResponse;
+  external bool detailedResponse;
 
   external factory GetTokenSilentlyOptions(
-      {final AuthorizationParams authorizationParams,
-      final String cacheMode,
-      final num timeoutInSeconds,
-      final bool detailedResponse});
+      {final GetTokenSilentlyAuthParams? authorizationParams,
+      final String? cacheMode,
+      final num? timeoutInSeconds,
+      final bool? detailedResponse});
 }
 
 @JS()

--- a/auth0_flutter/lib/src/web/js_interop_utils.dart
+++ b/auth0_flutter/lib/src/web/js_interop_utils.dart
@@ -41,4 +41,10 @@ extension AuthParamsExtension on AuthorizationParams {
   AuthorizationParams prepare([final Map<String, dynamic>? params]) =>
       JsInteropUtils.stripNulls(
           JsInteropUtils.addCustomParams(this, params ?? {}));
+
+  // Converts an instance of AuthorizationParams to
+  // GetTokenSilentlyAuthorizationParams.
+  GetTokenSilentlyAuthParams toGetTokenSilentlyParams() =>
+      JsInteropUtils.stripNulls(GetTokenSilentlyAuthParams(
+          redirect_uri: redirect_uri, scope: scope, audience: audience));
 }

--- a/auth0_flutter/lib/src/web/js_interop_utils.dart
+++ b/auth0_flutter/lib/src/web/js_interop_utils.dart
@@ -45,6 +45,6 @@ extension AuthParamsExtension on AuthorizationParams {
   // Converts an instance of AuthorizationParams to
   // GetTokenSilentlyAuthorizationParams.
   GetTokenSilentlyAuthParams toGetTokenSilentlyParams() =>
-      JsInteropUtils.stripNulls(GetTokenSilentlyAuthParams(
-          redirect_uri: redirect_uri, scope: scope, audience: audience));
+      JsInteropUtils.stripNulls(
+          GetTokenSilentlyAuthParams(scope: scope, audience: audience));
 }

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -168,7 +168,6 @@ void main() {
         .thenAnswer((final _) => Future.value(webCredentials));
 
     await auth0.credentials(
-        redirectUrl: 'http://redirect.url',
         scopes: {'openid', 'profile'},
         audience: 'http://my.api',
         cacheMode: CacheMode.cacheOnly,
@@ -178,7 +177,6 @@ void main() {
     final options =
         verify(mockClientProxy.getTokenSilently(captureAny)).captured.first;
 
-    expect(options.authorizationParams.redirect_uri, 'http://redirect.url');
     expect(options.authorizationParams.scope, 'openid profile');
     expect(options.authorizationParams.audience, 'http://my.api');
     expect(options.authorizationParams.prompt, 'none');

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -163,6 +163,30 @@ void main() {
     expect(result.scopes, {'openid', 'read_messages'});
   });
 
+  test('credentials is called with options and succeeds', () async {
+    when(mockClientProxy.getTokenSilently(any))
+        .thenAnswer((final _) => Future.value(webCredentials));
+
+    await auth0.credentials(
+        redirectUrl: 'http://redirect.url',
+        scopes: {'openid', 'profile'},
+        audience: 'http://my.api',
+        cacheMode: CacheMode.cacheOnly,
+        parameters: {'prompt': 'none'},
+        timeoutInSeconds: 120);
+
+    final options =
+        verify(mockClientProxy.getTokenSilently(captureAny)).captured.first;
+
+    expect(options.authorizationParams.redirect_uri, 'http://redirect.url');
+    expect(options.authorizationParams.scope, 'openid profile');
+    expect(options.authorizationParams.audience, 'http://my.api');
+    expect(options.authorizationParams.prompt, 'none');
+    expect(options.cacheMode, 'cache-only');
+    expect(options.timeoutInSeconds, 120);
+    expect(options.detailedResponse, true);
+  });
+
   test('credentials is called and throws', () async {
     when(mockClientProxy.getTokenSilently(any)).thenThrow(Exception());
 

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -33,6 +33,8 @@ export 'src/web-auth/web_auth_login_options.dart';
 export 'src/web-auth/web_auth_logout_options.dart';
 export 'src/web-auth/web_authentication_exception.dart';
 export 'src/web/cache_location.dart';
+export 'src/web/cache_mode.dart';
 export 'src/web/client_options.dart';
+export 'src/web/credentials_options.dart';
 export 'src/web/logout_options.dart';
 export 'src/web/popup_login_options.dart';

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_platform.dart
@@ -28,7 +28,7 @@ abstract class Auth0FlutterWebPlatform extends PlatformInterface {
     throw UnimplementedError('web.loginWithPopup has not been implemented');
   }
 
-  Future<Credentials> credentials() {
+  Future<Credentials> credentials(final CredentialsOptions? options) {
     throw UnimplementedError('web.credentials has not been implemented');
   }
 

--- a/auth0_flutter_platform_interface/lib/src/web/cache_mode.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/cache_mode.dart
@@ -1,0 +1,17 @@
+enum CacheMode {
+  on,
+  off,
+  cacheOnly;
+
+  @override
+  String toString() {
+    switch (this) {
+      case CacheMode.on:
+        return 'on';
+      case CacheMode.off:
+        return 'off';
+      case CacheMode.cacheOnly:
+        return 'cache-only';
+    }
+  }
+}

--- a/auth0_flutter_platform_interface/lib/src/web/cache_mode.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/cache_mode.dart
@@ -1,6 +1,14 @@
+/// How the cache is to be used when requesting new tokens silently.
 enum CacheMode {
+  /// The default setting. Reads from the cache first, and falls back to a
+  /// request to the server if the cache does not exist, or has expired.
   on,
+
+  /// The cache is ignored and always makes a request to the server for new
+  /// tokens.
   off,
+
+  /// The cache is always used and never sends a request to the server.
   cacheOnly;
 
   @override

--- a/auth0_flutter_platform_interface/lib/src/web/credentials_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/credentials_options.dart
@@ -1,7 +1,6 @@
 import '../../auth0_flutter_platform_interface.dart';
 
 class CredentialsOptions {
-  final String? redirectUrl;
   final String? audience;
   final Set<String>? scopes;
   final num? timeoutInSeconds;
@@ -10,8 +9,7 @@ class CredentialsOptions {
   final Map<String, String> parameters;
 
   CredentialsOptions(
-      {this.redirectUrl,
-      this.audience,
+      {this.audience,
       this.scopes,
       this.timeoutInSeconds,
       this.cacheMode,

--- a/auth0_flutter_platform_interface/lib/src/web/credentials_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/credentials_options.dart
@@ -1,0 +1,20 @@
+import '../../auth0_flutter_platform_interface.dart';
+
+class CredentialsOptions {
+  final String? redirectUrl;
+  final String? audience;
+  final Set<String>? scopes;
+  final num? timeoutInSeconds;
+  final CacheMode? cacheMode;
+  final bool? detailedResponse;
+  final Map<String, String> parameters;
+
+  CredentialsOptions(
+      {this.redirectUrl,
+      this.audience,
+      this.scopes,
+      this.timeoutInSeconds,
+      this.cacheMode,
+      this.detailedResponse,
+      this.parameters = const {}});
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR adds support for the options to `getTokenSilently` in the underlying SDK, with the exception of `redirect_uri` (Ionic has a specific use case/need for this that doesn't apply here).

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Covered with unit tests, also tested manually.
