### PR TITLE
Add note to `Credentials.refreshToken` [SDK-4116]

### DIFF
--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -30,7 +30,6 @@ class Auth0Web {
   /// * You can specify custom [leeway] and [issuer] values to be used for the
   /// validation of the ID token. See the [IdTokenValidationConfig] type to
   /// learn more about these parameters.
-  ///
   /// * See the [ClientOptions] type for the full description of the remaining
   /// parameters for this method.
   Future<Credentials?> onLoad(

--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -25,7 +25,11 @@ class Credentials {
   /// Token that can be used to request a new access token.
   ///
   /// The scope `offline_access` must have been requested on login for a refresh
-  ///  token to be returned.
+  /// token to be returned.
+  ///
+  /// **Note:** this property will always be `null` on the web platform. The
+  /// underlying SDK used does not expose the refresh token for security
+  /// reasons.
   ///
   /// [Read more about refresh tokens](https://auth0.com/docs/secure/tokens/refresh-tokens).
   final String? refreshToken;

--- a/auth0_flutter_platform_interface/lib/src/web/cache_location.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/cache_location.dart
@@ -1,4 +1,4 @@
-/// The location where cached data is stored by the underlying client
+/// The location where cached data is stored by the underlying SDK
 /// on the web platform.
 enum CacheLocation {
   /// Data is persisted in memory. The cache is lost on page reload.

--- a/auth0_flutter_platform_interface/lib/src/web/client_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/client_options.dart
@@ -1,6 +1,6 @@
 import '../../auth0_flutter_platform_interface.dart';
 
-/// The options for the underlying client on the web platform.
+/// The options for the underlying SDK on the web platform.
 class ClientOptions {
   /// The account to use, including the `domain` and `clientId` values.
   final Account account;


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The `Credentials.refreshToken` property will always be `null` on the web platform because the refresh token is handled internally by the SPA SDK, and it's never exposed. This PR adds a note to the API documentation of `Credentials.refreshToken` about this.