### PR TITLE
Unexport `LogoutOptions`

### DIFF
--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -2,7 +2,7 @@ import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
 import 'src/version.dart';
 
 export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart'
-    show CacheLocation, LogoutOptions;
+    show CacheLocation;
 
 /// Primary interface for interacting with Auth0 on web platforms.
 class Auth0Web {

--- a/auth0_flutter/lib/src/web/extensions/logout_options.extension.dart
+++ b/auth0_flutter/lib/src/web/extensions/logout_options.extension.dart
@@ -1,4 +1,5 @@
-import '../../../auth0_flutter_web.dart';
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+
 import '../js_interop.dart' as interop;
 import '../js_interop_utils.dart';
 

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -3,8 +3,6 @@
 @JS('auth0')
 library auth0;
 
-import 'dart:html';
-
 import 'package:js/js.dart';
 
 @JS()


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The `LogoutOptions` type is only used internally, and shouldn't be exported from the app-facing package. It seems to have been mistakenly exported so it could be imported in `logout_options.extension.dart`, instead of importing it directly from the `auth0_flutter_platform_interface` package.

Also, this PR removes the unused `dart:html` import from `js_interop.dart`.