### PR TITLE
Use Locale.US for Android

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -55,7 +55,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -55,7 +55,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -43,7 +43,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -43,7 +43,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -47,7 +47,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -47,7 +47,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -39,7 +39,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -39,7 +39,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -31,7 +31,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
             scope = scopes.joinToString(separator = " ")
         }
 
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
         format.timeZone = TimeZone.getTimeZone("UTC")
         val date = format.parse(credentials.get("expiresAt") as String)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -70,7 +70,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -70,7 +70,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -49,7 +49,7 @@ class LoginWebAuthRequestHandlerTest {
     fun `handler should log in using the Auth0 SDK`() {
         runRequestHandler { result, builder ->
             val sdf =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
             val formattedDate = sdf.format(defaultCredentials.expiresAt)
 
@@ -329,7 +329,7 @@ class LoginWebAuthRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -49,7 +49,7 @@ class LoginWebAuthRequestHandlerTest {
     fun `handler should log in using the Auth0 SDK`() {
         runRequestHandler { result, builder ->
             val sdf =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
             val formattedDate = sdf.format(defaultCredentials.expiresAt)
 
@@ -329,7 +329,7 @@ class LoginWebAuthRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
@@ -348,7 +348,7 @@ class LoginApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
@@ -348,7 +348,7 @@ class LoginApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
@@ -154,7 +154,7 @@ class LoginWithOtpApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
@@ -154,7 +154,7 @@ class LoginWithOtpApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
@@ -233,7 +233,7 @@ class RenewApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
@@ -233,7 +233,7 @@ class RenewApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
@@ -317,7 +317,7 @@ class GetCredentialsRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
@@ -317,7 +317,7 @@ class GetCredentialsRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandlerTest.kt
@@ -171,7 +171,7 @@ class SaveCredentialsRequestHandlerTest {
             "expiresAt" to "2022-01-01T00:00:00.000Z",
             "scopes" to arrayListOf("a", "b")
         )
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
         format.timeZone = TimeZone.getTimeZone("UTC")
         val date = format.parse(credentialsMap["expiresAt"] as String) as Date
         var scope: String? = null
@@ -223,7 +223,7 @@ class SaveCredentialsRequestHandlerTest {
             "tokenType" to "Bearer",
             "expiresAt" to "2022-01-01T00:00:00.000Z"
         )
-        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.US)
         val date = format.parse(credentialsMap["expiresAt"] as String) as Date
         var scope: String? = null
         val scopes = (credentialsMap["scopes"] ?: arrayListOf<String>()) as ArrayList<*>

--- a/auth0_flutter_platform_interface/pubspec.lock
+++ b/auth0_flutter_platform_interface/pubspec.lock
@@ -259,6 +259,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct dev"
+    description:
+      name: intl
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.0"
   io:
     dependency: transitive
     description:

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
+  intl: ^0.18.0
   mockito: ^5.1.0
   test: ^1.19.5
 

--- a/auth0_flutter_platform_interface/test/credentials_test.dart
+++ b/auth0_flutter_platform_interface/test/credentials_test.dart
@@ -1,0 +1,54 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  initializeDateFormatting();
+
+  test('Credentials throws when expiresAt Locale set to ar', () async {
+    final dateTime = DateTime(2022);
+    final isoDateTimeString = _formatISOTime(dateTime, 'ar');
+
+    expect(
+      () => Credentials.fromMap({
+        'accessToken': 'accessToken',
+        'idToken': 'idToken',
+        'refreshToken': 'refreshToken',
+        'expiresAt': isoDateTimeString,
+        'scopes': ['a'],
+        'userProfile': {'sub': '123', 'name': 'John Doe'},
+        'tokenType': 'Bearer',
+      }),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('Credentials does not throw when expiresAt Locale set to US', () async {
+    initializeDateFormatting();
+    final dateTime = DateTime(2022);
+    final isoDateTimeString = _formatISOTime(dateTime, 'en_US');
+
+    expect(
+      Credentials.fromMap({
+        'accessToken': 'accessToken',
+        'idToken': 'idToken',
+        'refreshToken': 'refreshToken',
+        'expiresAt': isoDateTimeString,
+        'scopes': ['a'],
+        'userProfile': {'sub': '123', 'name': 'John Doe'},
+        'tokenType': 'Bearer',
+      }),
+      isA<Credentials>(),
+    );
+  });
+}
+
+String _formatISOTime(final DateTime date, final String locale) {
+  final duration = date.timeZoneOffset;
+  if (duration.isNegative) {
+    return "${DateFormat('yyyy-MM-ddTHH:mm:ss.mmm', locale).format(date)}-${duration.inHours.toString().padLeft(2, '0')}${(duration.inMinutes - (duration.inHours * 60)).toString().padLeft(2, '0')}";
+  } else {
+    return "${DateFormat('yyyy-MM-ddTHH:mm:ss.mmm', locale).format(date)}+${duration.inHours.toString().padLeft(2, '0')}${(duration.inMinutes - (duration.inHours * 60)).toString().padLeft(2, '0')}";
+  }
+}


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Offering as an alternative to https://github.com/auth0/auth0-flutter/pull/206.

This aligns how Android and iOS parse dates. iOS is already formatting dates to `ISO8601String` by directly taking the `expiresAt` property, without modification. Android on the other hand is modifying this `expiresAt` by allowing it to be localised to whatever the systems `getDefaultLocale` is. 

To solve the issues we have seen with `ar` this ensures that all dates are using a consistent Locale of `Locale.US`. The test added `credentials_test` ~~is used just to illustrate the breaking change~~ is used to illustrate the issue with Arabic vs US English, but is actually fixed at the native level.

### 📎 References

No references.

### 🎯 Testing

Put your device into `Arabic` and attempt to use this library to log in. You'll notice that it works in this MR but doesn't on `main`
