### PR TITLE
Move custom matcher to `tests` dir

### DIFF
--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -25,7 +25,6 @@ export 'src/method_channel_auth0_flutter_auth.dart';
 export 'src/method_channel_auth0_flutter_web_auth.dart';
 export 'src/request/request.dart';
 export 'src/request/request_options.dart';
-export 'src/testing/auth0_exception_matcher.dart';
 export 'src/user_agent.dart';
 export 'src/user_profile.dart';
 export 'src/web-auth/safari_view_controller.dart';

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.1.0
-  test: ^1.19.5
+  test: ^1.22.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/auth0_flutter_platform_interface/test/matchers/auth0_exception_matcher.dart
+++ b/auth0_flutter_platform_interface/test/matchers/auth0_exception_matcher.dart
@@ -1,8 +1,7 @@
 // coverage: ignore-file
 
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../auth0_exception.dart';
 
 class Auth0ExceptionMatcher<T extends Auth0Exception> extends Matcher {
   final String _code;


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR solves a Flutter analyze issue by moving a custom matcher inside the tests dir, so the `flutter_test` package can be imported as a dev dependency.

<img width="1165" alt="Screenshot 2023-04-14 at 11 03 19 AM" src="https://user-images.githubusercontent.com/5055789/232067837-6c510e23-2174-4a84-9dc4-2a9cadfcec9d.png">
