### PR TITLE
Document how to pass the port `3000` when running a web app

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -103,7 +103,9 @@ Next, configure the following URLs for your application under the **Application 
 - Allowed Logout URLs: `http://localhost:3000`
 - Allowed Web Origins: `http://localhost:3000`
 
-> 💡 These URLs should reflect the origins that your application is running on. **Allowed Callback URLs** may also include a path, depending on where you're calling auth0_flutter's `onLoad()` method –[see below](#-web-2).
+> 💡 These URLs should reflect the origins that your app is running on. **Allowed Callback URLs** may also include a path, depending on where you're calling auth0_flutter's `onLoad()` method –[see below](#-web-2).
+
+> 💡 Make sure to use port `3000` when running your app: `flutter run -d chrome --web-port 3000`.
 
 Take note of the **client ID** and **domain** values under the **Basic Information** section. You'll need these values in the next step.
 

--- a/auth0_flutter/example/README.md
+++ b/auth0_flutter/example/README.md
@@ -52,6 +52,22 @@ Then, open the `strings.xml` file and replace `YOUR_AUTH0_DOMAIN` with your own 
 
 If you prefer to use a custom scheme, configure the `com_auth0_scheme` entry with the correct value.
 
+### 4. Run the app
+
+Use the [Flutter CLI's](https://docs.flutter.dev/reference/flutter-cli) `run` command.
+
+#### 📱 Mobile
+
+```sh
+flutter run
+```
+
+#### 🖥️ Web
+
+```sh
+flutter run -d chrome --web-port 3000
+```
+
 ## What is Auth0?
 
 Auth0 helps you to:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR documents in the READMEs of `auth0_flutter` and its example app how to pass the port `3000` to `flutter run` when running a web app. This is the port number used in the callback URLs on the READMEs.