### PR TITLE
Fix android unit tests on `main`

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/AuthenticationExceptionExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/AuthenticationExceptionExtensions.kt
@@ -31,6 +31,3 @@ fun AuthenticationException.toMap(): Map<String, Any> {
         if (exception.getValue("mfa_token") != null) { put("mfa_token", exception.getValue("mfa_token")!!) }
     }
 }
-
-val AuthenticationException.isTooManyAttempts: Boolean
-    get() = "too_many_attempts" == this.getCode()

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/AuthenticationExceptionExtensionsTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/AuthenticationExceptionExtensionsTest.kt
@@ -94,7 +94,9 @@ class AuthenticationExceptionExtensionsTest {
                 )
             },
             "isTooManyAttempts" to { exception: AuthenticationException ->
-                doReturn("too_many_attempts").`when`(exception).getCode()
+                `when`(exception.isTooManyAttempts).thenReturn(
+                    true
+                )
             },
             "isVerificationRequired" to { exception: AuthenticationException ->
                 `when`(exception.isVerificationRequired).thenReturn(


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR brings into the `main` branch the fix for the Android unit tests introduced by https://github.com/auth0/auth0-flutter/pull/240 into the `beta` branch.

From the original PR:

> This PR realigns the test for `AuthenticationException.isTooManyAttempts`. At the time the Flutter SDK was written, this exception type was not exposed by the underlying SDK. This support was added in [this PR](https://github.com/auth0/Auth0.Android/pull/615), so now the test can be updated to align with the others and be made to pass.

