### PR TITLE
fix: inline AuthParamsExtension.prepare usage and remove [SDK-4222]

### DIFF
--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -49,7 +49,8 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   Future<void> loginWithRedirect(final LoginOptions? options) {
     final client = _ensureClient();
 
-    final authParams = interop.AuthorizationParams(
+    final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
+        interop.AuthorizationParams(
             audience: options?.audience,
             redirect_uri: options?.redirectUrl,
             organization: options?.organizationId,
@@ -57,8 +58,8 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
             max_age: options?.idTokenValidationConfig?.maxAge,
             scope: options?.scopes.isNotEmpty == true
                 ? options?.scopes.join(' ')
-                : null)
-        .prepare(options?.parameters);
+                : null),
+        options?.parameters ?? {}));
 
     final loginOptions =
         interop.RedirectLoginOptions(authorizationParams: authParams);
@@ -70,15 +71,16 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   Future<Credentials> loginWithPopup(final PopupLoginOptions? options) async {
     final client = _ensureClient();
 
-    final authParams = interop.AuthorizationParams(
+    final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
+        interop.AuthorizationParams(
             audience: options?.audience,
             organization: options?.organizationId,
             invitation: options?.invitationUrl,
             max_age: options?.idTokenValidationConfig?.maxAge,
             scope: options?.scopes.isNotEmpty == true
                 ? options?.scopes.join(' ')
-                : null)
-        .prepare(options?.parameters);
+                : null),
+        options?.parameters ?? {}));
 
     final popupConfig = JsInteropUtils.stripNulls(interop.PopupConfigOptions(
         popup: options?.popupWindow,
@@ -90,9 +92,9 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
           popupConfig);
 
       return CredentialsExtension.fromWeb(await client.getTokenSilently(
-        interop.GetTokenSilentlyOptions(
-            authorizationParams: authParams.toGetTokenSilentlyParams(),
-            detailedResponse: true)));
+          interop.GetTokenSilentlyOptions(
+              authorizationParams: authParams.toGetTokenSilentlyParams(),
+              detailedResponse: true)));
     } catch (e) {
       throw WebExceptionExtension.fromJsObject(e);
     }

--- a/auth0_flutter/lib/src/web/js_interop_utils.dart
+++ b/auth0_flutter/lib/src/web/js_interop_utils.dart
@@ -36,12 +36,6 @@ class JsInteropUtils {
 }
 
 extension AuthParamsExtension on AuthorizationParams {
-  // Wrapper for common use case of stripping nulls and mixing in parameters
-  // on AuthorizationParams.
-  AuthorizationParams prepare([final Map<String, dynamic>? params]) =>
-      JsInteropUtils.stripNulls(
-          JsInteropUtils.addCustomParams(this, params ?? {}));
-
   // Converts an instance of AuthorizationParams to
   // GetTokenSilentlyAuthorizationParams.
   GetTokenSilentlyAuthParams toGetTokenSilentlyParams() =>


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR inlines the usage of `AuthParamsExtension.prepare` and removed, as it was causing issues with the web build when using `flutter build web`. The compiler appeared to be aggressively optimising out any code that appeared after this extension call, causing login to not even be called. I have as yet to fully understand why (especially as calls to the other method `toGetTokenSilentlyOptions` work fine), however the change presented here fixes the issue for the meantime.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Fixes #256 

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

The changes don't affect the existing tests, and no new tests were added.
