### PR TITLE
af: release v1.2.0-beta.1

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Fixed**
 
 - fix: inline AuthParamsExtension.prepare usage and remove [SDK-4222] [\#260](https://github.com/auth0/auth0-flutter/pull/260) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Use Locale.US for Android [\#238](https://github.com/auth0/auth0-flutter/pull/238) ([Mecharyry](https://github.com/Mecharyry))
 
 ## [v1.2.0-beta.0](https://github.com/auth0/auth0-flutter/tree/v1.2.0-beta.0) (2023-04-14)
 

--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [v1.2.0-beta.1](https://github.com/auth0/auth0-flutter/tree/v1.2.0-beta.1) (2023-05-24)
+
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.0-beta.0...v1.2.0-beta.1)
+
+**Changed**
+
+- Document how to load the SPA SDK in index.html [\#254](https://github.com/auth0/auth0-flutter/pull/254) ([Widcket](https://github.com/Widcket))
+- Document how to pass the port `3000` when running a web app [\#249](https://github.com/auth0/auth0-flutter/pull/249) ([Widcket](https://github.com/Widcket))
+
+**Fixed**
+
+- fix: inline AuthParamsExtension.prepare usage and remove [SDK-4222] [\#260](https://github.com/auth0/auth0-flutter/pull/260) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v1.2.0-beta.0](https://github.com/auth0/auth0-flutter/tree/v1.2.0-beta.0) (2023-04-14)
 
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.1.0...v1.2.0-beta.0)

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.2.0-beta.0'
+  s.version      = '1.2.0-beta.1'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '1.2.0-beta.0';
+const String version = '1.2.0-beta.1';

--- a/auth0_flutter/pubspec.lock
+++ b/auth0_flutter/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: "../auth0_flutter_platform_interface"
       relative: true
     source: path
-    version: "1.2.0-beta.0"
+    version: "1.2.0-beta.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android / iOS Flutter apps.
-version: 1.2.0-beta.0
+version: 1.2.0-beta.1
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  auth0_flutter_platform_interface: 1.2.0-beta.0
+  auth0_flutter_platform_interface: 1.2.0-beta.1
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
**Changed**

- Document how to load the SPA SDK in index.html [\#254](https://github.com/auth0/auth0-flutter/pull/254) ([Widcket](https://github.com/Widcket))
- Document how to pass the port `3000` when running a web app [\#249](https://github.com/auth0/auth0-flutter/pull/249) ([Widcket](https://github.com/Widcket))

**Fixed**

- fix: inline AuthParamsExtension.prepare usage and remove [SDK-4222] [\#260](https://github.com/auth0/auth0-flutter/pull/260) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Use Locale.US for Android [\#238](https://github.com/auth0/auth0-flutter/pull/238) ([Mecharyry](https://github.com/Mecharyry))

[SDK-4222]: https://auth0team.atlassian.net/browse/SDK-4222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ