### PR TITLE
af: inline usage of toGetTokenSilently options and remove extension

### DIFF
--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -93,7 +93,9 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
 
       return CredentialsExtension.fromWeb(await client.getTokenSilently(
           interop.GetTokenSilentlyOptions(
-              authorizationParams: authParams.toGetTokenSilentlyParams(),
+              authorizationParams: JsInteropUtils.stripNulls(
+                  interop.GetTokenSilentlyAuthParams(
+                      scope: authParams.scope, audience: authParams.audience)),
               detailedResponse: true)));
     } catch (e) {
       throw WebExceptionExtension.fromJsObject(e);

--- a/auth0_flutter/lib/src/web/js_interop_utils.dart
+++ b/auth0_flutter/lib/src/web/js_interop_utils.dart
@@ -34,11 +34,3 @@ class JsInteropUtils {
     return obj;
   }
 }
-
-extension AuthParamsExtension on AuthorizationParams {
-  // Converts an instance of AuthorizationParams to
-  // GetTokenSilentlyAuthorizationParams.
-  GetTokenSilentlyAuthParams toGetTokenSilentlyParams() =>
-      JsInteropUtils.stripNulls(
-          GetTokenSilentlyAuthParams(scope: scope, audience: audience));
-}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Similar to #260, this inlines the other extension method on a `@JS` type as it was exhibiting some weird behaviour that broke `loginWithPopup`. The extension class is also removed as no longer needed.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Resolves [an issue with loginWithPopup](https://github.com/auth0/auth0-flutter/issues/256#issuecomment-1561248472) reported in #256.

