### PR TITLE
Do not call `setState()` after web logout on the example app

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -81,13 +81,13 @@ class _ExampleAppState extends State<ExampleApp> {
         await auth0Web.logout(returnToUrl: 'http://localhost:3000');
       } else {
         await webAuth.logout();
+
+        setState(() {
+          _isLoggedIn = false;
+        });
       }
       output = 'Logged out.';
-
-      setState(() {
-        _isLoggedIn = false;
-      });
-    } on WebAuthenticationException catch (e) {
+    } catch (e) {
       output = e.toString();
     }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the example app to only call `setState()` after logout on the mobile platforms. On the web platform `onLoad()` will run after the redirect and set the state, making this unnecessary.

### 🎯 Testing

The changes were tested manually.