### PR TITLE
fix: allow audience and scope to be supplied during initialization

### DIFF
--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -32,6 +32,11 @@ class Auth0Web {
   /// learn more about these parameters.
   /// * See the [ClientOptions] type for the full description of the remaining
   /// parameters for this method.
+  /// * [audience] relates to the API Identifier you want to reference in your
+  /// access tokens. See [API settings](https://auth0.com/docs/get-started/apis/api-settings)
+  /// to learn more.
+  /// * [scopes] defaults to `openid profile email`. You can override these
+  /// scopes, but `openid` is always requested regardless of this setting.
   Future<Credentials?> onLoad(
       {final int? authorizeTimeoutInSeconds,
       final CacheLocation? cacheLocation,
@@ -44,7 +49,9 @@ class Auth0Web {
       final bool? useCookiesForTransactions,
       final bool? useFormData,
       final bool? useRefreshTokens,
-      final bool? useRefreshTokensFallback}) async {
+      final bool? useRefreshTokensFallback,
+      final String? audience,
+      final Set<String>? scopes}) async {
     await Auth0FlutterWebPlatform.instance.initialize(
         ClientOptions(
             account: _account,
@@ -59,7 +66,9 @@ class Auth0Web {
             useCookiesForTransactions: useCookiesForTransactions,
             useFormData: useFormData,
             useRefreshTokens: useRefreshTokens,
-            useRefreshTokensFallback: useRefreshTokensFallback),
+            useRefreshTokensFallback: useRefreshTokensFallback,
+            audience: audience,
+            scopes: scopes),
         _userAgent);
 
     if (await hasValidCredentials()) {

--- a/auth0_flutter/lib/src/web/extensions/client_options_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/client_options_extensions.dart
@@ -1,5 +1,6 @@
 import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
 import '../js_interop.dart';
+import '../js_interop_utils.dart';
 
 extension ClientOptionsExtension on ClientOptions {
   Auth0ClientOptions toAuth0ClientOptions(final UserAgent userAgent) =>
@@ -19,5 +20,8 @@ extension ClientOptionsExtension on ClientOptions {
           useCookiesForTransactions: useCookiesForTransactions,
           useFormData: useFormData,
           useRefreshTokens: useRefreshTokens,
-          useRefreshTokensFallback: useRefreshTokensFallback);
+          useRefreshTokensFallback: useRefreshTokensFallback,
+          authorizationParams: JsInteropUtils.stripNulls(AuthorizationParams(
+              audience: audience,
+              scope: scopes?.isNotEmpty == true ? scopes?.join(' ') : null)));
 }

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -79,6 +79,7 @@ class Auth0ClientOptions {
       {required final Auth0ClientInfo clientInfo,
       required final String domain,
       required final String clientId,
+      final String? audience,
       final int? authorizeTimeoutInSeconds,
       final String? cacheLocation,
       final String? cookieDomain,
@@ -90,7 +91,8 @@ class Auth0ClientOptions {
       final bool? useCookiesForTransactions,
       final bool? useFormData,
       final bool? useRefreshTokens,
-      final bool? useRefreshTokensFallback});
+      final bool? useRefreshTokensFallback,
+      final AuthorizationParams? authorizationParams});
 }
 
 @JS()

--- a/auth0_flutter/lib/src/web/js_interop.dart
+++ b/auth0_flutter/lib/src/web/js_interop.dart
@@ -79,7 +79,6 @@ class Auth0ClientOptions {
       {required final Auth0ClientInfo clientInfo,
       required final String domain,
       required final String clientId,
-      final String? audience,
       final int? authorizeTimeoutInSeconds,
       final String? cacheLocation,
       final String? cookieDomain,

--- a/auth0_flutter_platform_interface/lib/src/web/client_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/client_options.dart
@@ -95,6 +95,16 @@ class ClientOptions {
   /// The configuration for validating ID tokens.
   final IdTokenValidationConfig? idTokenValidationConfig;
 
+  /// The default audience to be used for requesting API access.
+  final String? audience;
+
+  /// The default scopes to be used on authentication requests.
+  ///
+  /// This defaults to `openid profile email` if not specified.
+  ///
+  /// Note: The openid scope is always applied regardless of this setting.
+  final Set<String>? scopes;
+
   ClientOptions(
       {required this.account,
       this.authorizeTimeoutInSeconds,
@@ -107,5 +117,7 @@ class ClientOptions {
       this.useFormData,
       this.useRefreshTokens,
       this.useRefreshTokensFallback,
-      this.idTokenValidationConfig});
+      this.idTokenValidationConfig,
+      this.audience,
+      this.scopes});
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR adds the ability to specify `audience` and `scopes` to `onLoad()`. This fixes an issue in a specific scenario when using both `useRefreshTokens` and `cacheLocation: CacheLocation.localStorage` and logging in with `audience` causes the refresh token to be missing during initialization.

This happens because `audience` (and `scopes`) are used as part of the cache key when looking up the refresh token internally but until now a developer had no way to specify those values.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Fixes #271 

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Tested manually by supplying `audience` and `scope` to `onLoad()`, logging in, and observing data coming through local storage and to `/authorize`.
