### PR TITLE
Release v1.2.1

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.2.1](https://github.com/auth0/auth0-flutter/tree/v1.2.1) (2023-06-06)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.0...v1.2.1)
+
+**Fixed**
+- fix: allow audience and scope to be supplied during initialization [\#272](https://github.com/auth0/auth0-flutter/pull/272) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v1.2.0](https://github.com/auth0/auth0-flutter/tree/v1.2.0) (2023-05-31)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.1.0...v1.2.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 1.2.0
+version: 1.2.1
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Fixed**
- fix: allow audience and scope to be supplied during initialization [\#272](https://github.com/auth0/auth0-flutter/pull/272) ([stevehobbsdev](https://github.com/stevehobbsdev))
