### PR TITLE
af: Pin Auth0.swift and its dependencies to last version that supports iOS 12

### DIFF
--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -15,7 +15,9 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '12.0'
 
   s.dependency 'Flutter'
-  s.dependency 'Auth0', '~> 2.3'
+  s.dependency 'Auth0', '2.3.2'
+  s.dependency 'JWTDecode', '3.0.1'
+  s.dependency 'SimpleKeychain', '1.0.1'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR pins Auth0.swift to **v2.3.2**, JWTDecode.swift to **v3.0.1**, and SimpleKeychain to **v1.0.1**, which is the last version that supports iOS 12.

Otherwise, Cocoapods will automatically pull the latest version of all these libraries.