### PR TITLE
Add automated publishing workflows [SDK-4044]

### DIFF
--- a/.github/workflows/publish-af.yml
+++ b/.github/workflows/publish-af.yml
@@ -1,0 +1,12 @@
+name: Publish auth0_flutter to pub.dev
+
+on:
+  push:
+    tags:
+      - 'af-v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: auth0_flutter

--- a/.github/workflows/publish-afpi.yml
+++ b/.github/workflows/publish-afpi.yml
@@ -1,0 +1,12 @@
+name: Publish auth0_flutter_platform_interface to pub.dev
+
+on:
+  push:
+    tags:
+      - 'afpi-v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: auth0_flutter_platform_interface


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds GitHub Actions workflows for automating the publishing of `auth0_flutter` and `auth0_flutter_platform_interface`, by pushing tags formatted as `af-v{{version}}` and `afpi-v{{version}}`, respectively.

[Protected tags](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules) have been set up in the repo settings matching these patterns:

<img width="106" alt="Screenshot 2023-06-21 at 7 27 46 PM" src="https://github.com/auth0/auth0-flutter/assets/5055789/2ea55f2d-7c33-49f8-b47b-4652e32c8161">