### PR TITLE
Use M1 resource class for iOS CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ orbs:
 parameters:
   flutter_version:
     type: string
-    default: 3.10.2
+    default: 3.10.5
 jobs:
   test_flutter_package:
     docker:
@@ -179,6 +179,9 @@ jobs:
           version: << parameters.ios_version >>
           platform: iOS
           device: << parameters.ios_simulator >>
+      - run:
+          name: Install Rosetta
+          command: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
       - flutter/install_sdk_and_pub:
           app-dir: ./auth0_flutter/example
           version: << pipeline.parameters.flutter_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,8 @@ jobs:
           cache-prefix: v1a
   test_ios:
     parameters:
+      ios_version:
+        type: string
       ios_simulator:
         type: string
     macos:
@@ -174,7 +176,7 @@ jobs:
     steps:
       - checkout
       - macos/preboot-simulator:
-          version: "15.0"
+          version: << parameters.ios_version >>
           platform: iOS
           device: << parameters.ios_simulator >>
       - flutter/install_sdk_and_pub:
@@ -221,6 +223,7 @@ workflows:
           requires:
             - test_flutter_package
       - test_ios:
+          ios_version: "16.0"
           ios_simulator: iPhone 14
           requires:
             - test_flutter_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,8 @@ jobs:
       ios_simulator:
         type: string
     macos:
-      xcode: "13.0.0"
+      xcode: "14.2.0"
+    resource_class: macos.m1.large.gen1
     environment:
       BUNDLE_RETRY: 3
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -220,6 +221,6 @@ workflows:
           requires:
             - test_flutter_package
       - test_ios:
-          ios_simulator: iPhone 13
+          ios_simulator: iPhone 14
           requires:
             - test_flutter_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,9 @@ jobs:
             mkdir cobertura
             bundle exec slather
           working_directory: ./auth0_flutter/example/ios
+      - run:
+          name: Ensure ~/.gnupg dir exists
+          command: mkdir -p ~/.gnupg
       - codecov/upload:
           file: ./auth0_flutter/example/ios/cobertura/cobertura.xml
           upload_name: Auth0 Flutter iOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - checkout
       - flutter/install_sdk_and_pub:
           app-dir: ./auth0_flutter
-          flutter_version: << pipeline.parameters.flutter_version >>
+          version: << pipeline.parameters.flutter_version >>
       - browser-tools/install-chrome
       - run:
           name: Analyze App Facing Package
@@ -104,7 +104,7 @@ jobs:
       - checkout
       - flutter/install_sdk_and_pub:
           app-dir: ./auth0_flutter
-          flutter_version: << pipeline.parameters.flutter_version >>
+          version: << pipeline.parameters.flutter_version >>
       - android/restore-gradle-cache
       - android/restore-build-cache
       - local-android/prepare-config
@@ -150,7 +150,7 @@ jobs:
       - checkout
       - flutter/install_sdk_and_pub:
           app-dir: ./auth0_flutter
-          flutter_version: << pipeline.parameters.flutter_version >>
+          version: << pipeline.parameters.flutter_version >>
       - local-android/prepare-config
       - run:
           name: Build Android app
@@ -181,7 +181,7 @@ jobs:
           device: << parameters.ios_simulator >>
       - flutter/install_sdk_and_pub:
           app-dir: ./auth0_flutter/example
-          flutter_version: << pipeline.parameters.flutter_version >>
+          version: << pipeline.parameters.flutter_version >>
       - flutter/install_ios_gem:
           app-dir: ./auth0_flutter/example
       - flutter/install_ios_pod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
             bundle exec slather
           working_directory: ./auth0_flutter/example/ios
       - run:
-          name: Ensure ~/.gnupg dir exists
+          name: Create ~/.gnupg dir if it does not exist
           command: mkdir -p ~/.gnupg
       - codecov/upload:
           file: ./auth0_flutter/example/ios/cobertura/cobertura.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ workflows:
           requires:
             - test_flutter_package
       - test_ios:
-          ios_version: "16.0"
+          ios_version: "16.2"
           ios_simulator: iPhone 14
           requires:
             - test_flutter_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   android: circleci/android@2
   macos: circleci/macos@2
-  flutter: circleci/flutter@1
+  flutter: circleci/flutter@2
   browser-tools: circleci/browser-tools@1
   codecov: codecov/codecov@3
   local-android:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the CircleCI config to use the M1 resource class, as the macOS `medium` executor is being deprecated: https://discuss.circleci.com/t/macos-resource-deprecation-update/46891

The Xcode, iOS simulator and its iOS version were bumped as well.