### PR TITLE
af: Use Application Context for Credentials Manager

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -53,6 +53,8 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
     credentialsManagerMethodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "auth0.com/auth0_flutter/credentials_manager")
     credentialsManagerMethodChannel.setMethodCallHandler(credentialsManagerCallHandler)
+
+    credentialsManagerCallHandler.context = flutterPluginBinding.applicationContext
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
@@ -1,6 +1,7 @@
 package com.auth0.auth0_flutter
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import androidx.annotation.NonNull
 import com.auth0.android.authentication.AuthenticationAPIClient
@@ -23,6 +24,8 @@ class CredentialsManagerMethodCallHandler(private val requestHandlers: List<Cred
     // GitHub issue: https://github.com/jacoco/jacoco/issues/1182
     @Generated
     lateinit var activity: Activity
+    @Generated
+    lateinit var context: Context
 
     var credentialsManager: SecureCredentialsManager? = null
 
@@ -33,8 +36,8 @@ class CredentialsManagerMethodCallHandler(private val requestHandlers: List<Cred
             val request = MethodCallRequest.fromCall(call)
 
             val api = AuthenticationAPIClient(request.account)
-            val storage = SharedPreferencesStorage(activity)
-            credentialsManager = credentialsManager ?: SecureCredentialsManager(activity, api, storage)
+            val storage = SharedPreferencesStorage(context)
+            credentialsManager = credentialsManager ?: SecureCredentialsManager(context, api, storage)
 
             val credentialsManager = credentialsManager as SecureCredentialsManager
             val localAuthentication = request.data.get("localAuthentication") as Map<String, String>?
@@ -44,7 +47,7 @@ class CredentialsManagerMethodCallHandler(private val requestHandlers: List<Cred
                 val description = localAuthentication["description"]
                 credentialsManager.requireAuthentication(activity, RequestCodes.AUTH_REQ_CODE, title, description)
             }
-            requestHandler.handle(credentialsManager, activity, request, result)
+            requestHandler.handle(credentialsManager, context, request, result)
         } else {
             result.notImplemented()
         }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
@@ -1,6 +1,8 @@
 package com.auth0.auth0_flutter
 
 import android.app.Activity
+import android.content.Context
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodChannel
 import org.junit.Test
@@ -17,7 +19,10 @@ class Auth0FlutterPluginTest {
         mockConstruction(MethodChannel::class.java).use { m ->
             val plugin = Auth0FlutterPlugin()
 
-            plugin.onAttachedToEngine(mock())
+            val mockBindings = mock<FlutterPluginBinding>()
+            val mockContext = mock<Context>()
+            `when`(mockBindings.applicationContext).thenReturn(mockContext)
+            plugin.onAttachedToEngine(mockBindings)
 
             val constructed: List<MethodChannel> = m.constructed()
 
@@ -40,7 +45,10 @@ class Auth0FlutterPluginTest {
         mockConstruction(MethodChannel::class.java).use { m ->
             val plugin = Auth0FlutterPlugin()
 
-            plugin.onAttachedToEngine(mock())
+            val mockBindings = mock<FlutterPluginBinding>()
+            val mockContext = mock<Context>()
+            `when`(mockBindings.applicationContext).thenReturn(mockContext)
+            plugin.onAttachedToEngine(mockBindings)
 
             val constructed: List<MethodChannel> = m.constructed()
 
@@ -61,19 +69,22 @@ class Auth0FlutterPluginTest {
     }
 
     @Test
-    fun `should set Activity on onAttachedToActivity`() {
+    fun `should set Activity on onAttachedToActivity and ApplicationContext on onAttachedToEngine`() {
         mockConstruction(MethodChannel::class.java).use { m ->
             val plugin = Auth0FlutterPlugin()
 
-            plugin.onAttachedToEngine(mock())
+            val mockBindings = mock<FlutterPluginBinding>()
+            val mockContext = mock<Context>()
+            `when`(mockBindings.applicationContext).thenReturn(mockContext)
+            plugin.onAttachedToEngine(mockBindings)
 
             val constructed: List<MethodChannel> = m.constructed()
 
-            val mockBindings = mock<ActivityPluginBinding>()
+            val mockActivityBindings = mock<ActivityPluginBinding>()
             val mockActivity = mock<Activity>()
-            `when`(mockBindings.activity).thenReturn(mockActivity)
+            `when`(mockActivityBindings.activity).thenReturn(mockActivity)
 
-            plugin.onAttachedToActivity(mockBindings)
+            plugin.onAttachedToActivity(mockActivityBindings)
 
             fun <TMethodCallHandler : MethodChannel.MethodCallHandler> getHandler(i: Int): TMethodCallHandler {
                 val captor = argumentCaptor<MethodChannel.MethodCallHandler>()
@@ -86,6 +97,7 @@ class Auth0FlutterPluginTest {
 
             assert(getHandler<Auth0FlutterWebAuthMethodCallHandler>(0).activity == mockActivity)
             assert(getHandler<CredentialsManagerMethodCallHandler>(2).activity == mockActivity)
+            assert(getHandler<CredentialsManagerMethodCallHandler>(2).context == mockContext)
 
             assert(constructed.size == 3)
         }
@@ -96,16 +108,19 @@ class Auth0FlutterPluginTest {
         mockConstruction(MethodChannel::class.java).use {
             val plugin = Auth0FlutterPlugin()
 
-            plugin.onAttachedToEngine(mock())
+            val mockBindings = mock<FlutterPluginBinding>()
+            val mockContext = mock<Context>()
+            `when`(mockBindings.applicationContext).thenReturn(mockContext)
+            plugin.onAttachedToEngine(mockBindings)
 
-            val mockBindings = mock<ActivityPluginBinding>()
+            val mockActivityBindings = mock<ActivityPluginBinding>()
             val mockActivity = mock<Activity>()
 
-            `when`(mockBindings.activity).thenReturn(mockActivity)
+            `when`(mockActivityBindings.activity).thenReturn(mockActivity)
 
-            plugin.onAttachedToActivity(mockBindings)
+            plugin.onAttachedToActivity(mockActivityBindings)
 
-            verify(mockBindings).addActivityResultListener(
+            verify(mockActivityBindings).addActivityResultListener(
                 any<CredentialsManagerMethodCallHandler>()
             )
         }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.auth0.auth0_flutter
 
 import android.app.Activity
+import android.content.Context
 import android.content.SharedPreferences
 import com.auth0.auth0_flutter.request_handlers.credentials_manager.ClearCredentialsRequestHandler
 import com.auth0.auth0_flutter.request_handlers.credentials_manager.CredentialsManagerRequestHandler
@@ -33,12 +34,14 @@ class CredentialsManagerMethodCallHandlerTest {
         arguments: HashMap<String, Any?> = defaultArguments,
         requestHandlers: List<CredentialsManagerRequestHandler>,
         activity: Activity? = null,
+        context: Context? = null,
         onResult: (Result) -> Unit,
     ) {
         val handler = CredentialsManagerMethodCallHandler(requestHandlers)
         val mockResult = mock<Result>()
 
         handler.activity = if (activity === null)  mock() else activity
+        handler.context = if (context === null)  mock() else context
 
         handler.onMethodCall(MethodCall(method, arguments), mockResult)
         onResult(mockResult)
@@ -69,15 +72,17 @@ class CredentialsManagerMethodCallHandlerTest {
         `when`(clearCredentialsHandler.method).thenReturn("credentialsManager#clearCredentials")
 
         val activity: Activity = mock()
+        val context: Context = mock()
         val mockPrefs: SharedPreferences = mock()
 
-        `when`(activity.getSharedPreferences(any(), any()))
+        `when`(context.getSharedPreferences(any(), any()))
             .thenReturn(mockPrefs)
 
         val handler = CredentialsManagerMethodCallHandler(listOf(clearCredentialsHandler))
         val mockResult = mock<Result>()
 
         handler.activity = activity
+        handler.context = context
         handler.credentialsManager = mock()
 
         handler.onMethodCall(MethodCall(clearCredentialsHandler.method, defaultArguments), mockResult)
@@ -92,15 +97,17 @@ class CredentialsManagerMethodCallHandlerTest {
         `when`(clearCredentialsHandler.method).thenReturn("credentialsManager#clearCredentials")
 
         val activity: Activity = mock()
+        val context: Context = mock()
         val mockPrefs: SharedPreferences = mock()
 
-        `when`(activity.getSharedPreferences(any(), any()))
+        `when`(context.getSharedPreferences(any(), any()))
             .thenReturn(mockPrefs)
 
         val handler = CredentialsManagerMethodCallHandler(listOf(clearCredentialsHandler))
         val mockResult = mock<Result>()
 
         handler.activity = activity
+        handler.context = context
         handler.credentialsManager = mock()
 
         handler.onMethodCall(MethodCall(clearCredentialsHandler.method, defaultArguments + hashMapOf("localAuthentication" to hashMapOf("title" to "test", "description" to "test description"))), mockResult)
@@ -115,15 +122,17 @@ class CredentialsManagerMethodCallHandlerTest {
         `when`(clearCredentialsHandler.method).thenReturn("credentialsManager#clearCredentials")
 
         val activity: Activity = mock()
+        val context: Context = mock()
         val mockPrefs: SharedPreferences = mock()
 
-        `when`(activity.getSharedPreferences(any(), any()))
+        `when`(context.getSharedPreferences(any(), any()))
             .thenReturn(mockPrefs)
 
         val handler = CredentialsManagerMethodCallHandler(listOf(clearCredentialsHandler))
         val mockResult = mock<Result>()
 
         handler.activity = activity
+        handler.context = context
         handler.credentialsManager = mock()
 
         handler.onMethodCall(MethodCall(clearCredentialsHandler.method, defaultArguments + hashMapOf("localAuthentication" to hashMapOf<String, String>())), mockResult)
@@ -140,14 +149,15 @@ class CredentialsManagerMethodCallHandlerTest {
         `when`(hasValidCredentialsHandler.method).thenReturn("credentialsManager#hasValidCredentials")
 
         val activity: Activity = mock()
+        val context: Context = mock()
         val mockPrefs: SharedPreferences = mock()
 
-        `when`(activity.getSharedPreferences(any(), any()))
+        `when`(context.getSharedPreferences(any(), any()))
             .thenReturn(mockPrefs)
 
-        runCallHandler(clearCredentialsHandler.method, activity = activity, requestHandlers = listOf(clearCredentialsHandler, hasValidCredentialsHandler)) {
-            verify(clearCredentialsHandler).handle(any(), eq(activity), any(), any())
-            verify(hasValidCredentialsHandler, times(0)).handle(any(), eq(activity), any(), any())
+        runCallHandler(clearCredentialsHandler.method, activity = activity, context = context, requestHandlers = listOf(clearCredentialsHandler, hasValidCredentialsHandler)) {
+            verify(clearCredentialsHandler).handle(any(), eq(context), any(), any())
+            verify(hasValidCredentialsHandler, times(0)).handle(any(), eq(context), any(), any())
         }
     }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality - N/A - Changes are internal

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes
We are using `applicationContext` to fetch the credentials instead of `Activity` which is not required and could cause issues when credentials are fetched from outside an activity

### 📎 References
https://github.com/auth0/auth0-flutter/issues/233

### 🎯 Testing

We have updated the existing Unit Tests and added check that proper context is set.
