### PR TITLE
chore: Add `.semgrepignore` exclusions

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,3 @@
-.circleci/
-.github/
 .idea/
 .vscode/
 appium-test/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,8 @@
+.circleci/
+.github/
+.idea/
+.vscode/
+appium-test/
+auth0_flutter/example/
+auth0_flutter/test/
+auth0_flutter_platform_interface/test/


### PR DESCRIPTION
This PR adds a `.semgrepignore` manifest file and excludes directories that are (or potentially could) incorrectly trigger false positives.