### PR TITLE
chore(security): Pin `pr-title-checker` to commit SHA

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -12,7 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@v1.3.4
+      # Pinned to commit for 1.4.0
+      - uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false


### PR DESCRIPTION
This PR pins the `pr-title-checker` third-party action to a full-length commit SHA — that of release 1.4.0.

Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository. https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions