### PR TITLE
Fix Android-related line in the README

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -127,7 +127,7 @@ final auth0 = Auth0('YOUR_AUTH0_DOMAIN', 'YOUR_AUTH0_CLIENT_ID');
 
 ##### Android: Configure manifest placeholders
 
-Open the `android/build.gradle` file and add the following manifest placeholders inside **android > defaultConfig**.
+Open the `android/app/build.gradle` file and add the following manifest placeholders inside **android > defaultConfig**.
 
 ```groovy
 // android/build.gradle


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR fixes a path in the Android setup instructions found in the README.md

### 📎 References

Closes https://github.com/auth0/auth0-flutter/issues/295