### PR TITLE
Update PKCE-related documentation

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -45,10 +45,7 @@ Head to the [Auth0 Dashboard](https://manage.auth0.com/#/applications/) and crea
 <details>
   <summary>Using an existing <strong>Native</strong> application?</summary>
 
-Select the **Settings** tab of your [application's page](https://manage.auth0.com/#/applications/) and verify the following:
-
-- Ensure that **Application Type** is set to `Native`
-- Ensure that the **Token Endpoint Authentication Method** setting has a value of `None`
+Select the **Settings** tab of your [application's page](https://manage.auth0.com/#/applications/) and ensure that **Application Type** is set to `Native`.
 
 Then, scroll down and select the **Show Advanced Settings** link. Under **Advanced Settings**, select the **OAuth** tab and verify the following:
 
@@ -83,17 +80,16 @@ Head to the [Auth0 Dashboard](https://manage.auth0.com/#/applications/) and crea
 <details>
   <summary>Using an existing <strong>Single Page</strong> application?</summary>
 
-Select the **Settings** tab of your [application's page](https://manage.auth0.com/#/applications/) and verify the following:
-
-- Ensure that **Application Type** is set to `Single Page Application`
-- Ensure that the **Token Endpoint Authentication Method** setting has a value of `None`
+Select the **Settings** tab of your [application's page](https://manage.auth0.com/#/applications/) and ensure that **Application Type** is set to `Single Page Application`. 
 
 Then, scroll down and select the **Show Advanced Settings** link. Under **Advanced Settings**, select the **OAuth** tab and verify the following:
 
 - Ensure that **JsonWebToken Signature Algorithm** is set to `RS256`
 - Ensure that **OIDC Conformant** is enabled
 
-Finally, if you made any chages don't forget to scroll to the end and press the **Save Changes** button.
+If you made any chages don't forget to scroll to the end and press the **Save Changes** button.
+
+Finally, head over to the **Credentials** tab and ensure that **Authentication Methods** is set to `None`.
 
 </details>
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Recently there have been some changes in Manage, and now the **Token Endpoint Authentication Method** setting no longer shows up for mobile apps (because for this kind of app it must be `None`). Whereas for regular web apps and SPAs it's been moved to another tab:

<img width="543" alt="Screenshot 2023-08-11 at 1 55 22 PM" src="https://github.com/auth0/Auth0.swift/assets/5055789/27ad3b7d-98f2-4e3c-b551-7f8b63b68018">

Since it was possible (before this change) to set it to an invalid value for mobile apps, we had to point this out in the README of the app-facing package. Now that this setting is no longer available for mobile apps and was moved for SPAs, this PR reworks the respective documentation.