### PR TITLE
Add Android App Links guidance to https schemes

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -179,6 +179,11 @@ Re-declare the activity manually using `tools:node="remove"` in the `android/src
 
 </details>
 
+> 💡 `https` schemes require enabling [Android App
+> Links](https://auth0.com/docs/applications/enable-android-app-links). You can
+> read more about setting this value in the [Auth0.Android SDK
+> README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+
 > 💡 If your Android app is using [product flavors](https://developer.android.com/studio/build/build-variants#product-flavors), you might need to specify different manifest placeholders for each flavor.
 
 ##### iOS: Configure custom URL scheme


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Surfacing an important step when setting up Android apps to support `https` schemes.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Aligning the Pub.dev docs with the same level of convenience as guidance found in other Auth0 documentation surrounding the use of `https` schemes:

- https://auth0.com/docs/quickstart/native/flutter/interactive#configure-android
- https://auth0.com/blog/get-started-with-flutter-authentication/#Configure-the-SDK

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Docs-only change, should not affect tests.