### PR TITLE
afpi: release afpi-v1.3.0

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [afpi-v1.3.0](https://github.com/auth0/auth0-flutter/tree/afpi-v1.3.0) (2023-10-27)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.1...afpi-v1.3.0)
+
+**Changed**
+- Lock Auth0.Android version to avoid dynamic versioning [\#311](https://github.com/auth0/auth0-flutter/pull/311) ([poovamraj](https://github.com/poovamraj))
+- Add namespace to build.gradle [\#290](https://github.com/auth0/auth0-flutter/pull/290) ([poovamraj](https://github.com/poovamraj))
+
+**Fixed**
+- Fix access token expiry android [\#315](https://github.com/auth0/auth0-flutter/pull/315) ([poovamraj](https://github.com/poovamraj))
+
 ## [v1.2.1](https://github.com/auth0/auth0-flutter/tree/v1.2.1) (2023-06-06)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.0...v1.2.1)
 

--- a/auth0_flutter_platform_interface/pubspec.lock
+++ b/auth0_flutter_platform_interface/pubspec.lock
@@ -529,5 +529,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">==3.0.0-0 <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/auth0_flutter_platform_interface/pubspec.lock
+++ b/auth0_flutter_platform_interface/pubspec.lock
@@ -529,5 +529,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">==3.0.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/auth0_flutter_platform_interface/pubspec.lock
+++ b/auth0_flutter_platform_interface/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -303,18 +303,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -335,10 +335,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: dd61809f04da1838a680926de50a9e87385c1de91c6579629c3d1723946e8059
+      sha256: "8b46d7eb40abdda92d62edd01546051f0c27365e65608c284de336dccfef88cc"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.4.1"
   package_config:
     dependency: transitive
     description:
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -468,10 +468,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   timing:
     dependency: transitive
     description:
@@ -504,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -521,5 +529,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 1.2.1
+version: 1.3.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION
**Changed**
- Lock Auth0.Android version to avoid dynamic versioning [\#311](https://github.com/auth0/auth0-flutter/pull/311) ([poovamraj](https://github.com/poovamraj))
- Add namespace to build.gradle [\#290](https://github.com/auth0/auth0-flutter/pull/290) ([poovamraj](https://github.com/poovamraj))

**Fixed**
- Fix access token expiry android [\#315](https://github.com/auth0/auth0-flutter/pull/315) ([poovamraj](https://github.com/poovamraj))
