### PR TITLE
af: Release af-v1.3.0

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [af-v1.3.0](https://github.com/auth0/auth0-flutter/tree/af-v1.3.0) (2023-10-27)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.1...af-v1.3.0)
+
+**Changed**
+- Lock Auth0.Android version to avoid dynamic versioning [\#311](https://github.com/auth0/auth0-flutter/pull/311) ([poovamraj](https://github.com/poovamraj))
+- Add namespace to build.gradle [\#290](https://github.com/auth0/auth0-flutter/pull/290) ([poovamraj](https://github.com/poovamraj))
+- af: Pin Auth0.swift and its dependencies to last version that supports iOS 12 [\#276](https://github.com/auth0/auth0-flutter/pull/276) ([Widcket](https://github.com/Widcket))
+
+**Fixed**
+- Fix access token expiry android [\#315](https://github.com/auth0/auth0-flutter/pull/315) ([poovamraj](https://github.com/poovamraj))
+- af: Use Application Context for Credentials Manager [\#289](https://github.com/auth0/auth0-flutter/pull/289) ([poovamraj](https://github.com/poovamraj))
+
 ## [v1.2.1](https://github.com/auth0/auth0-flutter/tree/v1.2.1) (2023-06-06)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/v1.2.0...v1.2.1)
 

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.2.1'
+  s.version      = '1.3.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '1.2.1';
+const String version = '1.3.0';

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android / iOS Flutter apps.
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:


### PR DESCRIPTION
**Changed**
- Lock Auth0.Android version to avoid dynamic versioning [\#311](https://github.com/auth0/auth0-flutter/pull/311) ([poovamraj](https://github.com/poovamraj))
- Add namespace to build.gradle [\#290](https://github.com/auth0/auth0-flutter/pull/290) ([poovamraj](https://github.com/poovamraj))
- af: Pin Auth0.swift and its dependencies to last version that supports iOS 12 [\#276](https://github.com/auth0/auth0-flutter/pull/276) ([Widcket](https://github.com/Widcket))

**Fixed**
- Fix access token expiry android [\#315](https://github.com/auth0/auth0-flutter/pull/315) ([poovamraj](https://github.com/poovamraj))
- af: Use Application Context for Credentials Manager [\#289](https://github.com/auth0/auth0-flutter/pull/289) ([poovamraj](https://github.com/poovamraj))