### PR TITLE
afpi: Ensure Dart `expiresAt` uses the UTC time zone

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -63,7 +63,7 @@ class Credentials {
         idToken: result['idToken'] as String,
         accessToken: result['accessToken'] as String,
         refreshToken: result['refreshToken'] as String?,
-        expiresAt: DateTime.parse(result['expiresAt'] as String),
+        expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
         scopes: Set<String>.from(result['scopes'] as List<Object?>),
         user: UserProfile.fromMap(Map<String, dynamic>.from(
             result['userProfile'] as Map<dynamic, dynamic>)),
@@ -74,7 +74,7 @@ class Credentials {
         'idToken': idToken,
         'accessToken': accessToken,
         'refreshToken': refreshToken,
-        'expiresAt': expiresAt.toIso8601String(),
+        'expiresAt': expiresAt.toUtc().toIso8601String(),
         'scopes': scopes.toList(),
         'tokenType': tokenType,
       };

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_auth_test.dart
@@ -12,7 +12,7 @@ class MethodCallHandler {
   static const Map<dynamic, dynamic> loginResultRequired = {
     'accessToken': 'accessToken',
     'idToken': 'idToken',
-    'expiresAt': '2022-01-01',
+    'expiresAt': '2023-11-01T22:16:35.760Z',
     'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'
@@ -47,7 +47,7 @@ class MethodCallHandler {
     'accessToken': 'accessToken',
     'idToken': 'idToken',
     'refreshToken': 'refreshToken',
-    'expiresAt': '2022-01-01',
+    'expiresAt': '2023-11-01T22:16:35.760Z',
     'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -12,7 +12,7 @@ class MethodCallHandler {
   static const Map<dynamic, dynamic> loginResultRequired = {
     'accessToken': 'accessToken',
     'idToken': 'idToken',
-    'expiresAt': '2022-01-01',
+    'expiresAt': '2023-11-01T22:16:35.760Z',
     'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -12,7 +12,7 @@ class MethodCallHandler {
   static const Map<dynamic, dynamic> credentials = {
     'accessToken': 'accessToken',
     'idToken': 'idToken',
-    'expiresAt': '2022-01-01',
+    'expiresAt': '2023-11-01T22:16:35.760Z',
     'scopes': ['a', 'b'],
     'userProfile': {'sub': '123', 'name': 'John Doe'},
     'tokenType': 'Bearer'


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently, both native implementations (iOS and Android) provide credentials to the Dart layer that include an `expiresAt` value formatted as ISO 8601 date with UTC time zone. More specifically, the format used follows the [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)'s profile of ISO 8601 dates, which is somewhat more restrictive for the sake of simplicity:

<img width="601" alt="Screenshot 2023-10-31 at 23 15 09" src="https://github.com/auth0/auth0-flutter/assets/5055789/f650cec8-1baf-4ac0-b08e-d5638183b506">

Among the fields that the RFC 3339 deems mandatory (that ISO 8601 does not) is the time zone. So, a RFC 3339 date must contain time zone information to be valid. The native implementations, in particular, use UTC as the time zone.

Besides passing RFC 3339 `expiresAt` dates *to* the Dart layer, the native implementations expect that any `expiresAt` dates received *from* the Dart layer also to be RFC 3339 dates. But, here comes the problem: the Dart layer generates the date strings from a [DateTime](https://api.dart.dev/stable/3.1.5/dart-core/DateTime-class.html) object. A `DateTime` can either be set as "local" time, or can be set as UTC. That is, Dart `DateTime` objects [do not support](https://github.com/dart-lang/sdk/issues/43391) time zones other than UTC and "local". And by default, they'll be set as "local", meaning that [when formatted](https://api.dart.dev/stable/3.1.5/dart-core/DateTime/toIso8601String.html) as ISO 8601 dates, they won't be RFC 3339 compliant:

<img width="726" alt="Screenshot 2023-10-31 at 23 43 40" src="https://github.com/auth0/auth0-flutter/assets/5055789/bc02c1da-b79f-4002-9812-bc4fa8afd31b">

We were not setting the `expiresAt` dates as UTC on the Dart layer. But still, this did not cause issues in most cases, because the Dart layer was dealing with `expiresAt` dates coming from the native implementations. As mentioned before, those are RFC 3339 compliant, and thus contain time zone information –the `Z` that signals UTC. It only caused issues when dealing with `DateTime` objects created externally, that were not set as UTC –e.g. as described in https://github.com/auth0/auth0-flutter/issues/304

To fix this issue, this PR enforces UTC for all `expiresAt` dates either coming *from* the native layer or going *to* the native layer, in the Dart layer.

### 📎 References

Fixes https://github.com/auth0/auth0-flutter/issues/304
See also https://ijmacd.github.io/rfc3339-iso8601/

### 🎯 Testing

Unit tests were added. The fix was also tested manually on both Android and iOS.