### PR TITLE
Fix build of Android example app on Mac ARM

### DIFF
--- a/auth0_flutter/example/android/app/build.gradle
+++ b/auth0_flutter/example/android/app/build.gradle
@@ -28,7 +28,6 @@ apply plugin: 'jacoco'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace exampleAppApplicationId
     compileSdk 31
     if (project.android.hasProperty("namespace")) {
         namespace exampleAppApplicationId
@@ -92,7 +91,7 @@ android {
             enable true
             reset()
             include 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'mips', 'mips64', 'arm64-v8a'
-            universalApk false
+            universalApk true
         }
     }
 }

--- a/auth0_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/auth0_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.auth0.auth0_flutter_example">
 
    <application
         android:label="auth0_flutter_example"


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR fixes a couple of errors preventing the build of the Android example app on Mac M2 processors.

<img width="855" alt="Screenshot 2023-11-02 at 23 21 54" src="https://github.com/auth0/auth0-flutter/assets/5055789/fe40308d-6095-4ec9-8dd3-311934ffafa1">

<img width="727" alt="Screenshot 2023-11-02 at 23 20 08" src="https://github.com/auth0/auth0-flutter/assets/5055789/6204f6f1-3416-4c3a-8164-13152b6baa6c">

