### PR TITLE
Update publish workflow for both packages

### DIFF
--- a/.github/workflows/publish-af.yml
+++ b/.github/workflows/publish-af.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
+      environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
       working-directory: auth0_flutter

--- a/.github/workflows/publish-afpi.yml
+++ b/.github/workflows/publish-afpi.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
+      environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
       working-directory: auth0_flutter_platform_interface


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the GitHub actions publish workflow for both `auth0_flutter` and `auth0_flutter_platform_interface`, as documented in https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pubdev.

Both packages have been configured in pub.dev to publish when using the GitHub `internal` environment only, in addition to the existing tag protection rules.
