### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/actions/setup-publish/action.yml
+++ b/.github/actions/setup-publish/action.yml
@@ -1,0 +1,30 @@
+name: Set up Flutter and Dart SDK for publishing
+description: Set up the environment for publishing the Flutter libraries to pub.dev
+
+inputs:
+  flutter:
+    description: The version of Flutter to use
+    required: true
+
+  working-directory:
+    description: The directory of the package to publish
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install Flutter
+      uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
+      with:
+          flutter-version: ${{ inputs.flutter }}
+          channel: stable
+          cache: true
+
+    - name: Install Flutter dependencies
+      working-directory: ${{ inputs.working-directory }}
+      run: flutter pub get
+      shell: bash
+
+    - name: Setup Dart SDK for publishing # With JWT token
+      uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d

--- a/.github/workflows/publish-af.yml
+++ b/.github/workflows/publish-af.yml
@@ -5,11 +5,28 @@ on:
     tags:
       - 'af-v[0-9]+.[0-9]+.[0-9]+*'
 
+env:
+  flutter: '3.x'
+
 jobs:
   publish:
+    name: Publish auth0_flutter to pub.dev
+    environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
-      working-directory: auth0_flutter
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup Flutter and Dart SDK
+        uses: ./.github/actions/setup-publish
+        with:
+          flutter: ${{ env.flutter }}
+          working-directory: auth0_flutter
+
+      - name: Publish
+        run: dart pub publish -f
+        working-directory: auth0_flutter

--- a/.github/workflows/publish-afpi.yml
+++ b/.github/workflows/publish-afpi.yml
@@ -5,11 +5,28 @@ on:
     tags:
       - 'afpi-v[0-9]+.[0-9]+.[0-9]+*'
 
+env:
+  flutter: '3.x'
+
 jobs:
   publish:
+    name: Publish auth0_flutter_platform_interface to pub.dev
+    environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
-      working-directory: auth0_flutter_platform_interface
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup Flutter and Dart SDK
+        uses: ./.github/actions/setup-publish
+        with:
+          flutter: ${{ env.flutter }}
+          working-directory: auth0_flutter_platform_interface
+
+      - name: Publish
+        run: dart pub publish -f
+        working-directory: auth0_flutter_platform_interface


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR fixes the CI publish workflow, as it was failing because the [dart-lang/setup-dart/.github/workflows/publish.yml@v1](https://github.com/dart-lang/setup-dart/blob/main/.github/workflows/publish.yml) action installs dependencies using `dart pub get`, but our packages depend on Flutter, and as such need to use `flutter pub get` instead:

<img width="742" alt="Screenshot 2023-11-08 at 16 41 53" src="https://github.com/auth0/auth0-flutter/assets/5055789/e3f235fe-c364-44ff-b9c9-0008dbb06c3b">


But still the Dart SDK needs to be installed using that action, as it contains [the logic](https://github.com/dart-lang/setup-dart/blob/main/lib/main.dart#L169) necessary for getting the token used for publishing.

Unlike that action, we're not adding a dry run step because it [returns a non-zero error code](https://github.com/dart-lang/pub/issues/3807#issuecomment-1602176761) (that fails the workflow) when there are warnings, and the `auth0_flutter` package produces warnings:

<img width="738" alt="Screenshot 2023-11-08 at 17 20 54" src="https://github.com/auth0/auth0-flutter/assets/5055789/d565cbb0-b623-46f7-913a-41c641908695">

We won't be fixing the warning marked with red; the scenario the warning is about does not apply for `auth0_flutter`, which will always depend on a specific version of `auth0_flutter_platform_interface`.