### PR TITLE
afpi: Fix import order for Flutter 3.16

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/auth/auth_multifactor_challenge_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth/auth_multifactor_challenge_options.dart
@@ -1,5 +1,5 @@
-import './challenge_type.dart';
 import '../request/request_options.dart';
+import './challenge_type.dart';
 
 class AuthMultifactorChallengeOptions implements RequestOptions {
   final String mfaToken;


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the import order in `auth0_flutter_platform_interface/lib/src/auth/auth_multifactor_challenge_options.dart`, as the respective analyze rule changed on Flutter 3.16, and now `flutter analyze` fails.

That is causing the CI to fail in all the other (currently) open PRs.