### PR TITLE
af: Use symlinks with relative paths 2/2

### DIFF
--- a/auth0_flutter/ios/Assets/.gitkeep
+++ b/auth0_flutter/ios/Assets/.gitkeep
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Assets/.gitkeep
+auth0_flutter/darwin/Assets/.gitkeep

--- a/auth0_flutter/ios/Classes/Auth0FlutterPlugin.h
+++ b/auth0_flutter/ios/Classes/Auth0FlutterPlugin.h
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h
+auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h

--- a/auth0_flutter/ios/Classes/Auth0FlutterPlugin.m
+++ b/auth0_flutter/ios/Classes/Auth0FlutterPlugin.m
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m
+auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerModels.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerModels.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift

--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Extensions.swift
+auth0_flutter/darwin/Classes/Extensions.swift

--- a/auth0_flutter/ios/Classes/HandlerError.swift
+++ b/auth0_flutter/ios/Classes/HandlerError.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/HandlerError.swift
+auth0_flutter/darwin/Classes/HandlerError.swift

--- a/auth0_flutter/ios/Classes/MethodHandler.swift
+++ b/auth0_flutter/ios/Classes/MethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/MethodHandler.swift
+auth0_flutter/darwin/Classes/MethodHandler.swift

--- a/auth0_flutter/ios/Classes/Models.swift
+++ b/auth0_flutter/ios/Classes/Models.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Models.swift
+auth0_flutter/darwin/Classes/Models.swift

--- a/auth0_flutter/ios/Classes/Properties.swift
+++ b/auth0_flutter/ios/Classes/Properties.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Properties.swift
+auth0_flutter/darwin/Classes/Properties.swift

--- a/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
+++ b/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift
+auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -1,1 +1,29 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/auth0_flutter.podspec
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint auth0_flutter.podspec` to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name         = 'auth0_flutter'
+  s.version      = '1.3.1'
+  s.summary      = 'Auth0 SDK for Flutter'
+  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.homepage     = 'https://auth0.com'
+  s.license      = { :file => '../LICENSE' }
+  s.author       = { 'Auth0' => 'support@auth0.com' }
+  s.source       = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+
+  s.ios.deployment_target = '13.0'
+  s.ios.dependency 'Flutter'
+
+  s.osx.deployment_target = '11.0'
+  s.osx.dependency 'FlutterMacOS'
+
+  s.dependency 'Auth0', '2.3.2'
+  s.dependency 'JWTDecode', '3.0.1'
+  s.dependency 'SimpleKeychain', '1.0.1'
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.swift_version       = ['5.3', '5.4', '5.5', '5.6', '5.7']
+end

--- a/auth0_flutter/macos/Assets/.gitkeep
+++ b/auth0_flutter/macos/Assets/.gitkeep
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Assets/.gitkeep
+auth0_flutter/darwin/Assets/.gitkeep

--- a/auth0_flutter/macos/Classes/Auth0FlutterPlugin.h
+++ b/auth0_flutter/macos/Classes/Auth0FlutterPlugin.h
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h
+auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h

--- a/auth0_flutter/macos/Classes/Auth0FlutterPlugin.m
+++ b/auth0_flutter/macos/Classes/Auth0FlutterPlugin.m
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m
+auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerModels.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerModels.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift

--- a/auth0_flutter/macos/Classes/Extensions.swift
+++ b/auth0_flutter/macos/Classes/Extensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Extensions.swift
+auth0_flutter/darwin/Classes/Extensions.swift

--- a/auth0_flutter/macos/Classes/HandlerError.swift
+++ b/auth0_flutter/macos/Classes/HandlerError.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/HandlerError.swift
+auth0_flutter/darwin/Classes/HandlerError.swift

--- a/auth0_flutter/macos/Classes/MethodHandler.swift
+++ b/auth0_flutter/macos/Classes/MethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/MethodHandler.swift
+auth0_flutter/darwin/Classes/MethodHandler.swift

--- a/auth0_flutter/macos/Classes/Models.swift
+++ b/auth0_flutter/macos/Classes/Models.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Models.swift
+auth0_flutter/darwin/Classes/Models.swift

--- a/auth0_flutter/macos/Classes/Properties.swift
+++ b/auth0_flutter/macos/Classes/Properties.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/Properties.swift
+auth0_flutter/darwin/Classes/Properties.swift

--- a/auth0_flutter/macos/Classes/SwiftAuth0FlutterPlugin.swift
+++ b/auth0_flutter/macos/Classes/SwiftAuth0FlutterPlugin.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift
+auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthExtensions.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthModels.swift
@@ -1,1 +1,1 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift
+auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -1,1 +1,29 @@
-/Users/rita/Desktop/auth0-flutter/auth0_flutter/darwin/auth0_flutter.podspec
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint auth0_flutter.podspec` to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name         = 'auth0_flutter'
+  s.version      = '1.3.1'
+  s.summary      = 'Auth0 SDK for Flutter'
+  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.homepage     = 'https://auth0.com'
+  s.license      = { :file => '../LICENSE' }
+  s.author       = { 'Auth0' => 'support@auth0.com' }
+  s.source       = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+
+  s.ios.deployment_target = '13.0'
+  s.ios.dependency 'Flutter'
+
+  s.osx.deployment_target = '11.0'
+  s.osx.dependency 'FlutterMacOS'
+
+  s.dependency 'Auth0', '2.3.2'
+  s.dependency 'JWTDecode', '3.0.1'
+  s.dependency 'SimpleKeychain', '1.0.1'
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.swift_version       = ['5.3', '5.4', '5.5', '5.6', '5.7']
+end

--- a/scripts/generate-symlinks.sh
+++ b/scripts/generate-symlinks.sh
@@ -30,10 +30,10 @@ for file in "${files[@]}"; do
         mkdir -p "$target_dir"
 
         case "$file" in
-            # If it's a .gitignore file, copy it
-            (*'.gitignore') cp -v "$file" "$target_dir" ;;
+            # If it's a .gitignore or Podspec file, copy it
+            (*'.gitignore' | *'.podspec') cp -v "$file" "$target_dir" ;;
             # Else symlink it
-            (*) ln -sv "$repo_path/$file" "$target_file" ;;
+            (*) ln -sv "$file" "$target_file" ;;
         esac
     done
 done


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The symlinks had been generated using absolute paths, which is incorrect. This PR re-generates them correctly, and modifies the generation script so that the Podspec also gets copied instead of symlinked.