### PR TITLE
Increase the timout of iOS smoke tests

### DIFF
--- a/auth0_flutter/example/ios/UITests/SmokeTests.swift
+++ b/auth0_flutter/example/ios/UITests/SmokeTests.swift
@@ -19,6 +19,7 @@ class SmokeTests: XCTestCase {
     func testLogin() {
         let app = XCUIApplication()
         app.activate()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: timeout))
         tap(button: loginButton)
         let emailInput = app.webViews.textFields.firstMatch
         XCTAssertTrue(emailInput.waitForExistence(timeout: timeout))
@@ -33,6 +34,7 @@ class SmokeTests: XCTestCase {
     func testLogout() {
         let app = XCUIApplication()
         app.activate()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: timeout))
         tap(button: loginButton)
         let sessionButton = app.webViews.staticTexts[email]
         XCTAssertTrue(sessionButton.waitForExistence(timeout: timeout))

--- a/auth0_flutter/example/ios/UITests/SmokeTests.swift
+++ b/auth0_flutter/example/ios/UITests/SmokeTests.swift
@@ -6,7 +6,7 @@ class SmokeTests: XCTestCase {
     private let loginButton = "Web Auth Login"
     private let logoutButton = "Web Auth Logout"
     private let continueButton = "Continue"
-    private let timeout: TimeInterval = 10
+    private let timeout: TimeInterval = 30
 
     override func setUp() {
         continueAfterFailure = false


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently, the iOS smoke tests have a timeout of 10 seconds when waiting for UI elements to appear. Looking at recent failures, this value does not seem to be enough, as the UL page hasn't finished rendering by the time this timeout expires:

<img width="867" alt="Screenshot 2023-11-25 at 00 01 53" src="https://github.com/auth0/auth0-flutter/assets/5055789/1ed0da40-01e6-497f-9366-35c98f2c8d1f">

This PR raises the timeout to 30m seconds to give the UL page enough time to finish rendering.
