### PR TITLE
Add support for passing parameters onLoad

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -180,6 +180,15 @@ final credentials = await auth0
 <details>
   <summary>Web</summary>
 
+Custom parameters can be configured globally.
+
+```dart
+await auth0Web.onLoad(
+    parameters: {'connection': 'github'});
+```
+
+Custom parameters can be configured when calling `loginWithRedirect`. Any globally configured parameter (passed to `onLoad()`) can be overriden when passing the same custom parameter to `loginWithRedirect`.
+
 ```dart
 await auth0Web.loginWithRedirect(
     redirectUrl: 'http://localhost:3000',

--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -51,7 +51,8 @@ class Auth0Web {
       final bool? useRefreshTokens,
       final bool? useRefreshTokensFallback,
       final String? audience,
-      final Set<String>? scopes}) async {
+      final Set<String>? scopes,
+      final Map<String, String> parameters = const {}}) async {
     await Auth0FlutterWebPlatform.instance.initialize(
         ClientOptions(
             account: _account,
@@ -68,7 +69,8 @@ class Auth0Web {
             useRefreshTokens: useRefreshTokens,
             useRefreshTokensFallback: useRefreshTokensFallback,
             audience: audience,
-            scopes: scopes),
+            scopes: scopes,
+            parameters: parameters),
         _userAgent);
 
     if (await hasValidCredentials()) {

--- a/auth0_flutter/lib/src/web/extensions/client_options_extensions.dart
+++ b/auth0_flutter/lib/src/web/extensions/client_options_extensions.dart
@@ -21,7 +21,12 @@ extension ClientOptionsExtension on ClientOptions {
           useFormData: useFormData,
           useRefreshTokens: useRefreshTokens,
           useRefreshTokensFallback: useRefreshTokensFallback,
-          authorizationParams: JsInteropUtils.stripNulls(AuthorizationParams(
-              audience: audience,
-              scope: scopes?.isNotEmpty == true ? scopes?.join(' ') : null)));
+          authorizationParams: JsInteropUtils.stripNulls(
+              JsInteropUtils.addCustomParams(
+                  AuthorizationParams(
+                      audience: audience,
+                      scope: scopes?.isNotEmpty == true
+                          ? scopes?.join(' ')
+                          : null),
+                  parameters)));
 }

--- a/auth0_flutter_platform_interface/lib/src/web/client_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web/client_options.dart
@@ -105,6 +105,9 @@ class ClientOptions {
   /// Note: The openid scope is always applied regardless of this setting.
   final Set<String>? scopes;
 
+  /// The default additional parameters to be sent to Auth0.
+  final Map<String, String> parameters;
+
   ClientOptions(
       {required this.account,
       this.authorizeTimeoutInSeconds,
@@ -119,5 +122,6 @@ class ClientOptions {
       this.useRefreshTokensFallback,
       this.idTokenValidationConfig,
       this.audience,
-      this.scopes});
+      this.scopes,
+      this.parameters = const {}});
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Adds support for passing custom parameters to onLoad, which are used as global custom parameters in the underlying Auth0-SPA-JS SDK.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

Closes #345

### 🎯 Testing

Update the sample application [here](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/example/lib/example_app.dart#L37):
```
auth0Web.onLoad(parameters: {'foo': 'bar'}).then((final credentials) => setState(() {
  _output = credentials?.idToken ?? '';
  _isLoggedIn = credentials != null;
}));
```
