### PR TITLE
af: Install Kover from the library's Gradle config

### DIFF
--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -1,10 +1,5 @@
-def libApplicationId = 'com.auth0.auth0_flutter'
-
-group libApplicationId
-version '1.0-SNAPSHOT'
-
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
@@ -16,16 +11,24 @@ buildscript {
     }
 }
 
+plugins {
+    id("org.jetbrains.kotlinx.kover") version "0.7.4"
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+def libApplicationId = 'com.auth0.auth0_flutter'
+
+group libApplicationId
+version '1.0-SNAPSHOT'
+
 rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
     }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.kotlinx.kover'
 
 android {
     compileSdkVersion 31


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR makes sure the Kover Gradle plugin is properly installed on the library's Gradle config. Previously, it was installed on the example app's config and *applied* on the library's config. When installed on another app, it couldn't find the plugin.

### 📎 References

Fixes https://github.com/auth0/auth0-flutter/issues/369

### 🎯 Testing

This was tested manually on the Quickstart sample app.