### PR TITLE
Use Xcode 15 to run iOS smoke tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
     test-ios-smoke:
         name: Run native iOS smoke tests using Xcode ${{ matrix.xcode }}
         needs: authorize
-        runs-on: macos-latest-large
+        runs-on: macos-13-large
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         env:
@@ -184,7 +184,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '14.2'
+              - '15.0.1'
 
         steps:
             - name: Checkout
@@ -203,7 +203,7 @@ jobs:
               uses: ./.github/actions/smoke-tests-darwin
               with:
                 platform: ${{ env.platform }}
-                destination: 'platform=iOS Simulator,name=iPhone 14'
+                destination: ${{ format('{0}{1}', 'platform=iOS Simulator,name=', env.ios-simulator) }}
 
     test-macos-unit:
         name: Run native macOS unit tests using Xcode ${{ matrix.xcode }}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the iOS smoke test job to use Xcode 15.0.1.