### PR TITLE
af: Update symlinks script to use relative path from symlink location

### DIFF
--- a/auth0_flutter/ios/Assets/.gitkeep
+++ b/auth0_flutter/ios/Assets/.gitkeep
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Assets/.gitkeep
+../../darwin/Assets/.gitkeep

--- a/auth0_flutter/ios/Classes/Auth0FlutterPlugin.h
+++ b/auth0_flutter/ios/Classes/Auth0FlutterPlugin.h
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h
+../../darwin/Classes/Auth0FlutterPlugin.h

--- a/auth0_flutter/ios/Classes/Auth0FlutterPlugin.m
+++ b/auth0_flutter/ios/Classes/Auth0FlutterPlugin.m
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m
+../../darwin/Classes/Auth0FlutterPlugin.m

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift
+../../../darwin/Classes/AuthAPI/AuthAPIExtensions.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift

--- a/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerModels.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerModels.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerModels.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift

--- a/auth0_flutter/ios/Classes/Extensions.swift
+++ b/auth0_flutter/ios/Classes/Extensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Extensions.swift
+../../darwin/Classes/Extensions.swift

--- a/auth0_flutter/ios/Classes/HandlerError.swift
+++ b/auth0_flutter/ios/Classes/HandlerError.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/HandlerError.swift
+../../darwin/Classes/HandlerError.swift

--- a/auth0_flutter/ios/Classes/MethodHandler.swift
+++ b/auth0_flutter/ios/Classes/MethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/MethodHandler.swift
+../../darwin/Classes/MethodHandler.swift

--- a/auth0_flutter/ios/Classes/Models.swift
+++ b/auth0_flutter/ios/Classes/Models.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Models.swift
+../../darwin/Classes/Models.swift

--- a/auth0_flutter/ios/Classes/Properties.swift
+++ b/auth0_flutter/ios/Classes/Properties.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Properties.swift
+../../darwin/Classes/Properties.swift

--- a/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
+++ b/auth0_flutter/ios/Classes/SwiftAuth0FlutterPlugin.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift
+../../darwin/Classes/SwiftAuth0FlutterPlugin.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift
+../../../darwin/Classes/WebAuth/WebAuthExtensions.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift

--- a/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/ios/Classes/WebAuth/WebAuthModels.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift
+../../../darwin/Classes/WebAuth/WebAuthModels.swift

--- a/auth0_flutter/macos/Assets/.gitkeep
+++ b/auth0_flutter/macos/Assets/.gitkeep
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Assets/.gitkeep
+../../darwin/Assets/.gitkeep

--- a/auth0_flutter/macos/Classes/Auth0FlutterPlugin.h
+++ b/auth0_flutter/macos/Classes/Auth0FlutterPlugin.h
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Auth0FlutterPlugin.h
+../../darwin/Classes/Auth0FlutterPlugin.h

--- a/auth0_flutter/macos/Classes/Auth0FlutterPlugin.m
+++ b/auth0_flutter/macos/Classes/Auth0FlutterPlugin.m
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Auth0FlutterPlugin.m
+../../darwin/Classes/Auth0FlutterPlugin.m

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIExtensions.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIExtensions.swift
+../../../darwin/Classes/AuthAPI/AuthAPIExtensions.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPILoginUsernameOrEmailMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPILoginWithOTPMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIMultifactorChallengeMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIRenewMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIResetPasswordMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPISignupMethodHandler.swift

--- a/auth0_flutter/macos/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift
+../../../darwin/Classes/AuthAPI/AuthAPIUserInfoMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerClearMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerExtensions.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerGetMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerHasValidMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerModels.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerModels.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerModels.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerModels.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift
+../../../darwin/Classes/CredentialsManager/CredentialsManagerSaveMethodHandler.swift

--- a/auth0_flutter/macos/Classes/Extensions.swift
+++ b/auth0_flutter/macos/Classes/Extensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Extensions.swift
+../../darwin/Classes/Extensions.swift

--- a/auth0_flutter/macos/Classes/HandlerError.swift
+++ b/auth0_flutter/macos/Classes/HandlerError.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/HandlerError.swift
+../../darwin/Classes/HandlerError.swift

--- a/auth0_flutter/macos/Classes/MethodHandler.swift
+++ b/auth0_flutter/macos/Classes/MethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/MethodHandler.swift
+../../darwin/Classes/MethodHandler.swift

--- a/auth0_flutter/macos/Classes/Models.swift
+++ b/auth0_flutter/macos/Classes/Models.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Models.swift
+../../darwin/Classes/Models.swift

--- a/auth0_flutter/macos/Classes/Properties.swift
+++ b/auth0_flutter/macos/Classes/Properties.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/Properties.swift
+../../darwin/Classes/Properties.swift

--- a/auth0_flutter/macos/Classes/SwiftAuth0FlutterPlugin.swift
+++ b/auth0_flutter/macos/Classes/SwiftAuth0FlutterPlugin.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/SwiftAuth0FlutterPlugin.swift
+../../darwin/Classes/SwiftAuth0FlutterPlugin.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthExtensions.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthExtensions.swift
+../../../darwin/Classes/WebAuth/WebAuthExtensions.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthLoginMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthLoginMethodHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift
+../../../darwin/Classes/WebAuth/WebAuthLogoutMethodHandler.swift

--- a/auth0_flutter/macos/Classes/WebAuth/WebAuthModels.swift
+++ b/auth0_flutter/macos/Classes/WebAuth/WebAuthModels.swift
@@ -1,1 +1,1 @@
-auth0_flutter/darwin/Classes/WebAuth/WebAuthModels.swift
+../../../darwin/Classes/WebAuth/WebAuthModels.swift

--- a/scripts/generate-symlinks.sh
+++ b/scripts/generate-symlinks.sh
@@ -33,7 +33,14 @@ for file in "${files[@]}"; do
             # If it's a .gitignore or Podspec file, copy it
             (*'.gitignore' | *'.podspec') cp -v "$file" "$target_dir" ;;
             # Else symlink it
-            (*) ln -sv "$file" "$target_file" ;;
+            (*)
+                # Calculate the relative path to the file from the symlink's
+                # location
+                file_subpath=${file#"$base_dir/"}
+                file_depth=$(echo "$file_subpath" | awk -F '/' '{print NF-1}')
+                file_relpath=$(printf '../%.0s' $(seq 1 $file_depth))
+
+                ln -sv "$file_relpath$file_subpath" "$target_file" ;;
         esac
     done
 done


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

`flutter pub publish` errors with the current symlinks. This PR updates the `generate-symlinks.sh` script to use the relative path from the symlink's location, and includes the regenerated symlinks.

<img width="828" alt="Screenshot 2023-12-15 at 15 24 39" src="https://github.com/auth0/auth0-flutter/assets/5055789/7a447896-9592-49ff-a06a-d22f24c4f185">

With these changes, `flutter pub publish --dry-run` does not error anymore.

### 🎯 Testing

The changes were tested manually with both the QS sample app, and the example app included in this repository.