### PR TITLE
Avoid Z as it represents UTC

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -39,7 +39,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -70,7 +70,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

We are removing using 'Z' in timestamp as it denotes UTC and we are representing the value in local time

### 📎 References
https://github.com/auth0/auth0-flutter/pull/315

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
