### PR TITLE
afpi: Release afpi-v1.6.0

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [afpi-v1.6.0](https://github.com/auth0/auth0-flutter/tree/afpi-v1.6.0) (2024-03-18)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v1.5.0...afpi-v1.6.0)
+
+**Added**
+- Add support for HTTPS redirect URLs [SDK-4754] [\#417](https://github.com/auth0/auth0-flutter/pull/417) ([Widcket](https://github.com/Widcket))
+
 ## [afpi-v1.5.0](https://github.com/auth0/auth0-flutter/tree/afpi-v1.5.0) (2023-12-15)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v1.4.0...afpi-v1.5.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 1.5.0
+version: 1.6.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Added**
- Add support for HTTPS redirect URLs [SDK-4754] [\#417](https://github.com/auth0/auth0-flutter/pull/417) ([Widcket](https://github.com/Widcket))


[SDK-4754]: https://auth0team.atlassian.net/browse/SDK-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ