### PR TITLE
Add UserProfile.toMap and unit test

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -76,6 +76,7 @@ class Credentials {
         'refreshToken': refreshToken,
         'expiresAt': expiresAt.toUtc().toIso8601String(),
         'scopes': scopes.toList(),
+        'userProfile': user.toMap(),
         'tokenType': tokenType,
       };
 }

--- a/auth0_flutter_platform_interface/lib/src/user_profile.dart
+++ b/auth0_flutter_platform_interface/lib/src/user_profile.dart
@@ -163,4 +163,28 @@ class UserProfile {
                 result['custom_claims'] as Map<dynamic, dynamic>)
             : null,
       );
+
+  Map<String, dynamic> toMap() => {
+        'sub': sub,
+        'name': name,
+        'given_name': givenName,
+        'family_name': familyName,
+        'middle_name': middleName,
+        'nickname': nickname,
+        'preferred_username': preferredUsername,
+        'profile': profileUrl?.toString(),
+        'picture': pictureUrl?.toString(),
+        'website': websiteUrl?.toString(),
+        'email': email,
+        'email_verified': isEmailVerified,
+        'gender': gender,
+        'birthdate': birthdate,
+        'zoneinfo': zoneinfo,
+        'locale': locale,
+        'phone_number': phoneNumber,
+        'phone_number_verified': isPhoneNumberVerified,
+        'address': address,
+        'updated_at': updatedAt?.toUtc().toIso8601String(),
+        'custom_claims': customClaims,
+      };
 }

--- a/auth0_flutter_platform_interface/test/credentials_test.dart
+++ b/auth0_flutter_platform_interface/test/credentials_test.dart
@@ -75,6 +75,57 @@ void main() {
 
       expect(credentials.toMap()['expiresAt'], '2023-11-01T22:16:35.760Z');
     });
+
+    test('converting to a map and back again populates the user property', () {
+      final dateTime = DateTime.utc(2023, 11, 2);
+      final updatedAt = DateTime.utc(2024, 10, 3);
+      const userName = 'User name';
+      const customClaimValue = 1;
+      const exampleUrl =
+          'https://store.google.com/ca/product/pixel_tablet?hl=en-GB';
+
+      final credentials = Credentials(
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        refreshToken: 'refreshToken',
+        expiresAt: dateTime,
+        scopes: {'a'},
+        user: UserProfile(
+          sub: 'sub',
+          name: userName,
+          givenName: 'givenName',
+          familyName: 'familyName',
+          middleName: 'middleName',
+          nickname: 'nickname',
+          preferredUsername: 'preferredUsername',
+          profileUrl: Uri.parse(exampleUrl),
+          pictureUrl: Uri.parse(exampleUrl),
+          websiteUrl: Uri.parse(exampleUrl),
+          email: 'email',
+          isEmailVerified: true,
+          gender: 'gender',
+          birthdate: 'birthdate',
+          zoneinfo: 'zoneinfo',
+          locale: 'locale',
+          phoneNumber: 'phoneNumber',
+          isPhoneNumberVerified: true,
+          address: {
+            'line_1': '123 Fox Lane',
+          },
+          updatedAt: updatedAt,
+          customClaims: {
+            'my_claim': customClaimValue,
+          },
+        ),
+        tokenType: 'Bearer',
+      );
+
+      final result = Credentials.fromMap(credentials.toMap());
+
+      expect(result.user.name, userName);
+      expect(result.user.customClaims?['my_claim'], customClaimValue);
+      expect(result.user.websiteUrl?.toString(), exampleUrl);
+    });
   });
 }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

- Added `UserProfile.toMap()` method
- Added call to the above function in `Credentials.toMap()` to add the result in there

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

https://github.com/auth0/auth0-flutter/issues/379

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Unit test added which converts to/from map and checks the result