### PR TITLE
(af) chore: upgraded dependency on Auth0.swift to 2.7.1 to fix the declaration of privacy manifest

### DIFF
--- a/auth0_flutter/darwin/auth0_flutter.podspec
+++ b/auth0_flutter/darwin/auth0_flutter.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '11.0'
   s.osx.dependency 'FlutterMacOS'
 
-  s.dependency 'Auth0', '2.7.0'
+  s.dependency 'Auth0', '2.7.1'
   s.dependency 'JWTDecode', '3.1.0'
   s.dependency 'SimpleKeychain', '1.1.0'
 

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '11.0'
   s.osx.dependency 'FlutterMacOS'
 
-  s.dependency 'Auth0', '2.7.0'
+  s.dependency 'Auth0', '2.7.1'
   s.dependency 'JWTDecode', '3.1.0'
   s.dependency 'SimpleKeychain', '1.1.0'
 

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '11.0'
   s.osx.dependency 'FlutterMacOS'
 
-  s.dependency 'Auth0', '2.7.0'
+  s.dependency 'Auth0', '2.7.1'
   s.dependency 'JWTDecode', '3.1.0'
   s.dependency 'SimpleKeychain', '1.1.0'
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Upgraded dependency on Auth0.swift to 2.7.1 to fix the declaration of privacy manifest

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

https://github.com/auth0/Auth0.swift/issues/845
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Tried building the sample app using the version `2.7.1` of `Auth0.swift` by linking the pod as a static library, static & dynamic framework and it was **successful** in all the cases, where as building with version `2.7.0` when linking `Auth0.swift` as either a static library/framework resulted in an error message saying `Multiple commands produce PrivacyInfo.xcprivacy` as shown below:

<img width="954" alt="image" src="https://github.com/auth0/auth0-flutter/assets/48179357/cf66dc40-83b8-40a6-adfa-12c23b289009">


<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
