### PR TITLE
Release af-v1.7.1

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [af-v1.7.1](https://github.com/auth0/auth0-flutter/tree/af-v1.7.1) (2024-05-03)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v1.7.0...af-v1.7.1)
+
+**Fixed**
+- (af) chore: upgraded dependency on Auth0.swift to 2.7.1 to fix the declaration of privacy manifest [\#448](https://github.com/auth0/auth0-flutter/pull/448) ([desusai7](https://github.com/desusai7))
+
 ## [af-v1.7.0](https://github.com/auth0/auth0-flutter/tree/af-v1.7.0) (2024-04-22)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v1.6.0...af-v1.7.0)
 

--- a/auth0_flutter/darwin/auth0_flutter.podspec
+++ b/auth0_flutter/darwin/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.7.0'
+  s.version      = '1.7.1'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.7.0'
+  s.version      = '1.7.1'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '1.7.0';
+const String version = '1.7.1';

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.7.0'
+  s.version      = '1.7.1'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android / iOS Flutter apps.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  auth0_flutter_platform_interface: ^1.6.0
+  auth0_flutter_platform_interface: ^1.7.0
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION

**Fixed**
- (af) chore: upgraded dependency on Auth0.swift to 2.7.1 to fix the declaration of privacy manifest [\#448](https://github.com/auth0/auth0-flutter/pull/448) ([desusai7](https://github.com/desusai7))
