### PR TITLE
Stop ignoring timezone when deserializing/parsing expiresAt field on Android

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -55,7 +55,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -43,7 +43,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -47,7 +47,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -39,7 +39,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -70,7 +70,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -49,7 +49,7 @@ class LoginWebAuthRequestHandlerTest {
     fun `handler should log in using the Auth0 SDK`() {
         runRequestHandler { result, builder ->
             val sdf =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
             val formattedDate = sdf.format(defaultCredentials.expiresAt)
 
@@ -329,7 +329,7 @@ class LoginWebAuthRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandlerTest.kt
@@ -348,7 +348,7 @@ class LoginApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
@@ -154,7 +154,7 @@ class LoginWithOtpApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
@@ -233,7 +233,7 @@ class RenewApiRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandlerTest.kt
@@ -317,7 +317,7 @@ class GetCredentialsRequestHandlerTest {
         verify(mockResult).success(captor.capture())
 
         val sdf =
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
 
         val formattedDate = sdf.format(credentials.expiresAt)
 


### PR DESCRIPTION
### 📋 Changes

Avoids losing timezone of the `expiresAt` field of access tokens when parsing them back from the `SecureCredentialsManager` gives us.

Note: I am currently assessing whether the Swift implementation suffers from the same bug or not.

### 🎯 Testing

Set a known expiration date in Auth0 on a test application, and print/observe the `expiresAt` field on the Flutter side. It will be local time interpreted as UTC, meaning that in my tests in CEST +02:00, the tokens would be marked as expiring in 2h and 60s when they would really expire after 60s.