### PR TITLE
Make sure SimpleDateFormat is set to UTC timezone

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -56,6 +56,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -44,6 +44,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
                 val formattedDate = sdf.format(credentials.expiresAt)
                 result.success(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -10,6 +10,7 @@ import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 private const val AUTH_RENEW_METHOD = "auth#renew"
 
@@ -48,6 +49,7 @@ class RenewApiRequestHandler : ApiRequestHandler {
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -40,6 +40,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -33,6 +33,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
         }
 
         val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        format.setTimeZone(TimeZone.getTimeZone("UTC"))
         val date = format.parse(credentials.get("expiresAt") as String)
 
         credentialsManager.saveCredentials(Credentials(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -71,6 +71,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
                 val scopes = credentials.scope?.split(" ") ?: listOf()
                 val sdf =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
                 val formattedDate = sdf.format(credentials.expiresAt)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandlerTest.kt
@@ -234,6 +234,7 @@ class RenewApiRequestHandlerTest {
 
         val sdf =
             SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
 
         val formattedDate = sdf.format(credentials.expiresAt)
 


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

After spending quite some time trying to understand why our access tokens would not be refreshed, I realized that something was wrong with the `expiresAt` field. The issue affects (at least) Android because the UTC timezone is added in the format while the formatter itself is timezone-unaware.

With the following added print statements, you can observe that the `Credentials.expiresAt` is formatted from local time with an appended Z, which means we lose the timezone information.

```
I/System.out(18918): RenewApiRequestHandler::onSuccess credentials.expiresAt Tue Jul 23 08:49:05 GMT+02:00 2024
I/System.out(18918): RenewApiRequestHandler::onSuccess formattedDate 2024-07-23T08:49:05.555Z
```

Making sure all `SimpleDateFormat` are set to the UTC timezone fixes the issue, but since `java.util.Date` is notably confusing to work with, a better fix would maybe be to use `java.time.Instant` (see alternative PR #469) and either call `.toInstant().toString()` everywhere (and `Instant.parse()`) which always work with ISO-8601 representation.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Print the `expiresAt` date in Flutter with and without this patch. This unit tests didn't catch this problem because the test had the same implementation issue.