### PR TITLE
Use java.time.Instant instead of java.text.SimpleDateFormat

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginApiRequestHandler.kt
@@ -8,7 +8,6 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
 import java.util.*
 
 private const val AUTH_LOGIN_METHOD = "auth#login"
@@ -54,10 +53,7 @@ class LoginApiRequestHandler : ApiRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
-                val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-
-                val formattedDate = sdf.format(credentials.expiresAt)
+                val formattedDate = credentials.expiresAt.toInstant().toString()
                 result.success(
                     mapOf(
                         "accessToken" to credentials.accessToken,

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -8,7 +8,6 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
 import java.util.*
 
 private const val AUTH_LOGIN_OTP_METHOD = "auth#loginOtp"
@@ -42,10 +41,7 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scope = credentials.scope?.split(" ") ?: listOf()
-                val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-
-                val formattedDate = sdf.format(credentials.expiresAt)
+                var formattedDate = credentials.expiresAt.toInstant().toString()
                 result.success(
                     mapOf(
                         "accessToken" to credentials.accessToken,

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -43,11 +43,8 @@ class RenewApiRequestHandler : ApiRequestHandler {
             }
 
             override fun onSuccess(credentials: Credentials) {
-                println("RenewApiRequestHandler::onSuccess credentials.expiresAt ${credentials.expiresAt}");
                 val scope = credentials.scope?.split(" ") ?: listOf()
                 val formattedDate = credentials.expiresAt.toInstant().toString();
-
-                println("RenewApiRequestHandler::onSuccess formattedDate ${formattedDate}");
 
                 result.success(
                     mapOf(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/RenewApiRequestHandler.kt
@@ -8,8 +8,6 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 private const val AUTH_RENEW_METHOD = "auth#renew"
 
@@ -45,11 +43,11 @@ class RenewApiRequestHandler : ApiRequestHandler {
             }
 
             override fun onSuccess(credentials: Credentials) {
+                println("RenewApiRequestHandler::onSuccess credentials.expiresAt ${credentials.expiresAt}");
                 val scope = credentials.scope?.split(" ") ?: listOf()
-                val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+                val formattedDate = credentials.expiresAt.toInstant().toString();
 
-                val formattedDate = sdf.format(credentials.expiresAt)
+                println("RenewApiRequestHandler::onSuccess formattedDate ${formattedDate}");
 
                 result.success(
                     mapOf(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetCredentialsRequestHandler.kt
@@ -8,7 +8,6 @@ import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
 import java.util.*
 
 class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
@@ -38,11 +37,7 @@ class GetCredentialsRequestHandler : CredentialsManagerRequestHandler {
 
             override fun onSuccess(credentials: Credentials) {
                 val scopes = credentials.scope?.split(" ") ?: listOf()
-                val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-
-                val formattedDate = sdf.format(credentials.expiresAt)
-
+                val formattedDate = credentials.expiresAt.toInstant().toString()
                 result.success(
                     mapOf(
                         "accessToken" to credentials.accessToken,

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -6,8 +6,7 @@ import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
-import java.time.LocalDate
+import java.time.Instant
 import java.util.*
 
 
@@ -32,15 +31,18 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
             scope = scopes.joinToString(separator = " ")
         }
 
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-        val date = format.parse(credentials.get("expiresAt") as String)
+        println("SaveCredentialsRequestHandler::get " + credentials.get("expiresAt"))
+
+        val instant = Instant.parse(credentials.get("expiresAt") as String)
+
+        println("SaveCredentialsRequestHandler Instant::parse " + instant)
 
         credentialsManager.saveCredentials(Credentials(
             credentials.get("idToken") as String,
             credentials.get("accessToken") as String,
             credentials.get("tokenType") as String,
             credentials.get("refreshToken") as String?,
-            date,
+            Date.from(instant),
             scope,
         ))
         result.success(true)

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/SaveCredentialsRequestHandler.kt
@@ -31,11 +31,7 @@ class SaveCredentialsRequestHandler : CredentialsManagerRequestHandler {
             scope = scopes.joinToString(separator = " ")
         }
 
-        println("SaveCredentialsRequestHandler::get " + credentials.get("expiresAt"))
-
         val instant = Instant.parse(credentials.get("expiresAt") as String)
-
-        println("SaveCredentialsRequestHandler Instant::parse " + instant)
 
         credentialsManager.saveCredentials(Credentials(
             credentials.get("idToken") as String,

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -8,7 +8,6 @@ import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
-import java.text.SimpleDateFormat
 import java.util.*
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
@@ -69,10 +68,7 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
             override fun onSuccess(credentials: Credentials) {
                 // Success! Access token and ID token are presents
                 val scopes = credentials.scope?.split(" ") ?: listOf()
-                val sdf =
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-
-                val formattedDate = sdf.format(credentials.expiresAt)
+                val formattedDate = credentials.expiresAt.toInstant().toString()
 
                 result.success(
                     mapOf(

--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -58,21 +58,17 @@ class Credentials {
     required this.tokenType,
   });
 
-  factory Credentials.fromMap(final Map<dynamic, dynamic> result) {
-    print("Credentials::fromMap result.expiresAt ${result['expiresAt']}");
-    print(
-        "Credentials::fromMap result.expiresAt DateTime::parse().toUtc() ${DateTime.parse(result['expiresAt'] as String).toUtc()}");
-    return Credentials(
-      idToken: result['idToken'] as String,
-      accessToken: result['accessToken'] as String,
-      refreshToken: result['refreshToken'] as String?,
-      expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
-      scopes: Set<String>.from(result['scopes'] as List<Object?>),
-      user: UserProfile.fromMap(Map<String, dynamic>.from(
-          result['userProfile'] as Map<dynamic, dynamic>)),
-      tokenType: result['tokenType'] as String,
-    );
-  }
+  factory Credentials.fromMap(final Map<dynamic, dynamic> result) =>
+      Credentials(
+        idToken: result['idToken'] as String,
+        accessToken: result['accessToken'] as String,
+        refreshToken: result['refreshToken'] as String?,
+        expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
+        scopes: Set<String>.from(result['scopes'] as List<Object?>),
+        user: UserProfile.fromMap(Map<String, dynamic>.from(
+            result['userProfile'] as Map<dynamic, dynamic>)),
+        tokenType: result['tokenType'] as String,
+      );
 
   Map<String, dynamic> toMap() => {
         'idToken': idToken,

--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -58,17 +58,21 @@ class Credentials {
     required this.tokenType,
   });
 
-  factory Credentials.fromMap(final Map<dynamic, dynamic> result) =>
-      Credentials(
-        idToken: result['idToken'] as String,
-        accessToken: result['accessToken'] as String,
-        refreshToken: result['refreshToken'] as String?,
-        expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
-        scopes: Set<String>.from(result['scopes'] as List<Object?>),
-        user: UserProfile.fromMap(Map<String, dynamic>.from(
-            result['userProfile'] as Map<dynamic, dynamic>)),
-        tokenType: result['tokenType'] as String,
-      );
+  factory Credentials.fromMap(final Map<dynamic, dynamic> result) {
+    print("Credentials::fromMap result.expiresAt ${result['expiresAt']}");
+    print(
+        "Credentials::fromMap result.expiresAt DateTime::parse().toUtc() ${DateTime.parse(result['expiresAt'] as String).toUtc()}");
+    return Credentials(
+      idToken: result['idToken'] as String,
+      accessToken: result['accessToken'] as String,
+      refreshToken: result['refreshToken'] as String?,
+      expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
+      scopes: Set<String>.from(result['scopes'] as List<Object?>),
+      user: UserProfile.fromMap(Map<String, dynamic>.from(
+          result['userProfile'] as Map<dynamic, dynamic>)),
+      tokenType: result['tokenType'] as String,
+    );
+  }
 
   Map<String, dynamic> toMap() => {
         'idToken': idToken,


### PR DESCRIPTION
### 📋 Changes

After spending quite some time trying to understand why our access tokens would not be refreshed, I realized that something was wrong with the `expiresAt` field. The issue affects (at least) Android because the UTC timezone is added in the format while the formatter itself is timezone-unaware.

With the following added print statements, you can observe that the `Credentials.expiresAt` is formatted from local time with an appended Z, which means we lose the timezone information.

```
I/System.out(18918): RenewApiRequestHandler::onSuccess credentials.expiresAt Tue Jul 23 08:49:05 GMT+02:00 2024
I/System.out(18918): RenewApiRequestHandler::onSuccess formattedDate 2024-07-23T08:49:05.555Z
```

Making sure all `SimpleDateFormat` are set to the UTC timezone fixes the issue, but since `java.util.Date` is notably confusing to work with, a better fix is to switch to `java.time.Instant` and use `Instant.toString()` as well as `Instant.parse()` which work with ISO-8601 formatting.

### 🎯 Testing

Making sure the tests still use `SimpleDateFormat` is a great way to avoid having the actual implementation have the same bug than the tests. Unit tests should be good enough in that case.