### PR TITLE
Replaced pull_request_target with pull_request to fix the workflow security issue

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,6 +1,6 @@
 name: "PR Title Checker"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION



### 📋 Changes

Replace `pull_request_target ` with `pull_request ` in the github workflow