### PR TITLE
Set `compileSdk` to `34` to match Auth0.Android

### DIFF
--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -31,7 +31,7 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
     if (project.android.hasProperty("namespace")) {
         namespace libApplicationId
     }

--- a/auth0_flutter/example/android/app/build.gradle
+++ b/auth0_flutter/example/android/app/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'org.jetbrains.kotlinx.kover'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdk 31
+    compileSdk 34
     if (project.android.hasProperty("namespace")) {
         namespace exampleAppApplicationId
     }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR sets the `compileSdk` to `34`, to match the value currently used in Auth0.Android: https://github.com/auth0/Auth0.Android/blob/3.2.1/auth0/build.gradle#L37

### 📎 References

Closes #488 