### PR TITLE
Use actions/upload-artifact@v4 on CI workflows

### DIFF
--- a/.github/actions/smoke-tests-darwin/action.yml
+++ b/.github/actions/smoke-tests-darwin/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
 
     - name: Upload xcresult bundles
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: '${{ inputs.platform }} xcresult bundles (smoke tests)'

--- a/.github/actions/unit-tests-darwin/action.yml
+++ b/.github/actions/unit-tests-darwin/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - name: Upload xcresult bundles
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: '${{ inputs.platform }} xcresult bundles (unit tests)'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
                 flutter test --coverage --exclude-tags browser
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+              uses: actions/upload-artifact@v4
               with:
                 name: auth0_flutter coverage
                 path: auth0_flutter/coverage/lcov.info
@@ -112,7 +112,7 @@ jobs:
               run: flutter test --coverage
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+              uses: actions/upload-artifact@v4
               with:
                 name: auth0_flutter_platform_interface coverage
                 path: auth0_flutter_platform_interface/coverage/lcov.info
@@ -154,7 +154,7 @@ jobs:
               run: bundle exec slather coverage -x --scheme Runner Runner.xcodeproj
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+              uses: actions/upload-artifact@v4
               with:
                 name: iOS coverage
                 path: auth0_flutter/example/ios/cobertura
@@ -289,13 +289,13 @@ jobs:
               run: ./gradlew koverXmlReportDebug
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+              uses: actions/upload-artifact@v4
               with:
                 name: Android coverage
                 path: auth0_flutter/example/build/app/coverage.xml
 
             - name: Upload test results
-              uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+              uses: actions/upload-artifact@v4
               if: ${{ failure() }}
               with:
                 name: Test results
@@ -392,14 +392,14 @@ jobs:
     #               USER_EMAIL=$USER_EMAIL USER_PASSWORD=$USER_PASSWORD node appium-test/test.js
 
     #         - name: Upload recording
-    #           uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    #           uses: actions/upload-artifact@v4
     #           if: ${{ failure() }}
     #           with:
     #             name: 'Android - smoke tests recording'
     #             path: recording_video.webm
 
     #         - name: Upload APK
-    #           uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    #           uses: actions/upload-artifact@v4
     #           if: ${{ failure() }}
     #           with:
     #             name: 'Android - APK'


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR pins all usages of `actions/upload-artifact` to v4. This is necessary because Dependabot does not seem to be able to bump the version of `actions/upload-artifact` used inside composite actions, leading to a version mismatch between:

- Workflows using `actions/upload-artifact` directly
- Workflows using `actions/upload-artifact` indirectly, through a composite action