### PR TITLE
Make sure `flutter analyze` warnings and infos don't fail CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: Analize auth0_flutter package
               working-directory: auth0_flutter
-              run: flutter analyze
+              run: flutter analyze --no-fatal-warnings --no-fatal-infos
 
     analyze-auth0_flutter_platform_interface:
         name: Analyze auth0_flutter_platform_interface Flutter package
@@ -59,7 +59,7 @@ jobs:
 
             - name: Analize auth0_flutter_platform_interface package
               working-directory: auth0_flutter_platform_interface
-              run: flutter analyze
+              run: flutter analyze --no-fatal-warnings --no-fatal-infos
 
     test-auth0_flutter:
         name: Test auth0_flutter Flutter package


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the CI config to make sure that running `flutter analyze` does not fail the CI on warnings and infos.

### 📎 References

https://github.com/flutter/flutter/issues/31918
