### PR TITLE
af: Ignore locale when it's not a string

### DIFF
--- a/auth0_flutter/lib/src/web/extensions/user_profile_extension.dart
+++ b/auth0_flutter/lib/src/web/extensions/user_profile_extension.dart
@@ -33,6 +33,15 @@ extension UserProfileExtension on UserProfile {
             ? claims[PublicClaims.emailVerified] as bool
             : claims[PublicClaims.emailVerified] == 'true'
         : null;
+    final isPhoneVerified = claims[PublicClaims.phoneNumberVerified] != null
+        ? claims[PublicClaims.phoneNumberVerified] is bool
+            ? claims[PublicClaims.phoneNumberVerified] as bool
+            : claims[PublicClaims.phoneNumberVerified] == 'true'
+        : null;
+    final locale = claims[PublicClaims.locale] != null &&
+            claims[PublicClaims.locale] is String
+        ? claims[PublicClaims.locale] as String
+        : null;
 
     return UserProfile(
       sub: claims[PublicClaims.sub] as String,
@@ -50,9 +59,9 @@ extension UserProfileExtension on UserProfile {
       gender: claims[PublicClaims.gender] as String?,
       birthdate: claims[PublicClaims.birthdate] as String?,
       zoneinfo: claims[PublicClaims.zoneinfo] as String?,
-      locale: claims[PublicClaims.locale] as String?,
+      locale: locale,
       phoneNumber: claims[PublicClaims.phoneNumber] as String?,
-      isPhoneNumberVerified: claims[PublicClaims.phoneNumberVerified] as bool?,
+      isPhoneNumberVerified: isPhoneVerified,
       address: address,
       updatedAt: updatedAt,
       customClaims: customClaims.isNotEmpty ? customClaims : null,

--- a/auth0_flutter/test/web/extensions/user_profile_extension_test.dart
+++ b/auth0_flutter/test/web/extensions/user_profile_extension_test.dart
@@ -132,58 +132,42 @@ void main() {
         () async {
       const Map<String, dynamic> claims = {
         ...requiredValues,
-        PublicClaims.name: 'John Alexander Doe',
-        PublicClaims.givenName: 'John',
-        PublicClaims.familyName: 'Doe',
-        PublicClaims.middleName: 'Alexander',
-        PublicClaims.nickname: 'johnny',
-        PublicClaims.preferredUsername: 'johnnyD',
-        PublicClaims.profile: 'https://example.com/profile',
-        PublicClaims.picture: 'https://example.com/picture.png',
-        PublicClaims.website: 'https://example.com',
-        PublicClaims.email: 'john.doe@example.com',
         PublicClaims.emailVerified: 'true',
-        PublicClaims.gender: 'male',
-        PublicClaims.birthdate: '01-01-2000',
-        PublicClaims.zoneinfo: 'America/Chicago',
-        PublicClaims.locale: 'en-US',
-        PublicClaims.phoneNumber: '111111111',
-        PublicClaims.phoneNumberVerified: true,
-        PublicClaims.address: {'street': '1 Foo St', 'zip_code': '11111-1111'},
-        PublicClaims.updatedAt: '2023-02-28T15:08:56+00:00',
-        'foo': 'bar'
       };
 
       final result = UserProfileExtension.fromClaims(claims);
 
-      expect(result.name, claims[PublicClaims.name]);
-      expect(result.givenName, claims[PublicClaims.givenName]);
-      expect(result.familyName, claims[PublicClaims.familyName]);
-      expect(result.middleName, claims[PublicClaims.middleName]);
-      expect(result.nickname, claims[PublicClaims.nickname]);
-      expect(result.preferredUsername, claims[PublicClaims.preferredUsername]);
-      expect(
-          result.profileUrl, Uri.parse(claims[PublicClaims.profile] as String));
-      expect(
-          result.pictureUrl, Uri.parse(claims[PublicClaims.picture] as String));
-      expect(
-          result.websiteUrl, Uri.parse(claims[PublicClaims.website] as String));
-      expect(result.email, claims[PublicClaims.email]);
       expect(
         result.isEmailVerified,
         claims[PublicClaims.emailVerified] == 'true',
       );
-      expect(result.gender, claims[PublicClaims.gender]);
-      expect(result.birthdate, claims[PublicClaims.birthdate]);
-      expect(result.zoneinfo, claims[PublicClaims.zoneinfo]);
-      expect(result.locale, claims[PublicClaims.locale]);
-      expect(result.phoneNumber, claims[PublicClaims.phoneNumber]);
-      expect(result.isPhoneNumberVerified,
-          claims[PublicClaims.phoneNumberVerified]);
-      expect(result.address, claims[PublicClaims.address]);
-      expect(result.updatedAt,
-          DateTime.parse(claims[PublicClaims.updatedAt] as String));
-      expect(result.customClaims?['foo'], claims['foo']);
+    });
+
+    test('creates UserProfile from claims with stringified phone_verified',
+        () async {
+      const Map<String, dynamic> claims = {
+        ...requiredValues,
+        PublicClaims.phoneNumberVerified: 'true'
+      };
+
+      final result = UserProfileExtension.fromClaims(claims);
+
+      expect(
+        result.isPhoneNumberVerified,
+        claims[PublicClaims.phoneNumberVerified] == 'true',
+      );
+    });
+
+    test('creates UserProfile from claims ignoring non-string locale',
+        () async {
+      const Map<String, dynamic> claims = {
+        ...requiredValues,
+        PublicClaims.locale: {'foo': 'bar'}
+      };
+
+      final result = UserProfileExtension.fromClaims(claims);
+
+      expect(result.locale, isNull);
     });
 
     test('throws exception with invalid profile URL', () async {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR makes sure to check if the `locale` value in the user profile is a string value. If it's not, then it sets `locale` to `null`.

This is necessary when some third-party OIDC connection doesn't return the locale as specified in the OIDC spec (e.g. LinkedIn), to keep the login from failing:

<img width="1457" alt="Screenshot 2025-02-21 at 00 07 00" src="https://github.com/user-attachments/assets/85751a6b-66e9-47e3-9b16-af295f2c8238" />

Also, the handling of the `phone_verified` claim was updated to match that of `email_verified`.

### 📎 References

Fixes https://github.com/auth0/auth0-flutter/issues/432

### 🎯 Testing

Unit tests were added. The change was also tested manually by logging in using a LinkedIn connection.