### PR TITLE
Update GH actions to use macOS 14 and Xcode to v15.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.4'
+              - '15.3'
 
         env:
           platform: iOS
@@ -172,7 +172,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.4'
+              - '15.3'
 
         steps:
             - name: Checkout
@@ -201,7 +201,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.4'
+              - '15.3'
 
         env:
           platform: macOS
@@ -242,7 +242,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.4'
+              - '15.3'
 
         steps:
             - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,13 +119,13 @@ jobs:
 
     test-ios-unit:
         name: Run native iOS unit tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '15.4'
 
         env:
           platform: iOS
@@ -161,7 +161,7 @@ jobs:
 
     test-ios-smoke:
         name: Run native iOS smoke tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13-large
+        runs-on: macos-14-large
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         env:
@@ -172,7 +172,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '15.4'
 
         steps:
             - name: Checkout
@@ -195,13 +195,13 @@ jobs:
 
     test-macos-unit:
         name: Run native macOS unit tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '15.4'
 
         env:
           platform: macOS
@@ -231,7 +231,7 @@ jobs:
 
     test-macos-smoke:
         name: Run native macOS smoke tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         env:
@@ -242,7 +242,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '15.4'
 
         steps:
             - name: Checkout


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the iOS CI jobs to use macOS 14 (with Xcode v15.3, which is the minimum minor version of Xcode 15 that supports macOS 14) to fix a CI issue related to the Ruby version available.