### PR TITLE
Use Ruby 3.3.1 on Github Actions

### DIFF
--- a/.github/actions/setup-darwin/action.yml
+++ b/.github/actions/setup-darwin/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Either iOS or macOS
     required: true
 
+  ruby:
+    description: The version of Ruby to use
+    required: true
+
   flutter:
     description: The version of Flutter to use
     required: true
@@ -31,29 +35,25 @@ runs:
       run: echo "platform=$(echo ${{ inputs.platform }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # pin@v1.221.0
+      with:
+        ruby-version: ${{ inputs.ruby }}
+        bundler-cache: true
+        cache-version: 1
+        working-directory: auth0_flutter/example/${{ steps.lowercase-platform.outputs.platform }}
+
     - name: Install Flutter
       uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
       with:
-          flutter-version: ${{ inputs.flutter }}
-          channel: stable
-          cache: true
+        flutter-version: ${{ inputs.flutter }}
+        channel: stable
+        cache: true
 
     - name: Install Flutter dependencies
       working-directory: auth0_flutter/example
       run: flutter pub get
       shell: bash
-
-    - name: Set Ruby version
-      working-directory: auth0_flutter/example/${{ steps.lowercase-platform.outputs.platform }}
-      run: ruby -e 'puts RUBY_VERSION' | tee .ruby-version
-      shell: bash
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # Pinned to version 1.176.0
-      with:
-          bundler-cache: true
-          cache-version: 1
-          working-directory: auth0_flutter/example/${{ steps.lowercase-platform.outputs.platform }}
 
     - name: Setup Xcode
       run: sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode }}.app/Contents/Developer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ concurrency:
     cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
+    ruby: '3.3.1'
     flutter: '3.x'
     ios-simulator: iPhone 15
     java: 11
@@ -138,6 +139,7 @@ jobs:
               uses: ./.github/actions/setup-darwin
               with:
                 platform: ${{ env.platform }}
+                ruby: ${{ env.ruby }}
                 flutter: ${{ env.flutter }}
                 xcode: ${{ matrix.xcode }}
                 auth0-domain: ${{ vars.AUTH0_DOMAIN }}
@@ -182,6 +184,7 @@ jobs:
               uses: ./.github/actions/setup-darwin
               with:
                 platform: ${{ env.platform }}
+                ruby: ${{ env.ruby }}
                 flutter: ${{ env.flutter }}
                 xcode: ${{ matrix.xcode }}
                 auth0-domain: ${{ vars.AUTH0_DOMAIN }}
@@ -214,6 +217,7 @@ jobs:
               uses: ./.github/actions/setup-darwin
               with:
                 platform: ${{ env.platform }}
+                ruby: ${{ env.ruby }}
                 flutter: ${{ env.flutter }}
                 xcode: ${{ matrix.xcode }}
                 auth0-domain: ${{ vars.AUTH0_DOMAIN }}
@@ -252,6 +256,7 @@ jobs:
               uses: ./.github/actions/setup-darwin
               with:
                 platform: ${{ env.platform }}
+                ruby: ${{ env.ruby }}
                 flutter: ${{ env.flutter }}
                 xcode: ${{ matrix.xcode }}
                 auth0-domain: ${{ vars.AUTH0_DOMAIN }}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR pins the version of Ruby to be used by GitHub Actions to **v3.3.1** to fix a CI issue:

<img width="1044" alt="Screenshot 2025-02-28 at 18 25 27" src="https://github.com/user-attachments/assets/0a5b9d90-aca9-40b7-9979-783669a3bcf2" />

Also, the `setup-ruby` action was updated to **v1.221.0**.
