### PR TITLE
Updated Readme recommending App links

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -365,6 +365,8 @@ try {
 
 ### Android: Custom schemes
 
+> Whenever possible, Auth0 recommends using [Android App Links](https://auth0.com/docs/applications/enable-android-app-links) as a secure way to link directly to content within your app. Custom URL schemes can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6).
+
 On Android, `https` is used by default as the callback URL scheme. This works best for Android API 23+ if you're using [Android App Links](https://auth0.com/docs/get-started/applications/enable-android-app-links-support), but in previous Android versions, this may show the intent chooser dialog prompting the user to choose either your app or the browser. You can change this behavior by using a custom unique scheme so that Android opens the link directly with your app.
 
 1. Update the `auth0Scheme` manifest placeholder on the `android/build.gradle` file.

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -194,6 +194,8 @@ Re-declare the activity manually using `tools:node="remove"` in the `android/src
 > read more about setting this value in the [Auth0.Android SDK
 > README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
 
+> Whenever possible, Auth0 recommends using [Android App Links](https://auth0.com/docs/applications/enable-android-app-links) as a secure way to link directly to content within your app. Custom URL schemes can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6).
+
 > 💡 If your Android app is using [product flavors](https://developer.android.com/studio/build/build-variants#product-flavors), you might need to specify different manifest placeholders for each flavor.
 
 ##### iOS/macOS: Configure the associated domain


### PR DESCRIPTION
This PR adds the following paragraph to the auth0_android README:
> Whenever possible, Auth0 recommends using [Android App Links](https://auth0.com/docs/applications/enable-android-app-links) as a secure way to link directly to content within your app. Custom URL schemes can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6).
