### PR TITLE
feat(auth): 🔐 Add UserProfile serialization and include in Credentials

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials.dart
@@ -76,6 +76,7 @@ class Credentials {
         'refreshToken': refreshToken,
         'expiresAt': expiresAt.toUtc().toIso8601String(),
         'scopes': scopes.toList(),
+        'userProfile': user.toMap(),
         'tokenType': tokenType,
       };
 }

--- a/auth0_flutter_platform_interface/lib/src/user_profile.dart
+++ b/auth0_flutter_platform_interface/lib/src/user_profile.dart
@@ -163,4 +163,28 @@ class UserProfile {
                 result['custom_claims'] as Map<dynamic, dynamic>)
             : null,
       );
+
+  Map<String, dynamic> toMap() => {
+        'sub': sub,
+        'name': name,
+        'given_name': givenName,
+        'family_name': familyName,
+        'middle_name': middleName,
+        'nickname': nickname,
+        'preferred_username': preferredUsername,
+        'profile': profileUrl?.toString(),
+        'picture': pictureUrl?.toString(),
+        'website': websiteUrl?.toString(),
+        'email': email,
+        'email_verified': isEmailVerified,
+        'gender': gender,
+        'birthdate': birthdate,
+        'zoneinfo': zoneinfo,
+        'locale': locale,
+        'phone_number': phoneNumber,
+        'phone_number_verified': isPhoneNumberVerified,
+        'address': address,
+        'updated_at': updatedAt?.toIso8601String(),
+        'custom_claims': customClaims,
+      };
 }

--- a/auth0_flutter_platform_interface/lib/src/user_profile.dart
+++ b/auth0_flutter_platform_interface/lib/src/user_profile.dart
@@ -184,7 +184,7 @@ class UserProfile {
         'phone_number': phoneNumber,
         'phone_number_verified': isPhoneNumberVerified,
         'address': address,
-        'updated_at': updatedAt?.toUtc(),
+        'updated_at': updatedAt?.toUtc().toIso8601String(),
         'custom_claims': customClaims,
       };
 }

--- a/auth0_flutter_platform_interface/lib/src/user_profile.dart
+++ b/auth0_flutter_platform_interface/lib/src/user_profile.dart
@@ -184,7 +184,7 @@ class UserProfile {
         'phone_number': phoneNumber,
         'phone_number_verified': isPhoneNumberVerified,
         'address': address,
-        'updated_at': updatedAt?.toIso8601String(),
+        'updated_at': updatedAt?.toUtc(),
         'custom_claims': customClaims,
       };
 }

--- a/auth0_flutter_platform_interface/test/credentials_test.dart
+++ b/auth0_flutter_platform_interface/test/credentials_test.dart
@@ -20,6 +20,14 @@ void main() {
       });
 
       expect(credentials.expiresAt.isUtc, true);
+      expect(
+        credentials.toMap()['userProfile']['sub'],
+        '123',
+      );
+      expect(
+        credentials.toMap()['userProfile']['name'],
+        'John Doe',
+      );
     });
 
     test('Credentials throws when expiresAt Locale set to ar', () async {

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -267,7 +267,9 @@ void main() {
       expect(
           verificationResult.arguments['credentials']['tokenType'], 'Bearer');
       expect(
-          verificationResult.arguments['credentials']['userProfile'], isNull);
+        verificationResult.arguments['credentials']['userProfile'],
+        isNotNull,
+      );
     });
 
     test(

--- a/auth0_flutter_platform_interface/test/user_profile_test.dart
+++ b/auth0_flutter_platform_interface/test/user_profile_test.dart
@@ -50,7 +50,7 @@ void main() {
       expect(userProfile.phoneNumber, '+1234567890');
       expect(userProfile.isPhoneNumberVerified, true);
       expect(userProfile.address, {'country': 'USA', 'postal_code': '12345'});
-      expect(userProfile.updatedAt, DateTime.parse('2023-01-01T00:00:00.000Z'));
+      expect(userProfile.updatedAt?.isUtc, true);
       expect(userProfile.customClaims, {'role': 'admin'});
     });
 
@@ -87,27 +87,28 @@ void main() {
 
     test('toMap correctly converts all properties', () {
       final userProfile = UserProfile(
-          sub: 'user123',
-          name: 'John Doe',
-          givenName: 'John',
-          familyName: 'Doe',
-          middleName: 'Smith',
-          nickname: 'Johnny',
-          preferredUsername: 'john.doe',
-          profileUrl: Uri.parse('https://example.com/profile'),
-          pictureUrl: Uri.parse('https://example.com/picture.jpg'),
-          websiteUrl: Uri.parse('https://johndoe.com'),
-          email: 'john@example.com',
-          isEmailVerified: true,
-          gender: 'male',
-          birthdate: '1990-01-01',
-          zoneinfo: 'America/New_York',
-          locale: 'en-US',
-          phoneNumber: '+1234567890',
-          isPhoneNumberVerified: true,
-          address: {'country': 'USA', 'postal_code': '12345'},
-          updatedAt: DateTime.parse('2023-01-01T00:00:00.000Z'),
-          customClaims: {'role': 'admin'});
+        sub: 'user123',
+        name: 'John Doe',
+        givenName: 'John',
+        familyName: 'Doe',
+        middleName: 'Smith',
+        nickname: 'Johnny',
+        preferredUsername: 'john.doe',
+        profileUrl: Uri.parse('https://example.com/profile'),
+        pictureUrl: Uri.parse('https://example.com/picture.jpg'),
+        websiteUrl: Uri.parse('https://johndoe.com'),
+        email: 'john@example.com',
+        isEmailVerified: true,
+        gender: 'male',
+        birthdate: '1990-01-01',
+        zoneinfo: 'America/New_York',
+        locale: 'en-US',
+        phoneNumber: '+1234567890',
+        isPhoneNumberVerified: true,
+        address: {'country': 'USA', 'postal_code': '12345'},
+        updatedAt: DateTime.parse('2023-01-01T00:00:00.000Z'),
+        customClaims: {'role': 'admin'},
+      );
 
       final map = userProfile.toMap();
 
@@ -130,7 +131,7 @@ void main() {
       expect(map['phone_number'], '+1234567890');
       expect(map['phone_number_verified'], true);
       expect(map['address'], {'country': 'USA', 'postal_code': '12345'});
-      expect(map['updated_at'], '2023-01-01T00:00:00.000Z');
+      expect(map['updated_at'], DateTime.parse('2023-01-01T00:00:00.000Z'));
       expect(map['custom_claims'], {'role': 'admin'});
     });
   });

--- a/auth0_flutter_platform_interface/test/user_profile_test.dart
+++ b/auth0_flutter_platform_interface/test/user_profile_test.dart
@@ -1,0 +1,137 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UserProfile', () {
+    test('fromMap correctly maps all properties', () {
+      final map = {
+        'sub': 'user123',
+        'name': 'John Doe',
+        'given_name': 'John',
+        'family_name': 'Doe',
+        'middle_name': 'Smith',
+        'nickname': 'Johnny',
+        'preferred_username': 'john.doe',
+        'profile': 'https://example.com/profile',
+        'picture': 'https://example.com/picture.jpg',
+        'website': 'https://johndoe.com',
+        'email': 'john@example.com',
+        'email_verified': true,
+        'gender': 'male',
+        'birthdate': '1990-01-01',
+        'zoneinfo': 'America/New_York',
+        'locale': 'en-US',
+        'phone_number': '+1234567890',
+        'phone_number_verified': true,
+        'address': {'country': 'USA', 'postal_code': '12345'},
+        'updated_at': '2023-01-01T00:00:00.000Z',
+        'custom_claims': {'role': 'admin'}
+      };
+
+      final userProfile = UserProfile.fromMap(map);
+
+      expect(userProfile.sub, 'user123');
+      expect(userProfile.name, 'John Doe');
+      expect(userProfile.givenName, 'John');
+      expect(userProfile.familyName, 'Doe');
+      expect(userProfile.middleName, 'Smith');
+      expect(userProfile.nickname, 'Johnny');
+      expect(userProfile.preferredUsername, 'john.doe');
+      expect(userProfile.profileUrl, Uri.parse('https://example.com/profile'));
+      expect(
+          userProfile.pictureUrl, Uri.parse('https://example.com/picture.jpg'));
+      expect(userProfile.websiteUrl, Uri.parse('https://johndoe.com'));
+      expect(userProfile.email, 'john@example.com');
+      expect(userProfile.isEmailVerified, true);
+      expect(userProfile.gender, 'male');
+      expect(userProfile.birthdate, '1990-01-01');
+      expect(userProfile.zoneinfo, 'America/New_York');
+      expect(userProfile.locale, 'en-US');
+      expect(userProfile.phoneNumber, '+1234567890');
+      expect(userProfile.isPhoneNumberVerified, true);
+      expect(userProfile.address, {'country': 'USA', 'postal_code': '12345'});
+      expect(userProfile.updatedAt, DateTime.parse('2023-01-01T00:00:00.000Z'));
+      expect(userProfile.customClaims, {'role': 'admin'});
+    });
+
+    test('fromMap handles missing optional properties', () {
+      final map = {
+        'sub': 'user123',
+        'email': 'john@example.com',
+      };
+
+      final userProfile = UserProfile.fromMap(map);
+
+      expect(userProfile.sub, 'user123');
+      expect(userProfile.email, 'john@example.com');
+      expect(userProfile.name, isNull);
+      expect(userProfile.givenName, isNull);
+      expect(userProfile.familyName, isNull);
+      expect(userProfile.middleName, isNull);
+      expect(userProfile.nickname, isNull);
+      expect(userProfile.preferredUsername, isNull);
+      expect(userProfile.profileUrl, isNull);
+      expect(userProfile.pictureUrl, isNull);
+      expect(userProfile.websiteUrl, isNull);
+      expect(userProfile.isEmailVerified, isNull);
+      expect(userProfile.gender, isNull);
+      expect(userProfile.birthdate, isNull);
+      expect(userProfile.zoneinfo, isNull);
+      expect(userProfile.locale, isNull);
+      expect(userProfile.phoneNumber, isNull);
+      expect(userProfile.isPhoneNumberVerified, isNull);
+      expect(userProfile.address, isNull);
+      expect(userProfile.updatedAt, isNull);
+      expect(userProfile.customClaims, isNull);
+    });
+
+    test('toMap correctly converts all properties', () {
+      final userProfile = UserProfile(
+          sub: 'user123',
+          name: 'John Doe',
+          givenName: 'John',
+          familyName: 'Doe',
+          middleName: 'Smith',
+          nickname: 'Johnny',
+          preferredUsername: 'john.doe',
+          profileUrl: Uri.parse('https://example.com/profile'),
+          pictureUrl: Uri.parse('https://example.com/picture.jpg'),
+          websiteUrl: Uri.parse('https://johndoe.com'),
+          email: 'john@example.com',
+          isEmailVerified: true,
+          gender: 'male',
+          birthdate: '1990-01-01',
+          zoneinfo: 'America/New_York',
+          locale: 'en-US',
+          phoneNumber: '+1234567890',
+          isPhoneNumberVerified: true,
+          address: {'country': 'USA', 'postal_code': '12345'},
+          updatedAt: DateTime.parse('2023-01-01T00:00:00.000Z'),
+          customClaims: {'role': 'admin'});
+
+      final map = userProfile.toMap();
+
+      expect(map['sub'], 'user123');
+      expect(map['name'], 'John Doe');
+      expect(map['given_name'], 'John');
+      expect(map['family_name'], 'Doe');
+      expect(map['middle_name'], 'Smith');
+      expect(map['nickname'], 'Johnny');
+      expect(map['preferred_username'], 'john.doe');
+      expect(map['profile'], 'https://example.com/profile');
+      expect(map['picture'], 'https://example.com/picture.jpg');
+      expect(map['website'], 'https://johndoe.com');
+      expect(map['email'], 'john@example.com');
+      expect(map['email_verified'], true);
+      expect(map['gender'], 'male');
+      expect(map['birthdate'], '1990-01-01');
+      expect(map['zoneinfo'], 'America/New_York');
+      expect(map['locale'], 'en-US');
+      expect(map['phone_number'], '+1234567890');
+      expect(map['phone_number_verified'], true);
+      expect(map['address'], {'country': 'USA', 'postal_code': '12345'});
+      expect(map['updated_at'], '2023-01-01T00:00:00.000Z');
+      expect(map['custom_claims'], {'role': 'admin'});
+    });
+  });
+}

--- a/auth0_flutter_platform_interface/test/user_profile_test.dart
+++ b/auth0_flutter_platform_interface/test/user_profile_test.dart
@@ -50,7 +50,10 @@ void main() {
       expect(userProfile.phoneNumber, '+1234567890');
       expect(userProfile.isPhoneNumberVerified, true);
       expect(userProfile.address, {'country': 'USA', 'postal_code': '12345'});
-      expect(userProfile.updatedAt?.isUtc, true);
+      expect(
+        userProfile.updatedAt?.toUtc().toIso8601String(),
+        '2023-01-01T00:00:00.000Z',
+      );
       expect(userProfile.customClaims, {'role': 'admin'});
     });
 
@@ -131,7 +134,7 @@ void main() {
       expect(map['phone_number'], '+1234567890');
       expect(map['phone_number_verified'], true);
       expect(map['address'], {'country': 'USA', 'postal_code': '12345'});
-      expect(map['updated_at'], DateTime.parse('2023-01-01T00:00:00.000Z'));
+      expect(map['updated_at'], '2023-01-01T00:00:00.000Z');
       expect(map['custom_claims'], {'role': 'admin'});
     });
   });


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

- Add userProfile to Credentials.toMap() method
- Implement toMap() method in UserProfile class
- Update existing tests and add new UserProfile tests


### 🎯 Testing

Added tests for the updated code and all of the tests pass
![image](https://github.com/user-attachments/assets/3b4c07c3-38a9-48f5-a021-21ee8d4d416b)


Actually messed up signing commits here https://github.com/auth0/auth0-flutter/pull/475 🙈
So created a new one
