### PR TITLE
Removed the packaged_api_docs linter rule

### DIFF
--- a/auth0_flutter/analysis_options.yaml
+++ b/auth0_flutter/analysis_options.yaml
@@ -90,4 +90,4 @@ linter:
     sort_pub_dependencies: true
 
     # Specific rules
-    package_api_docs: true # TODO: replace with public_member_api_docs
+    # TODO: package_api_docs has been removed. replace with public_member_api_docs

--- a/auth0_flutter_platform_interface/analysis_options.yaml
+++ b/auth0_flutter_platform_interface/analysis_options.yaml
@@ -90,4 +90,4 @@ linter:
     sort_pub_dependencies: true
 
     # Specific rules
-    package_api_docs: true # TODO: replace with public_member_api_docs
+    # TODO: package_api_docs has been removed. replace with public_member_api_docs


### PR DESCRIPTION
This PR removes the `packaged_api_docs`  linter rule from flutter analyze file as it has been removed from Dart 3.7 and higher
