### PR TITLE
Added support to configure credentials manager for iOS and Android 

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -23,7 +23,7 @@ runs:
 
   steps:
     - name: Install Flutter
-      uses: subosito/flutter-action@c05b4b29742b9d69a8a940563c6f72559b4cf2bb  #pin@v1.10.0
+      uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046  #pin@v2.19.0
       with:
         flutter-version: 3.29.3
         channel: stable

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -23,9 +23,9 @@ runs:
 
   steps:
     - name: Install Flutter
-      uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # pin@v2.19.0
+      uses: subosito/flutter-action@v2
       with:
-        flutter-version: ${{ inputs.flutter }}
+        flutter-version: 3.29.3 # pin@v3.29.3
         channel: stable
         cache: true
 

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -23,9 +23,9 @@ runs:
 
   steps:
     - name: Install Flutter
-      uses: subosito/flutter-action@v2
+      uses: subosito/flutter-action@c05b4b29742b9d69a8a940563c6f72559b4cf2bb  #pin@v1.10.0
       with:
-        flutter-version: 3.29.3 # pin@v3.29.3
+        flutter-version: 3.29.3
         channel: stable
         cache: true
 

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -17,7 +17,7 @@
   - [Retrieve stored credentials](#retrieve-stored-credentials)
   - [Custom implementations](#custom-implementations)
   - [Local authentication](#local-authentication)
-  - [Credential Manager configuration](#credential-manager-configuration)
+  - [Credentials Manager configuration](#credentials-manager-configuration)
   - [Disable credentials storage](#disable-credentials-storage)
   - [Errors](#errors-1)
 - [🌐 Handling Credentials on the Web](#-handling-credentials-on-the-web)
@@ -396,7 +396,7 @@ await webAuth.logout();
 - [Retrieve stored credentials](#retrieve-stored-credentials)
 - [Custom implementations](#custom-implementations)
 - [Local authentication](#local-authentication)
-- [Credential Manager configuration](#credential-manager-configuration)
+- [Credentials Manager configuration](#credentials-manager-configuration)
 - [Credentials Manager errors](#credentials-manager-errors)
 - [Disable credentials storage](#disable-credentials-storage)
 
@@ -455,7 +455,7 @@ Check the [API documentation](https://pub.dev/documentation/auth0_flutter_platfo
 
 > ⚠️ Enabling local authentication will not work if you're using a custom Credentials Manager implementation. In that case, you will need to build support for local authentication into your custom implementation.
 
-### Credential Manager configuration
+### Credentials Manager configuration
 
 You can set platform specific configuration on the CredentialManager while initialising it.
 On iOS, this would mean configuring the `storeKey` of the Auth0.swift Credentials Manager, and the `accessGroup` and `accessibilty` of SimpleKeychain. If these are not set, the default values will be used.

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -17,6 +17,7 @@
   - [Retrieve stored credentials](#retrieve-stored-credentials)
   - [Custom implementations](#custom-implementations)
   - [Local authentication](#local-authentication)
+  - [Credential Manager configuration](#credential-manager-configuration)
   - [Disable credentials storage](#disable-credentials-storage)
   - [Errors](#errors-1)
 - [🌐 Handling Credentials on the Web](#-handling-credentials-on-the-web)
@@ -395,6 +396,7 @@ await webAuth.logout();
 - [Retrieve stored credentials](#retrieve-stored-credentials)
 - [Custom implementations](#custom-implementations)
 - [Local authentication](#local-authentication)
+- [Credential Manager configuration](#credential-manager-configuration)
 - [Credentials Manager errors](#credentials-manager-errors)
 - [Disable credentials storage](#disable-credentials-storage)
 
@@ -452,6 +454,26 @@ final credentials = await auth0.credentialsManager.credentials();
 Check the [API documentation](https://pub.dev/documentation/auth0_flutter_platform_interface/latest/auth0_flutter_platform_interface/LocalAuthentication-class.html) to learn more about the available `LocalAuthentication` properties.
 
 > ⚠️ Enabling local authentication will not work if you're using a custom Credentials Manager implementation. In that case, you will need to build support for local authentication into your custom implementation.
+
+### Credential Manager configuration
+
+You can set platform specific configuration on the CredentialManager while initialising it.
+On iOS ,this would mean configuring the `storeKey`, `accessGroup` and  `accessibilty` of the key chain. If these are not set then, the default values will be used.
+On Android , you can configure the `shared preference`  name used to store the credentials.
+
+```dart
+const configuration = CredentialsManagerConfiguration(
+    androidConfiguration: AndroidCredentialsConfiguration("testSharedPreference"),
+    iosConfiguration: IOSCredentialsConfiguration(
+        storeKey: "iosStoreKey",
+        accessGroup: "com.example.accessGroup",
+        accessibility: Accessibility.afterFirstUnlock));
+
+final auth0 = Auth0('YOUR_AUTH0_DOMAIN', 'YOUR_AUTH0_CLIENT_ID',
+    credentialsManagerConfiguration: configuration);
+final credentials = await auth0.credentialsManager.credentials();
+
+```
 
 ### Disable credentials storage
 

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -458,8 +458,8 @@ Check the [API documentation](https://pub.dev/documentation/auth0_flutter_platfo
 ### Credential Manager configuration
 
 You can set platform specific configuration on the CredentialManager while initialising it.
-On iOS ,this would mean configuring the `storeKey`, `accessGroup` and  `accessibilty` of the key chain. If these are not set then, the default values will be used.
-On Android , you can configure the `shared preference`  name used to store the credentials.
+On iOS, this would mean configuring the `storeKey` of the Auth0.swift Credentials Manager, and the `accessGroup` and `accessibilty` of SimpleKeychain. If these are not set, the default values will be used.
+On Android , you can configure the `sharedpreferences`  name used to store the credentials.
 
 ```dart
 const configuration = CredentialsManagerConfiguration(

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
@@ -91,6 +91,30 @@ class CredentialsManagerMethodCallHandlerTest {
     }
 
     @Test
+    fun `handler should extract sharedPreferenceName correctly`() {
+        val clearCredentialsHandler = mock<ClearCredentialsRequestHandler>()
+
+        `when`(clearCredentialsHandler.method).thenReturn("credentialsManager#clearCredentials")
+
+        val activity: Activity = mock()
+        val context: Context = mock()
+        val mockPrefs: SharedPreferences = mock()
+
+        `when`(context.getSharedPreferences(any(), any()))
+            .thenReturn(mockPrefs)
+
+        val arguments = defaultArguments + hashMapOf(
+            "credentialsManagerConfiguration" to mapOf(
+                "android" to mapOf("sharedPreferencesName" to "test_prefs")
+            )
+        )
+
+        runCallHandler(clearCredentialsHandler.method, arguments as HashMap, listOf(clearCredentialsHandler), activity, context) {
+            verify(context).getSharedPreferences(eq("test_prefs"), any())
+        }
+    }
+
+    @Test
     fun `handler should call credentialsManager requireAuthentication`() {
         val clearCredentialsHandler = mock<ClearCredentialsRequestHandler>()
 

--- a/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
+++ b/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="com_auth0_domain">YOUR_AUTH0_DOMAIN</string>
-    <string name="com_auth0_scheme">demo</string>
-</resources>

--- a/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
+++ b/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="com_auth0_domain">DOMAIN</string>
+    <string name="com_auth0_scheme">SCHEME</string>
+</resources>

--- a/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
+++ b/auth0_flutter/example/android/app/src/main/res/values/strings.xml.example
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="com_auth0_domain">DOMAIN</string>
-    <string name="com_auth0_scheme">SCHEME</string>
+    <string name="com_auth0_domain">YOUR_AUTH0_DOMAIN</string>
+    <string name="com_auth0_scheme">demo</string>
 </resources>

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
@@ -306,3 +306,128 @@ extension CredentialsManagerHandlerTests {
         ]
     }
 }
+
+
+// MARK: - Credentials Manager Configuration Arguments
+
+extension CredentialsManagerHandlerTests {
+    
+    func testUsesDefaultConfigurationWhenMissing() {
+           let expectation = expectation(description: "Default configuration")
+           let method = CredentialsManagerHandler.Method.save.rawValue
+           
+           // Keep track of whether a configuration was passed
+           var configPassed = false
+           let originalProvider = sut.credentialsManagerProvider
+           
+           sut.credentialsManagerProvider = { auth, args in
+               configPassed = args["credentialsManagerConfiguration"] != nil
+               return self.sut.createCredentialManager(auth, args)
+           }
+           
+           sut.handle(FlutterMethodCall(methodName: method, arguments: arguments())) { _ in
+               XCTAssertFalse(configPassed, "No configuration should be passed")
+               expectation.fulfill()
+           }
+           
+           wait(for: [expectation])
+           sut.credentialsManagerProvider = originalProvider
+       }
+    
+    
+       func testPassesIOSStoreKey() {
+           let expectation = expectation(description: "iOS store key")
+           let method = CredentialsManagerHandler.Method.save.rawValue
+           let customStoreKey = "custom.store.key"
+           
+           var passedStoreKey: String?
+           let originalProvider = sut.credentialsManagerProvider
+           
+           let configurationDict: [String: Any] = [
+               "ios": ["storeKey": customStoreKey]
+           ]
+           
+           var args = arguments()
+           args["credentialsManagerConfiguration"] = configurationDict
+           
+           sut.credentialsManagerProvider = { auth, args in
+               if let config = args["credentialsManagerConfiguration"] as? [String: Any],
+                  let iosConfig = config["ios"] as? [String: String] {
+                   passedStoreKey = iosConfig["storeKey"]
+               }
+               return self.sut.createCredentialManager(auth, args)
+           }
+           
+           sut.handle(FlutterMethodCall(methodName: method, arguments: args)) { _ in
+               XCTAssertEqual(passedStoreKey, customStoreKey)
+               expectation.fulfill()
+           }
+           
+           wait(for: [expectation])
+           sut.credentialsManagerProvider = originalProvider
+       }
+    
+    func testPassesIOSAccessGroup() {
+            let expectation = expectation(description: "iOS access group")
+            let method = CredentialsManagerHandler.Method.save.rawValue
+            let customAccessGroup = "com.example.group"
+            
+            var passedAccessGroup: String?
+            let originalProvider = sut.credentialsManagerProvider
+            
+            let configurationDict: [String: Any] = [
+                "ios": ["accessGroup": customAccessGroup]
+            ]
+            
+            var args = arguments()
+            args["credentialsManagerConfiguration"] = configurationDict
+            
+            sut.credentialsManagerProvider = { auth, args in
+                if let config = args["credentialsManagerConfiguration"] as? [String: Any],
+                   let iosConfig = config["ios"] as? [String: String] {
+                    passedAccessGroup = iosConfig["accessGroup"]
+                }
+                return self.sut.createCredentialManager(auth, args)
+            }
+            
+            sut.handle(FlutterMethodCall(methodName: method, arguments: args)) { _ in
+                XCTAssertEqual(passedAccessGroup, customAccessGroup)
+                expectation.fulfill()
+            }
+            
+            wait(for: [expectation])
+            sut.credentialsManagerProvider = originalProvider
+        }
+    
+    func testPassesIOSAccessibility() {
+            let expectation = expectation(description: "iOS accessibility")
+            let method = CredentialsManagerHandler.Method.save.rawValue
+            let customAccessibility = "whenUnlocked"
+            
+            var passedAccessibility: String?
+            let originalProvider = sut.credentialsManagerProvider
+            
+            let configurationDict: [String: Any] = [
+                "ios": ["accessibility": customAccessibility]
+            ]
+            
+            var args = arguments()
+            args["credentialsManagerConfiguration"] = configurationDict
+            
+            sut.credentialsManagerProvider = { auth, args in
+                if let config = args["credentialsManagerConfiguration"] as? [String: Any],
+                   let iosConfig = config["ios"] as? [String: String] {
+                    passedAccessibility = iosConfig["accessibility"]
+                }
+                return self.sut.createCredentialManager(auth, args)
+            }
+            
+            sut.handle(FlutterMethodCall(methodName: method, arguments: args)) { _ in
+                XCTAssertEqual(passedAccessibility, customAccessibility)
+                expectation.fulfill()
+            }
+            
+            wait(for: [expectation])
+            sut.credentialsManagerProvider = originalProvider
+        }
+}

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
@@ -331,7 +331,6 @@ extension CredentialsManagerHandlerTests {
            }
            
            wait(for: [expectation])
-           sut.credentialsManagerProvider = originalProvider
        }
     
     
@@ -364,7 +363,6 @@ extension CredentialsManagerHandlerTests {
            }
            
            wait(for: [expectation])
-           sut.credentialsManagerProvider = originalProvider
        }
     
     func testPassesIOSAccessGroup() {
@@ -396,7 +394,6 @@ extension CredentialsManagerHandlerTests {
             }
             
             wait(for: [expectation])
-            sut.credentialsManagerProvider = originalProvider
         }
     
     func testPassesIOSAccessibility() {
@@ -428,6 +425,5 @@ extension CredentialsManagerHandlerTests {
             }
             
             wait(for: [expectation])
-            sut.credentialsManagerProvider = originalProvider
         }
 }

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerHandlerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Auth0
 @testable import auth0_flutter
 
-class CredentialsManagerHandlerTests: XCTestCase {
+    class CredentialsManagerHandlerTests: XCTestCase {
     var sut: CredentialsManagerHandler!
 
     override func setUpWithError() throws {
@@ -318,7 +318,6 @@ extension CredentialsManagerHandlerTests {
            
            // Keep track of whether a configuration was passed
            var configPassed = false
-           let originalProvider = sut.credentialsManagerProvider
            
            sut.credentialsManagerProvider = { auth, args in
                configPassed = args["credentialsManagerConfiguration"] != nil
@@ -340,7 +339,6 @@ extension CredentialsManagerHandlerTests {
            let customStoreKey = "custom.store.key"
            
            var passedStoreKey: String?
-           let originalProvider = sut.credentialsManagerProvider
            
            let configurationDict: [String: Any] = [
                "ios": ["storeKey": customStoreKey]
@@ -371,7 +369,6 @@ extension CredentialsManagerHandlerTests {
             let customAccessGroup = "com.example.group"
             
             var passedAccessGroup: String?
-            let originalProvider = sut.credentialsManagerProvider
             
             let configurationDict: [String: Any] = [
                 "ios": ["accessGroup": customAccessGroup]
@@ -402,7 +399,6 @@ extension CredentialsManagerHandlerTests {
             let customAccessibility = "whenUnlocked"
             
             var passedAccessibility: String?
-            let originalProvider = sut.credentialsManagerProvider
             
             let configurationDict: [String: Any] = [
                 "ios": ["accessibility": customAccessibility]

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -49,8 +49,8 @@ class Auth0 {
   /// [DefaultCredentialsManager], set [localAuthentication]` to an instance
   /// of [LocalAuthentication]. Note however that this setting has no effect
   /// when specifying a custom [credentialsManager].
-  /// Use [CredentialsManagerConfiguration] to configure platform specific
-  /// configuration of the CredentialsManager
+  /// Use [CredentialsManagerConfiguration] to set platform-specific
+  /// configuration for the default CredentialsManager.
   Auth0(final String domain, final String clientId,
       {final LocalAuthentication? localAuthentication,
       final CredentialsManager? credentialsManager,

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -49,17 +49,22 @@ class Auth0 {
   /// [DefaultCredentialsManager], set [localAuthentication]` to an instance
   /// of [LocalAuthentication]. Note however that this setting has no effect
   /// when specifying a custom [credentialsManager].
+  /// Use [CredentialsManagerConfiguration] to configure platform specific
+  /// configuration of the CredentialsManager
   Auth0(final String domain, final String clientId,
       {final LocalAuthentication? localAuthentication,
-      final CredentialsManager? credentialsManager})
+      final CredentialsManager? credentialsManager,
+      final CredentialsManagerConfiguration? credentialsManagerConfiguration})
       : _account = Account(domain, clientId) {
     _credentialsManager = credentialsManager ??
         DefaultCredentialsManager(
           _account,
           _userAgent,
           localAuthentication: localAuthentication,
+          credentialsManagerConfiguration:credentialsManagerConfiguration
         );
   }
+
 
   /// An instance of [AuthenticationApi], the primary interface for interacting
   /// with the Auth0 Authentication API

--- a/auth0_flutter/lib/src/mobile/credentials_manager.dart
+++ b/auth0_flutter/lib/src/mobile/credentials_manager.dart
@@ -25,10 +25,13 @@ class DefaultCredentialsManager extends CredentialsManager {
   final Account _account;
   final UserAgent _userAgent;
   final LocalAuthentication? _localAuthentication;
+  final CredentialsManagerConfiguration? _credentialsManagerConfiguration;
 
   DefaultCredentialsManager(this._account, this._userAgent,
-      {final LocalAuthentication? localAuthentication})
-      : _localAuthentication = localAuthentication;
+      {final LocalAuthentication? localAuthentication,
+      final CredentialsManagerConfiguration? credentialsManagerConfiguration})
+      : _localAuthentication = localAuthentication,
+        _credentialsManagerConfiguration = credentialsManagerConfiguration;
 
   /// Retrieves the credentials from the storage and refreshes them if they have
   ///  already expired.
@@ -76,12 +79,12 @@ class DefaultCredentialsManager extends CredentialsManager {
   Future<bool> clearCredentials() => CredentialsManagerPlatform.instance
       .clearCredentials(_createApiRequest(null));
 
-  CredentialsManagerRequest<TOptions>
-      _createApiRequest<TOptions extends RequestOptions>(
-              final TOptions? options) =>
-          CredentialsManagerRequest<TOptions>(
-              account: _account,
-              options: options,
-              userAgent: _userAgent,
-              localAuthentication: _localAuthentication);
+  CredentialsManagerRequest<TOptions> _createApiRequest<
+          TOptions extends RequestOptions>(final TOptions? options) =>
+      CredentialsManagerRequest<TOptions>(
+          account: _account,
+          options: options,
+          userAgent: _userAgent,
+          localAuthentication: _localAuthentication,
+          credentialsManagerConfiguration: _credentialsManagerConfiguration);
 }

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -16,6 +16,7 @@ export 'src/auth0_exception.dart';
 export 'src/auth0_flutter_auth_platform.dart';
 export 'src/auth0_flutter_web_auth_platform.dart';
 export 'src/auth0_flutter_web_platform.dart';
+export 'src/credentials-manager/credentials_manager_configuration.dart';
 export 'src/credentials-manager/credentials_manager_exception.dart';
 export 'src/credentials-manager/credentials_manager_platform.dart';
 export 'src/credentials-manager/method_channel_credentials_manager.dart';

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_configuration.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_configuration.dart
@@ -1,4 +1,5 @@
-//
+/// Class used to set platform-specific configuration for
+/// [CredentialsManager] in the SDK.
 class CredentialsManagerConfiguration {
   IOSCredentialsConfiguration? iosConfiguration;
   AndroidCredentialsConfiguration? androidConfiguration;
@@ -7,36 +8,46 @@ class CredentialsManagerConfiguration {
       {this.iosConfiguration, this.androidConfiguration});
 
   Map<String, dynamic> toMap() => {
-      'ios': iosConfiguration?.toMap(),
-      'android': androidConfiguration?.toMap(),
-    }..removeWhere((final key, final value) => value == null);
+        'ios': iosConfiguration?.toMap(),
+        'android': androidConfiguration?.toMap(),
+      }..removeWhere((final key, final value) => value == null);
 }
 
-class IOSCredentialsConfiguration {
-  String storeKey;
-  String accessGroup;
-  Accessibility accessibility;
 
-  IOSCredentialsConfiguration(this.storeKey, this.accessGroup,this.accessibility);
+/// Configuration options for the iOS platform that can be set while instantiating
+/// the [CredentialsManager]. It can be used to set the keychain store key,
+/// access group and accessibility level for the stored credentials.
+class IOSCredentialsConfiguration {
+  /// Defaults to "credentials"
+  String? storeKey;
+  /// Defaults to nil
+  String? accessGroup;
+  /// Defaults to [Accessibility.afterFirstUnlock]
+  Accessibility? accessibility;
+
+  IOSCredentialsConfiguration(
+      {this.storeKey, this.accessGroup, this.accessibility});
 
   Map<String, dynamic> toMap() => {
-      'storeKey': storeKey,
-      'accessGroup': accessGroup,
-    'accessibility': accessibility.name,
-    }..removeWhere((final key, final value) => value == null);
+        'storeKey': storeKey,
+        'accessGroup': accessGroup,
+        'accessibility': accessibility?.name,
+      }..removeWhere((final key, final value) => value == null);
 }
 
+/// Configuration options for the Android platform that can be set while instantiating
+/// the [CredentialsManager].
 class AndroidCredentialsConfiguration {
   String sharedPreferenceName;
 
   AndroidCredentialsConfiguration(this.sharedPreferenceName);
 
   Map<String, dynamic> toMap() => {
-      'sharedPreferencesName': sharedPreferenceName,
-    }..removeWhere((final key, final value) => value == null);
+        'sharedPreferencesName': sharedPreferenceName,
+      }..removeWhere((final key, final value) => value == null);
 }
 
-
+/// The accessibility level for the credentials on iOS.
 enum Accessibility {
   afterFirstUnlock,
   afterFirstUnlockThisDeviceOnly,

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_configuration.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_configuration.dart
@@ -1,0 +1,46 @@
+//
+class CredentialsManagerConfiguration {
+  IOSCredentialsConfiguration? iosConfiguration;
+  AndroidCredentialsConfiguration? androidConfiguration;
+
+  CredentialsManagerConfiguration(
+      {this.iosConfiguration, this.androidConfiguration});
+
+  Map<String, dynamic> toMap() => {
+      'ios': iosConfiguration?.toMap(),
+      'android': androidConfiguration?.toMap(),
+    }..removeWhere((final key, final value) => value == null);
+}
+
+class IOSCredentialsConfiguration {
+  String storeKey;
+  String accessGroup;
+  Accessibility accessibility;
+
+  IOSCredentialsConfiguration(this.storeKey, this.accessGroup,this.accessibility);
+
+  Map<String, dynamic> toMap() => {
+      'storeKey': storeKey,
+      'accessGroup': accessGroup,
+    'accessibility': accessibility.name,
+    }..removeWhere((final key, final value) => value == null);
+}
+
+class AndroidCredentialsConfiguration {
+  String sharedPreferenceName;
+
+  AndroidCredentialsConfiguration(this.sharedPreferenceName);
+
+  Map<String, dynamic> toMap() => {
+      'sharedPreferencesName': sharedPreferenceName,
+    }..removeWhere((final key, final value) => value == null);
+}
+
+
+enum Accessibility {
+  afterFirstUnlock,
+  afterFirstUnlockThisDeviceOnly,
+  whenPasscodeSetThisDeviceOnly,
+  whenUnlocked,
+  whenUnlockedThisDeviceOnly
+}

--- a/auth0_flutter_platform_interface/lib/src/request/request.dart
+++ b/auth0_flutter_platform_interface/lib/src/request/request.dart
@@ -19,29 +19,39 @@ abstract class BaseRequest<TOptions extends RequestOptions?> {
 class CredentialsManagerRequest<TOptions extends RequestOptions?>
     extends BaseRequest<TOptions?> {
   final LocalAuthentication? localAuthentication;
+  final CredentialsManagerConfiguration? credentialsManagerConfiguration;
 
   CredentialsManagerRequest({
     required final Account account,
     final TOptions? options,
     required final UserAgent userAgent,
     this.localAuthentication,
+    this.credentialsManagerConfiguration,
   }) : super(account: account, options: options, userAgent: userAgent);
 
   @override
   Map<String, dynamic> toMap() {
+    final map = super.toMap();
+
     if (localAuthentication != null) {
-      return (super.toMap())
-        ..addAll({
-          'localAuthentication': {
-            'title': localAuthentication?.title,
-            'description': localAuthentication?.description,
-            'cancelTitle': localAuthentication?.cancelTitle,
-            'fallbackTitle': localAuthentication?.fallbackTitle
-          }
-        });
-    } else {
-      return super.toMap();
+      map.addAll({
+        'localAuthentication': {
+          'title': localAuthentication?.title,
+          'description': localAuthentication?.description,
+          'cancelTitle': localAuthentication?.cancelTitle,
+          'fallbackTitle': localAuthentication?.fallbackTitle
+        }
+      });
     }
+
+    if (credentialsManagerConfiguration != null) {
+      map.addAll({
+        'credentialsManagerConfiguration':
+            credentialsManagerConfiguration?.toMap()
+      });
+    }
+
+    return map;
   }
 }
 

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -132,6 +132,61 @@ void main() {
           'test-fallback-title');
     });
 
+    test('correctly includes the credential manager configuration settings', () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.credentials);
+
+      await MethodChannelCredentialsManager().getCredentials(
+          CredentialsManagerRequest<GetCredentialsOptions>(
+              account: const Account('', ''),
+              userAgent: UserAgent(name: '', version: ''),
+              options: GetCredentialsOptions(),
+              credentialsManagerConfiguration: CredentialsManagerConfiguration(
+                  iosConfiguration: IOSCredentialsConfiguration(
+                      storeKey: 'test-store-key',
+                      accessGroup: 'test-access-group',
+                      accessibility: Accessibility.whenUnlocked
+                  ),
+                  androidConfiguration: AndroidCredentialsConfiguration(
+                       'test-shared-preferences'
+                  ))));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['credentialsManagerConfiguration'], isNotNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios'], isNotNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['storeKey'], 'test-store-key');
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['accessGroup'], 'test-access-group');
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['accessibility'], 'whenUnlocked');
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['android'], isNotNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['android']['sharedPreferencesName'], 'test-shared-preferences');
+    });
+
+    test('correctly includes the optional parameters of credential manager configuration settings', () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.credentials);
+
+      await MethodChannelCredentialsManager().getCredentials(
+          CredentialsManagerRequest<GetCredentialsOptions>(
+              account: const Account('', ''),
+              userAgent: UserAgent(name: '', version: ''),
+              options: GetCredentialsOptions(),
+              credentialsManagerConfiguration: CredentialsManagerConfiguration(
+                  iosConfiguration: IOSCredentialsConfiguration(
+                      accessGroup: 'test-access-group',
+                  ),
+              )));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['credentialsManagerConfiguration'], isNotNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios'], isNotNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['storeKey'], isNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['accessGroup'], 'test-access-group');
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['ios']['accessibility'], isNull);
+      expect(verificationResult.arguments['credentialsManagerConfiguration']['android'], isNull);
+    });
+
     test('correctly returns the response from the Method Channel', () async {
       when(mocked.methodCallHandler(any))
           .thenAnswer((final _) async => MethodCallHandler.credentials);


### PR DESCRIPTION


- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)


### 📋 Changes

This PR adds support to configure the CredentialsManager class on both Android and iOS platforms. This change allows user to set the `sharedpreferenceName` in Android and `secretKey` , `accessGroup` and `accessibility` on iOS while setting up the CredentialsManager in `auth0_flutter`

### 📎 References
#553 

