### PR TITLE
Release afpi-v1.11.0

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [afpi-v1.11.0](https://github.com/auth0/auth0-flutter/tree/afpi-v1.11.0) (2025-06-11)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v1.10.0...afpi-v1.11.0)
+
+**Added**
+- Added support to configure credentials manager for iOS and Android  [\#576](https://github.com/auth0/auth0-flutter/pull/576) ([pmathew92](https://github.com/pmathew92))
+
 ## [afpi-v1.10.0](https://github.com/auth0/auth0-flutter/tree/afpi-v1.10.0) (2025-04-29)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v1.9.0...afpi-v1.10.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 1.10.0
+version: 1.11.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Added**
- Added support to configure credentials manager for iOS and Android  [\#576](https://github.com/auth0/auth0-flutter/pull/576) ([pmathew92](https://github.com/pmathew92))
