### PR TITLE
Implements dart api to input allowed browser packages for web auth login

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -45,7 +45,8 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     GetCredentialsRequestHandler(),
     SaveCredentialsRequestHandler(),
     HasValidCredentialsRequestHandler(),
-    ClearCredentialsRequestHandler()
+    ClearCredentialsRequestHandler(),
+    GetIdTokenContentRequestHandler()
   ))
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetIdTokenContentRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetIdTokenContentRequestHandler.kt
@@ -1,0 +1,47 @@
+package com.auth0.auth0_flutter.request_handlers.credentials_manager
+
+import android.content.Context
+import com.auth0.android.authentication.storage.CredentialsManagerException
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import io.flutter.plugin.common.MethodChannel
+import java.io.Serializable
+import java.lang.Exception
+
+
+class GetIdTokenContentRequestHandler: CredentialsManagerRequestHandler {
+    override val method: String = "credentialsManager#getIDTokenContent"
+    override fun handle(
+        credentialsManager: SecureCredentialsManager,
+        context: Context,
+        request: MethodCallRequest,
+        result: MethodChannel.Result
+    ) {
+            result.success(
+                mapOf(
+                    "id" to credentialsManager.userProfile?.getId(),
+                    "name" to credentialsManager.userProfile?.name,
+                    "nickname" to credentialsManager.userProfile?.nickname,
+                    "pictureURL" to credentialsManager.userProfile?.pictureURL,
+                    "email" to credentialsManager.userProfile?.email,
+                    "isEmailVerified" to credentialsManager.userProfile?.isEmailVerified,
+                    "familyName" to credentialsManager.userProfile?.familyName,
+                    "createdAt" to credentialsManager.userProfile?.createdAt,
+                    "identities" to credentialsManager.userProfile?.getIdentities()?.map {
+                        mapOf(
+                            "provider" to it.provider,
+                            "id" to it.connection,
+                            "isSocial" to it.isSocial,
+                            "accessToken" to it.accessToken,
+                            "accessTokenSecret" to it.accessTokenSecret,
+                            "profileInfo" to it.getProfileInfo()
+                        )
+                    },
+                    "extraInfo" to credentialsManager.userProfile?.getExtraInfo(),
+                    "userMetadata" to credentialsManager.userProfile?.getUserMetadata(),
+                    "appMetadata" to credentialsManager.userProfile?.getAppMetadata(),
+                    "givenName" to credentialsManager.userProfile?.givenName
+                )
+            )
+    }
+}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -45,8 +45,14 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
 
         if(args["allowedPackages"] is List<*>) {
-            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
-                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
+            if((args["allowedPackages"] as List<String>).isNotEmpty()) {
+                builder.withCustomTabsOptions(
+                    CustomTabsOptions.newBuilder().withBrowserPicker(
+                        BrowserPicker.newBuilder()
+                            .withAllowedPackages(args["allowedPackages"] as List<String>).build()
+                    ).build()
+                )
+            }
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -3,12 +3,15 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
+import android.util.Log
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
     override val method: String = "webAuth#login"
@@ -38,6 +41,12 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
         if (args["invitationUrl"] is String) {
             builder.withInvitationUrl(args["invitationUrl"] as String)
+        }
+
+
+        if(args["allowedPackages"] is List<*>) {
+            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
+                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -50,7 +50,7 @@ class _ExampleAppState extends State<ExampleApp> {
         return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
 
-      final result = await webAuth.login(useHTTPS: true);
+      final result = await webAuth.login(useHTTPS: true, allowedPackages: []);
 
       setState(() {
         _isLoggedIn = true;

--- a/auth0_flutter/lib/src/mobile/credentials_manager.dart
+++ b/auth0_flutter/lib/src/mobile/credentials_manager.dart
@@ -9,7 +9,9 @@ abstract class CredentialsManager {
     final Map<String, String> parameters = const {},
   });
 
-  Future<bool> storeCredentials(final Credentials credentials);
+  Future<UserInfo> getIDTokenContents();
+
+    Future<bool> storeCredentials(final Credentials credentials);
 
   Future<bool> hasValidCredentials({
     final int minTtl = 0,
@@ -54,6 +56,10 @@ class DefaultCredentialsManager extends CredentialsManager {
         scopes: scopes,
         parameters: parameters,
       )));
+
+  @override
+  Future<UserInfo> getIDTokenContents() =>
+      CredentialsManagerPlatform.instance.getIDTokenContents(_createApiRequest(null));
 
   /// Stores the given credentials in the storage. Must have an `access_token`
   /// or `id_token` and a `expires_in` value.

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -81,6 +81,7 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
+        final List<String> allowedPackages = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =
@@ -98,10 +99,10 @@ class WebAuthentication {
             scheme: _scheme,
             useHTTPS: useHTTPS,
             useEphemeralSession: useEphemeralSession,
-            safariViewController: safariViewController)));
+            safariViewController: safariViewController,
+            allowedPackages: allowedPackages)));
 
     await _credentialsManager?.storeCredentials(credentials);
-
     return credentials;
   }
 

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
@@ -1,6 +1,8 @@
 // coverage:ignore-file
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../../auth0_flutter_platform_interface.dart';
+import '../user_info.dart';
 import '../credentials.dart';
 import '../request/request.dart';
 import 'method_channel_credentials_manager.dart';
@@ -34,6 +36,11 @@ abstract class CredentialsManagerPlatform extends PlatformInterface {
   Future<Credentials> getCredentials(
       final CredentialsManagerRequest<GetCredentialsOptions> request) {
     throw UnimplementedError('getCredentials() has not been implemented');
+  }
+
+  /// Retrieves the credentials from the native storage.
+  Future<UserInfo> getIDTokenContents(final CredentialsManagerRequest request) {
+    throw UnimplementedError('getIDTokenContents() has not been implemented');
   }
 
   /// Removes the credentials from the native storage if present.

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 
+import '../user_info.dart';
 import '../credentials.dart';
 import '../request/request.dart';
 import '../request/request_options.dart';
@@ -15,6 +16,8 @@ const String credentialsManagerSaveCredentialsMethod =
     'credentialsManager#saveCredentials';
 const String credentialsManagerGetCredentialsMethod =
     'credentialsManager#getCredentials';
+const String credentialsManagerGetUserProfileMethod =
+'credentialsManager#getIDTokenContent';
 const String credentialsManagerClearCredentialsMethod =
     'credentialsManager#clearCredentials';
 const String credentialsManagerHasValidCredentialsMethod =
@@ -46,6 +49,12 @@ class MethodChannelCredentialsManager extends CredentialsManagerPlatform {
     final bool? result = await _invokeRequest<bool, RequestOptions?>(
         method: credentialsManagerSaveCredentialsMethod, request: request);
     return result ?? true;
+  }
+
+  @override
+  Future<UserInfo> getIDTokenContents(final CredentialsManagerRequest request) async {
+      final Map<String, dynamic> result = await _invokeMapRequest(method: credentialsManagerGetUserProfileMethod, request: request);
+      return UserInfo.fromJson(result);
   }
 
   /// Removes the credentials from the native storage if present.

--- a/auth0_flutter_platform_interface/lib/src/user_info.dart
+++ b/auth0_flutter_platform_interface/lib/src/user_info.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'dart:ffi'; // For jsonEncode, jsonDecode (if you implement them)
+
+// Assuming UserIdentity is also a class you'll define in Dart
+// If UserIdentity needs to be serializable, it should also have toJson/fromJson.
+class UserIdentity {
+  // Example properties, adjust based on your actual UserIdentity structure
+  final String id;
+  final String connection;
+  final String provider;
+  final bool? isSocial;
+  final String? accessToken;
+  final String? accessTokenSecret;
+  final Map<String, dynamic>? _profileInfo;
+
+  UserIdentity({
+    required this.id,
+    required this.connection,
+    required this.provider,
+    this.isSocial,
+    this.accessToken,
+    this.accessTokenSecret,
+    Map<String, dynamic>? profileInfo})
+      : _profileInfo = profileInfo ;
+  factory UserIdentity.fromJson(final Map<String, dynamic> json)
+    => UserIdentity(
+      connection: json['connection'] as String,
+      id: json['id'] as String,
+      isSocial: json['isSocial'] as bool?,
+      provider: json['provider'] as String,
+      accessToken: json['accessToken'] as String?,
+      accessTokenSecret: json['accessTokenSecret'] as String?,
+      profileInfo: json['profileInfo'] as Map<String, dynamic>?
+    );
+}
+
+
+class UserInfo {
+  // Private fields (using _ prefix)
+  final String? _id;
+  final List<UserIdentity>? _identities;
+  final Map<String, dynamic>? _extraInfo; // Using dynamic for Any type
+  final Map<String, dynamic>? _userMetadata;
+  final Map<String, dynamic>? _appMetadata;
+
+  // Public fields (no special prefix, directly accessible)
+  final String? name;
+  final String? nickname;
+  final String? pictureURL;
+  final String? email;
+  final bool? isEmailVerified;
+  final String? familyName;
+  final DateTime? createdAt; // Using DateTime for Date
+  final String? givenName;
+
+
+  UserInfo({
+    final String? id, // Private fields can be passed through constructor
+    this.name,
+    this.nickname,
+    this.pictureURL,
+    this.email,
+    this.isEmailVerified,
+    this.familyName,
+    this.createdAt,
+    final List<UserIdentity>? identities,
+    final Map<String, dynamic>? extraInfo,
+    final Map<String, dynamic>? userMetadata,
+    final Map<String, dynamic>? appMetadata,
+    this.givenName,
+  })
+      : _id = id,
+        _identities = identities,
+        _extraInfo = extraInfo,
+        _userMetadata = userMetadata,
+        _appMetadata = appMetadata;
+
+  /// Getter for the unique Identifier of the user. If this represents a Full User Profile (Management API) the 'id' field will be returned.
+  /// If the value is not present, it will be considered a User Information and the id will be obtained from the 'sub' claim.
+  String? getId() {
+    if (_id != null) {
+      return _id;
+    }
+    // Using null-aware operator and type checking for 'sub'
+    return (_extraInfo != null && _extraInfo.containsKey('sub'))
+        ? _extraInfo['sub'] as String?
+        : null;
+  }
+
+  Map<String, dynamic> getUserMetadata() =>
+      _userMetadata ?? {}; // Return empty map if null
+
+  Map<String, dynamic> getAppMetadata() =>
+      _appMetadata ?? {}; // Return empty map if null
+
+  List<UserIdentity> getIdentities() =>
+      _identities ?? []; // Return empty list if null
+
+  /// Returns extra information of the profile that is not part of the normalized profile
+  ///
+  /// @return a map with user's extra information found in the profile
+  Map<String, dynamic> getExtraInfo() =>
+      // Assuming _extraInfo is already a Map<String, dynamic>
+  // If it needed a .toMap() like Kotlin, you'd implement conversion here.
+  _extraInfo ?? {}; // Return empty map if null
+
+  // --- Convenience methods for serialization and immutability ---
+
+  // Factory constructor for creating a UserProfile from a JSON map
+  factory UserInfo.fromJson(final Map<String, dynamic> json) =>
+      UserInfo(
+        id: json['id'] as String?,
+        name: json['name'] as String?,
+        nickname: json['nickname'] as String?,
+        pictureURL: json['pictureURL'] as String?,
+        email: json['email'] as String?,
+        isEmailVerified: json['isEmailVerified'] as bool?,
+        familyName: json['familyName'] as String?,
+        // Handle date parsing
+        createdAt: json['createdAt'] != null
+            ? DateTime.parse(json['createdAt'] as String)
+            : null,
+        // Handle list of UserIdentity
+        identities: (json['identities'] as List<dynamic>?)
+            ?.map((e) => UserIdentity.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        extraInfo: json['extraInfo'] as Map<String, dynamic>?,
+        userMetadata: json['userMetadata'] as Map<String, dynamic>?,
+        appMetadata: json['appMetadata'] as Map<String, dynamic>?,
+        givenName: json['givenName'] as String?,
+      );
+}

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import '../login_options.dart';
 import 'safari_view_controller.dart';
 
@@ -6,24 +8,28 @@ class WebAuthLoginOptions extends LoginOptions {
   final bool useEphemeralSession;
   final String? scheme;
   final SafariViewController? safariViewController;
+  final List<String> allowedPackages;
 
   WebAuthLoginOptions(
-      {super.audience,
-      super.idTokenValidationConfig,
-      super.organizationId,
-      super.invitationUrl,
-      super.redirectUrl,
-      super.scopes,
-      super.parameters,
-      this.useHTTPS = false,
-      this.useEphemeralSession = false,
-      this.scheme,
-      this.safariViewController});
+      {
+        super.audience,
+        super.idTokenValidationConfig,
+        super.organizationId,
+        super.invitationUrl,
+        super.redirectUrl,
+        super.scopes,
+        super.parameters,
+        this.useHTTPS = false,
+        this.useEphemeralSession = false,
+        this.scheme,
+        this.safariViewController,
+        this.allowedPackages = const []});
 
   @override
   Map<String, dynamic> toMap() {
     final map = {
       ...super.toMap(),
+      'allowedPackages': allowedPackages,
       'useHTTPS': useHTTPS,
       'useEphemeralSession': useEphemeralSession,
       'scheme': scheme,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

In android we have api to input allowed browser packages for web auth login. this is required particularly to provide a list of browsers that are allowed to open the universal login url
This api is exposed already in android. Its exposed in flutter for addressing https://github.com/auth0/auth0-flutter/issues/392?reload=1?reload=1


### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
