### PR TITLE
Implements dart api to input allowed browser packages for web auth login #599

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -45,8 +45,14 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
 
         if(args["allowedPackages"] is List<*>) {
-            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
-                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
+            if((args["allowedPackages"] as List<String>).isNotEmpty()) {
+                builder.withCustomTabsOptions(
+                    CustomTabsOptions.newBuilder().withBrowserPicker(
+                        BrowserPicker.newBuilder()
+                            .withAllowedPackages(args["allowedPackages"] as List<String>).build()
+                    ).build()
+                )
+            }
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -3,12 +3,15 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
+import android.util.Log
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
     override val method: String = "webAuth#login"
@@ -38,6 +41,12 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
         if (args["invitationUrl"] is String) {
             builder.withInvitationUrl(args["invitationUrl"] as String)
+        }
+
+
+        if(args["allowedPackages"] is List<*>) {
+            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
+                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -50,7 +50,7 @@ class _ExampleAppState extends State<ExampleApp> {
         return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
 
-      final result = await webAuth.login(useHTTPS: true);
+      final result = await webAuth.login(useHTTPS: true, allowedPackages: []);
 
       setState(() {
         _isLoggedIn = true;

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -81,6 +81,7 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
+        final List<String> allowedPackages = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =
@@ -98,10 +99,10 @@ class WebAuthentication {
             scheme: _scheme,
             useHTTPS: useHTTPS,
             useEphemeralSession: useEphemeralSession,
-            safariViewController: safariViewController)));
+            safariViewController: safariViewController,
+            allowedPackages: allowedPackages)));
 
     await _credentialsManager?.storeCredentials(credentials);
-
     return credentials;
   }
 

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import '../login_options.dart';
 import 'safari_view_controller.dart';
 
@@ -6,24 +8,28 @@ class WebAuthLoginOptions extends LoginOptions {
   final bool useEphemeralSession;
   final String? scheme;
   final SafariViewController? safariViewController;
+  final List<String> allowedPackages;
 
   WebAuthLoginOptions(
-      {super.audience,
-      super.idTokenValidationConfig,
-      super.organizationId,
-      super.invitationUrl,
-      super.redirectUrl,
-      super.scopes,
-      super.parameters,
-      this.useHTTPS = false,
-      this.useEphemeralSession = false,
-      this.scheme,
-      this.safariViewController});
+      {
+        super.audience,
+        super.idTokenValidationConfig,
+        super.organizationId,
+        super.invitationUrl,
+        super.redirectUrl,
+        super.scopes,
+        super.parameters,
+        this.useHTTPS = false,
+        this.useEphemeralSession = false,
+        this.scheme,
+        this.safariViewController,
+        this.allowedPackages = const []});
 
   @override
   Map<String, dynamic> toMap() {
     final map = {
       ...super.toMap(),
+      'allowedPackages': allowedPackages,
       'useHTTPS': useHTTPS,
       'useEphemeralSession': useEphemeralSession,
       'scheme': scheme,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes
In android we have api to input allowed browser packages for web auth login. this is required particularly to provide a list of browsers that are allowed to open the universal login url
This api is exposed already in android. Its exposed in flutter for addressing https://github.com/auth0/auth0-flutter/issues/392

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
