### PR TITLE
dart api to input allowed browser packages for web auth login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,13 +120,13 @@ jobs:
 
     test-ios-unit:
         name: Run native iOS unit tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '16.1'
 
         env:
           platform: iOS
@@ -163,7 +163,7 @@ jobs:
 
     test-ios-smoke:
         name: Run native iOS smoke tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13-large
+        runs-on: macos-14-large
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         env:
@@ -174,7 +174,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '16.1'
 
         steps:
             - name: Checkout
@@ -198,13 +198,13 @@ jobs:
 
     test-macos-unit:
         name: Run native macOS unit tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '16.1'
 
         env:
           platform: macOS
@@ -235,7 +235,7 @@ jobs:
 
     test-macos-smoke:
         name: Run native macOS smoke tests using Xcode ${{ matrix.xcode }}
-        runs-on: macos-13
+        runs-on: macos-14
         environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
 
         env:
@@ -246,7 +246,7 @@ jobs:
         strategy:
           matrix:
             xcode:
-              - '15.0.1'
+              - '16.1'
 
         steps:
             - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
     ruby: '3.3.1'
     flutter: '3.x'
-    ios-simulator: iPhone 15
+    ios-simulator: iPhone 16
     java: 11
 
 jobs:

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -11,7 +11,6 @@ import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
-import android.util.Log
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
     override val method: String = "webAuth#login"
@@ -43,16 +42,14 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
             builder.withInvitationUrl(args["invitationUrl"] as String)
         }
 
-
-        if(args["allowedPackages"] is List<*>) {
-            if((args["allowedPackages"] as List<String>).isNotEmpty()) {
-                builder.withCustomTabsOptions(
-                    CustomTabsOptions.newBuilder().withBrowserPicker(
-                        BrowserPicker.newBuilder()
-                            .withAllowedPackages(args["allowedPackages"] as List<String>).build()
-                    ).build()
-                )
-            }
+        val allowedPackages = (args["allowedPackages"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+        if(allowedPackages.isNotEmpty()) {
+            builder.withCustomTabsOptions(
+                CustomTabsOptions.newBuilder().withBrowserPicker(
+                    BrowserPicker.newBuilder()
+                        .withAllowedPackages(allowedPackages).build()
+                ).build()
+            )
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -45,8 +45,14 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
 
         if(args["allowedPackages"] is List<*>) {
-            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
-                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
+            if((args["allowedPackages"] as List<String>).isNotEmpty()) {
+                builder.withCustomTabsOptions(
+                    CustomTabsOptions.newBuilder().withBrowserPicker(
+                        BrowserPicker.newBuilder()
+                            .withAllowedPackages(args["allowedPackages"] as List<String>).build()
+                    ).build()
+                )
+            }
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -3,12 +3,15 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
+import android.util.Log
 
 class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.Builder) : WebAuthRequestHandler {
     override val method: String = "webAuth#login"
@@ -38,6 +41,12 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
 
         if (args["invitationUrl"] is String) {
             builder.withInvitationUrl(args["invitationUrl"] as String)
+        }
+
+
+        if(args["allowedPackages"] is List<*>) {
+            builder.withCustomTabsOptions(CustomTabsOptions.newBuilder().withBrowserPicker(
+                BrowserPicker.newBuilder().withAllowedPackages(args["allowedPackages"] as List<String>).build()).build())
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -42,12 +42,12 @@ class LoginWebAuthRequestHandler(private val builderResolver: (MethodCallRequest
             builder.withInvitationUrl(args["invitationUrl"] as String)
         }
 
-        val allowedPackages = (args["allowedPackages"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        if(allowedPackages.isNotEmpty()) {
+        val allowedBrowsers = (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+        if(allowedBrowsers.isNotEmpty()) {
             builder.withCustomTabsOptions(
                 CustomTabsOptions.newBuilder().withBrowserPicker(
                     BrowserPicker.newBuilder()
-                        .withAllowedPackages(allowedPackages).build()
+                        .withAllowedPackages(allowedBrowsers).build()
                 ).build()
             )
         }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -346,7 +346,7 @@ class LoginWebAuthRequestHandlerTest {
     @Test
     fun `handler should not add an empty allowedPackages when given an empty array`() {
         val args = hashMapOf<String, Any?>(
-            "allowedPackages" to listOf<String>()
+            "allowedBrowsers" to listOf<String>()
         )
 
         runRequestHandler(args) { _, builder ->

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -354,8 +354,7 @@ class LoginWebAuthRequestHandlerTest {
     @Test
     fun `handle skips invalid allowedPackages without crashing`() {
         val argsWithInvalidPackages = requestArgs.toMutableMap().apply {
-            put("allowedPackages", "not-a-list")  // Wrong type
-        }
+            put("allowedPackages", "not-a-list")
         val request = MethodCallRequest("webAuth#login", argsWithInvalidPackages)
         handler.handle(context, request, result)
         verify(result).success(any())

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -340,4 +340,24 @@ class LoginWebAuthRequestHandlerTest {
         assertThat((captor.firstValue as Map<*, *>)["scopes"], equalTo(listOf("scope1", "scope2")))
         assertThat(((captor.firstValue as Map<*, *>)["userProfile"] as Map<*, *>)["name"], equalTo("John Doe"))
     }
+
+    @Test
+    fun `handle works without allowedPackages`() {
+        val argsWithoutPackages = requestArgs.toMutableMap().apply {
+            remove("allowedPackages")
+        }
+        val request = MethodCallRequest("webAuth#login", argsWithoutPackages)
+        handler.handle(context, request, result)
+        verify(result).success(any())
+    }
+
+    @Test
+    fun `handle skips invalid allowedPackages without crashing`() {
+        val argsWithInvalidPackages = requestArgs.toMutableMap().apply {
+            put("allowedPackages", "not-a-list")  // Wrong type
+        }
+        val request = MethodCallRequest("webAuth#login", argsWithInvalidPackages)
+        handler.handle(context, request, result)
+        verify(result).success(any())
+    }
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -344,7 +344,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should add an empty allowedPackages when given an empty array`() {
+    fun `handler should not add an empty allowedPackages when given an empty array`() {
         val args = hashMapOf<String, Any?>(
             "allowedPackages" to listOf<String>()
         )
@@ -356,7 +356,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should add an empty allowedPackages when not specified`() {
+    fun `handler should not add an empty allowedPackages when not specified`() {
         val args = hashMapOf<String, Any?>()
 
         runRequestHandler(args) { _, builder ->

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -50,7 +50,7 @@ class _ExampleAppState extends State<ExampleApp> {
         return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
 
-      final result = await webAuth.login(useHTTPS: true);
+      final result = await webAuth.login(useHTTPS: true, allowedPackages: []);
 
       setState(() {
         _isLoggedIn = true;

--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -50,7 +50,7 @@ class _ExampleAppState extends State<ExampleApp> {
         return auth0Web.loginWithRedirect(redirectUrl: 'http://localhost:3000');
       }
 
-      final result = await webAuth.login(useHTTPS: true, allowedPackages: []);
+      final result = await webAuth.login(useHTTPS: true);
 
       setState(() {
         _isLoggedIn = true;

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -69,6 +69,10 @@ class WebAuthentication {
   /// domain –or custom domain, if you have one.
   /// * (iOS/macOS only): [useEphemeralSession] controls whether shared persistent
   /// storage is used for cookies. [Read more on the effects this setting has](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#2-how-can-i-disable-the-ios-login-alert-box).
+  /// * (android only): [allowedPackages] Defines an allowlist of browser packages
+  /// When the user's default browser is in the allowlist, it uses the default browser
+  /// When the user's default browser is not in the allowlist, but the user has another allowed browser installed, the allowed browser is used instead
+  /// When the user's default browser is not in the allowlist, and the user has no other allowed browser installed, an error is returned
   Future<Credentials> login(
       {final String? audience,
       final Set<String> scopes = const {
@@ -81,7 +85,7 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
-        final List<String> allowedPackages = const [],
+      final List<String> allowedPackages = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -81,6 +81,7 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
+        final List<String> allowedPackages = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =
@@ -98,10 +99,10 @@ class WebAuthentication {
             scheme: _scheme,
             useHTTPS: useHTTPS,
             useEphemeralSession: useEphemeralSession,
-            safariViewController: safariViewController)));
+            safariViewController: safariViewController,
+            allowedPackages: allowedPackages)));
 
     await _credentialsManager?.storeCredentials(credentials);
-
     return credentials;
   }
 

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -69,7 +69,7 @@ class WebAuthentication {
   /// domain –or custom domain, if you have one.
   /// * (iOS/macOS only): [useEphemeralSession] controls whether shared persistent
   /// storage is used for cookies. [Read more on the effects this setting has](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#2-how-can-i-disable-the-ios-login-alert-box).
-  /// * (android only): [allowedPackages] Defines an allowlist of browser packages
+  /// * (android only): [allowedBrowsers] Defines an allowlist of browser packages
   /// When the user's default browser is in the allowlist, it uses the default browser
   /// When the user's default browser is not in the allowlist, but the user has another allowed browser installed, the allowed browser is used instead
   /// When the user's default browser is not in the allowlist, and the user has no other allowed browser installed, an error is returned
@@ -85,7 +85,7 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
-      final List<String> allowedPackages = const [],
+      final List<String> allowedBrowsers = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =
@@ -104,7 +104,7 @@ class WebAuthentication {
             useHTTPS: useHTTPS,
             useEphemeralSession: useEphemeralSession,
             safariViewController: safariViewController,
-            allowedPackages: allowedPackages)));
+            allowedBrowsers: allowedBrowsers)));
 
     await _credentialsManager?.storeCredentials(credentials);
     return credentials;

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -6,7 +6,7 @@ class WebAuthLoginOptions extends LoginOptions {
   final bool useEphemeralSession;
   final String? scheme;
   final SafariViewController? safariViewController;
-  final List<String> allowedPackages;
+  final List<String> allowedBrowsers;
 
   WebAuthLoginOptions(
       {
@@ -21,13 +21,13 @@ class WebAuthLoginOptions extends LoginOptions {
         this.useEphemeralSession = false,
         this.scheme,
         this.safariViewController,
-        this.allowedPackages = const []});
+        this.allowedBrowsers = const []});
 
   @override
   Map<String, dynamic> toMap() {
     final map = {
       ...super.toMap(),
-      'allowedPackages': allowedPackages,
+      'allowedBrowsers': allowedBrowsers,
       'useHTTPS': useHTTPS,
       'useEphemeralSession': useEphemeralSession,
       'scheme': scheme,

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import '../login_options.dart';
 import 'safari_view_controller.dart';
 
@@ -6,24 +8,28 @@ class WebAuthLoginOptions extends LoginOptions {
   final bool useEphemeralSession;
   final String? scheme;
   final SafariViewController? safariViewController;
+  final List<String> allowedPackages;
 
   WebAuthLoginOptions(
-      {super.audience,
-      super.idTokenValidationConfig,
-      super.organizationId,
-      super.invitationUrl,
-      super.redirectUrl,
-      super.scopes,
-      super.parameters,
-      this.useHTTPS = false,
-      this.useEphemeralSession = false,
-      this.scheme,
-      this.safariViewController});
+      {
+        super.audience,
+        super.idTokenValidationConfig,
+        super.organizationId,
+        super.invitationUrl,
+        super.redirectUrl,
+        super.scopes,
+        super.parameters,
+        this.useHTTPS = false,
+        this.useEphemeralSession = false,
+        this.scheme,
+        this.safariViewController,
+        this.allowedPackages = const []});
 
   @override
   Map<String, dynamic> toMap() {
     final map = {
       ...super.toMap(),
+      'allowedPackages': allowedPackages,
       'useHTTPS': useHTTPS,
       'useEphemeralSession': useEphemeralSession,
       'scheme': scheme,

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import '../login_options.dart';
 import 'safari_view_controller.dart';
 

--- a/auth0_flutter_platform_interface/test/web_auth_login_options_test.dart
+++ b/auth0_flutter_platform_interface/test/web_auth_login_options_test.dart
@@ -1,0 +1,54 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WebAuthLoginOptions', () {
+    test('toMap should include all fields correctly', () {
+      final safariViewController = SafariViewController(presentationStyle: SafariViewControllerPresentationStyle.automatic);
+      final idTokenValidationConfig = IdTokenValidationConfig(leeway: 0, maxAge: 0, issuer: "issuer");
+      final options = WebAuthLoginOptions(
+        audience: 'https://myapi.com',
+        idTokenValidationConfig: idTokenValidationConfig,
+        organizationId: 'org_123',
+        invitationUrl: 'https://invite.com',
+        redirectUrl: 'com.app://login',
+        scopes: {'openid', 'profile'},
+        parameters: {'prompt': 'login'},
+        useHTTPS: true,
+        useEphemeralSession: true,
+        scheme: 'demo',
+        safariViewController: safariViewController,
+        allowedBrowsers: ['chrome', 'firefox'],
+      );
+
+      final map = options.toMap();
+
+      expect(map['audience'], 'https://myapi.com');
+      expect(map['leeway'], idTokenValidationConfig.leeway);
+      expect(map['issuer'], idTokenValidationConfig.issuer);
+      expect(map['maxAge'], idTokenValidationConfig.maxAge);
+      expect(map['organizationId'], 'org_123');
+      expect(map['invitationUrl'], 'https://invite.com');
+      expect(map['redirectUrl'], 'com.app://login');
+      expect(map['scopes'], ['openid', 'profile']);
+      expect(map['parameters'], {'prompt': 'login'});
+      expect(map['useHTTPS'], true);
+      expect(map['useEphemeralSession'], true);
+      expect(map['scheme'], 'demo');
+      expect(map['allowedBrowsers'], ['chrome', 'firefox']);
+      expect(map['safariViewController'], safariViewController.toMap());
+    });
+
+    test('toMap should handle null optional values gracefully', () {
+      final options = WebAuthLoginOptions();
+
+      final map = options.toMap();
+
+      expect(map['useHTTPS'], false);
+      expect(map['useEphemeralSession'], false);
+      expect(map['scheme'], isNull);
+      expect(map['safariViewController'], isNull);
+      expect(map['allowedBrowsers'], isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

In android we have api to input allowed browser packages for web auth login. this is required particularly to provide a list of browsers that are allowed to open the universal login url
This api is exposed already in android. Its exposed in flutter for addressing https://github.com/auth0/auth0-flutter/issues/392

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Reviewers can pass allowedPackages while performing login via web auth.

When the user's default browser is in the allowlist, it uses the default browser
When the user's default browser is not in the allowlist, but the user has another allowed browser installed, the allowed browser is used instead
When the user's default browser is not in the allowlist, and the user has no other allowed browser installed, an error is returned