### PR TITLE
Adding fix for OnLoad() for refresh redirecting

### DIFF
--- a/auth0_flutter/lib/auth0_flutter_web.dart
+++ b/auth0_flutter/lib/auth0_flutter_web.dart
@@ -7,17 +7,27 @@ export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
 /// Primary interface for interacting with Auth0 on web platforms.
 class Auth0Web {
   final Account _account;
+  final String? _redirectUrl;
+  final CacheLocation? _cacheLocation;
 
   final UserAgent _userAgent =
       UserAgent(name: 'auth0-flutter', version: version);
 
-  /// Creates an instance of the [Auth0Web] client with the provided [domain]
-  /// and [clientId] properties.
+  /// Creates an instance of the [Auth0Web] client with the provided
+  /// [domain], [clientId], and optional [redirectUrl] and [cacheLocation] properties.
+  ///
+  /// [redirectUrl] is used for silent authentication in [onLoad].
+  /// [cacheLocation] is used to specify where the SDK should store
+  /// its authentication state. Defaults to `memory`. Setting this to `localStorage`
+  /// is often required for seamless silent authentication on page reloads.
   ///
   /// [domain] and [clientId] are both values that can be retrieved from the
   /// **Settings** page of your [Auth0 application](https://manage.auth0.com/#/applications/).
-  Auth0Web(final String domain, final String clientId)
-      : _account = Account(domain, clientId);
+  Auth0Web(final String domain, final String clientId,
+      {final String? redirectUrl, final CacheLocation? cacheLocation})
+      : _account = Account(domain, clientId),
+        _redirectUrl = redirectUrl,
+        _cacheLocation = cacheLocation;
 
   /// Get the app state that was provided during a previous call
   /// to [loginWithRedirect].
@@ -63,7 +73,7 @@ class Auth0Web {
         ClientOptions(
             account: _account,
             authorizeTimeoutInSeconds: authorizeTimeoutInSeconds,
-            cacheLocation: cacheLocation,
+            cacheLocation: cacheLocation ?? _cacheLocation,
             cookieDomain: cookieDomain,
             httpTimeoutInSeconds: httpTimeoutInSeconds,
             idTokenValidationConfig:
@@ -76,7 +86,10 @@ class Auth0Web {
             useRefreshTokensFallback: useRefreshTokensFallback,
             audience: audience,
             scopes: scopes,
-            parameters: parameters),
+            parameters: {
+              if (_redirectUrl != null) 'redirect_uri': _redirectUrl!,
+              ...parameters
+            }),
         _userAgent);
 
     if (await hasValidCredentials()) {

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -33,7 +33,6 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   /// Thus clearing this object is not needed,
   /// as the actual state is managed across reloads,
   /// using the transaction manager.
-  // TODO: move the `appState` to the result of `onLoad/initialize`
   Object? _appState;
 
   @override
@@ -57,6 +56,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
 
         _appState = result.appState.dartify();
 
+        window.history.replaceState(null, '', window.location.pathname);
         return;
       } catch (e) {
         throw WebExceptionExtension.fromJsObject(JSObject.fromInteropObject(e));


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ X] All new/changed/fixed functionality is covered by tests (or N/A)
- [ X] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Added redirectUrl and cacheLocation to the Auth0Web constructor: These optional parameters allow developers to configure the redirect URI and authentication state storage location once at initialization. This ensures consistency between loginWithRedirect and onLoad() calls.

Fixed onLoad() silent authentication: Previously, onLoad() could fail on page refresh due to a redirect_uri mismatch or a missing_transaction error.

### 📎 References
https://github.com/auth0/auth0-flutter/issues/409

### 🎯 Testing

The new functionality is covered by manual end-to-end testing.
