### PR TITLE
fix(android): SMS login to use phoneNumber instead of email

### DIFF
--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -23,7 +23,7 @@ runs:
         pip install boto3 requests
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@aa1f74b81b53cb3adb28afcdb21d7b9f3fceea98 # pin@v4.3.0
+      uses: aws-actions/configure-aws-credentials@209f2a4450bb4b277e1dedaff40ad2fd8d4d0a4c # pin@v4.3.0
       with:
         role-to-assume: ${{ env.PRODSEC_TOOLS_ARN }}
         aws-region: 'us-east-1'

--- a/.github/actions/setup-darwin/action.yml
+++ b/.github/actions/setup-darwin/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@0ecad18fe538ef70f6b82773daecc6af1a7fe58a # pin@v1.252.0
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # pin@v1.255.0
       with:
         ruby-version: ${{ inputs.ruby }}
         bundler-cache: true

--- a/.github/workflows/check-symlinks.yml
+++ b/.github/workflows/check-symlinks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
         - name: Checkout
-          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
         - name: Run check
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Install Flutter
               uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Install Flutter
               uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
@@ -68,7 +68,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Install Flutter
               uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
@@ -99,7 +99,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Install Flutter
               uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # pin@v2.21.0
@@ -133,7 +133,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Set up environment
               uses: ./.github/actions/setup-darwin
@@ -178,7 +178,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Set up environment
               uses: ./.github/actions/setup-darwin
@@ -211,7 +211,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Set up environment
               uses: ./.github/actions/setup-darwin
@@ -250,7 +250,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Set up environment
               uses: ./.github/actions/setup-darwin
@@ -275,7 +275,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Set up environment
               uses: ./.github/actions/setup-android
@@ -323,7 +323,7 @@ jobs:
 
     #     steps:
     #         - name: Checkout
-    #           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    #           uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
     #         - name: Gradle cache
     #           uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc
@@ -423,7 +423,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
             - name: Download coverage report for auth0_flutter
               uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0

--- a/.github/workflows/publish-af.yml
+++ b/.github/workflows/publish-af.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Flutter and Dart SDK
         uses: ./.github/actions/setup-publish

--- a/.github/workflows/publish-afpi.yml
+++ b/.github/workflows/publish-afpi.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Flutter and Dart SDK
         uses: ./.github/actions/setup-publish

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha || github.ref }}
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithSMSCodeApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithSMSCodeApiRequestHandler.kt
@@ -23,7 +23,7 @@ class LoginWithSMSCodeApiRequestHandler : ApiRequestHandler {
         assertHasProperties(listOf("phoneNumber", "verificationCode"), args)
 
         val builder = api.loginWithPhoneNumber(
-            args["email"] as String,
+            args["phoneNumber"] as String,
             args["verificationCode"] as String
         ).apply {
             val scopes = (args["scopes"] ?: arrayListOf<String>()) as ArrayList<*>


### PR DESCRIPTION

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)


### 📋 Changes

- Fixed `LoginWithSMSCodeApiRequestHandler` to pass the correct phoneNumber argument to `AuthenticationAPIClient.loginWithPhoneNumber()` instead of email.

- This ensures that SMS-based authentication works correctly without causing `null cannot be cast to non-null type kotlin.String errors`.


### 📎 References
- Fixes #632


### 🎯 Testing
Manual verification steps:

#### Manual verification steps using the example app:

- Run the included example app.

- Use the passwordless embedded flow:

Start authentication with:

```
api.startPasswordlessWithPhoneNumber(phoneNumber: "+XXXXXXX")
```
- Then log in with:

```
api.loginWithSmsCode(
  phoneNumber: "+XXXXXXX",
  verificationCode: "123456"
)
```
#### Expected results:

No crash or null cannot be cast error occurs.
