### PR TITLE
Resolves the inconsistency where the web platform required an invitation ticket ID for the  parameter, while mobile platforms required the full URL.

### DIFF
--- a/auth0_flutter/example/web/index.html
+++ b/auth0_flutter/example/web/index.html
@@ -38,7 +38,7 @@
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter_bootstrap.js" async></script>
-  <script src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js" defer></script>
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
 </head>
 <body>
   <script>

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -69,7 +69,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<void> loginWithRedirect(final LoginOptions? options) {
     final client = _ensureClient();
-    final invitationTicket = getInvitationTicket(options?.invitationUrl);
+    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
 
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
@@ -94,7 +94,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<Credentials> loginWithPopup(final PopupLoginOptions? options) async {
     final client = _ensureClient();
-    final invitationTicket = getInvitationTicket(options?.invitationUrl);
+    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
 
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
@@ -154,7 +154,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<bool> hasValidCredentials() => clientProxy!.isAuthenticated();
 
-  String? getInvitationTicket(final String? invitationUrl) {
+  String? _getInvitationTicket(final String? invitationUrl) {
     if (invitationUrl == null || invitationUrl.isEmpty) {
       return null;
     }

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -39,18 +39,21 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   Future<Object?> get appState => Future<Object?>.value(_appState);
 
   String? _getInvitationTicket(final String? invitationUrl) {
-    if (invitationUrl == null) {
+    if (invitationUrl == null || invitationUrl.isEmpty) {
       return null;
     }
 
     final uri = Uri.tryParse(invitationUrl);
-    // If it's a full URL, parse the 'invitation' query parameter.
-    if (uri != null && uri.hasAuthority) {
-      return uri.queryParameters['invitation'];
+
+    // If parsing fails or it's not a valid web/custom scheme URL,
+    // the input string is the ticket ID itself.
+    if (uri == null || !uri.hasAuthority) {
+      return invitationUrl;
     }
 
-    // Otherwise, it's the invitation ticket ID itself.
-    return invitationUrl;
+    // If it is a valid URL, return the 'invitation' query parameter,
+    // which will be the ticket ID if present, or null if not.
+    return uri.queryParameters['invitation'];
   }
 
   @override

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -38,6 +38,21 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<Object?> get appState => Future<Object?>.value(_appState);
 
+  String? _getInvitationTicket(final String? invitationUrl) {
+    if (invitationUrl == null) {
+      return null;
+    }
+
+    final uri = Uri.tryParse(invitationUrl);
+    // If it's a full URL, parse the 'invitation' query parameter.
+    if (uri != null && uri.hasAuthority) {
+      return uri.queryParameters['invitation'];
+    }
+
+    // Otherwise, it's the invitation ticket ID itself.
+    return invitationUrl;
+  }
+
   @override
   Future<void> initialize(
       final ClientOptions clientOptions, final UserAgent userAgent) async {
@@ -69,12 +84,14 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<void> loginWithRedirect(final LoginOptions? options) {
     final client = _ensureClient();
+    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
+
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
             audience: options?.audience,
             redirect_uri: options?.redirectUrl,
             organization: options?.organizationId,
-            invitation: options?.invitationUrl,
+            invitation: invitationTicket,
             max_age: options?.idTokenValidationConfig?.maxAge,
             scope: options?.scopes.isNotEmpty == true
                 ? options?.scopes.join(' ')
@@ -92,12 +109,13 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<Credentials> loginWithPopup(final PopupLoginOptions? options) async {
     final client = _ensureClient();
+    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
 
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
             audience: options?.audience,
             organization: options?.organizationId,
-            invitation: options?.invitationUrl,
+            invitation: invitationTicket,
             max_age: options?.idTokenValidationConfig?.maxAge,
             scope: options?.scopes.isNotEmpty == true
                 ? options?.scopes.join(' ')

--- a/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
+++ b/auth0_flutter/lib/src/web/auth0_flutter_plugin_real.dart
@@ -38,24 +38,6 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<Object?> get appState => Future<Object?>.value(_appState);
 
-  String? _getInvitationTicket(final String? invitationUrl) {
-    if (invitationUrl == null || invitationUrl.isEmpty) {
-      return null;
-    }
-
-    final uri = Uri.tryParse(invitationUrl);
-
-    // If parsing fails or it's not a valid web/custom scheme URL,
-    // the input string is the ticket ID itself.
-    if (uri == null || !uri.hasAuthority) {
-      return invitationUrl;
-    }
-
-    // If it is a valid URL, return the 'invitation' query parameter,
-    // which will be the ticket ID if present, or null if not.
-    return uri.queryParameters['invitation'];
-  }
-
   @override
   Future<void> initialize(
       final ClientOptions clientOptions, final UserAgent userAgent) async {
@@ -87,7 +69,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<void> loginWithRedirect(final LoginOptions? options) {
     final client = _ensureClient();
-    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
+    final invitationTicket = getInvitationTicket(options?.invitationUrl);
 
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
@@ -112,7 +94,7 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
   @override
   Future<Credentials> loginWithPopup(final PopupLoginOptions? options) async {
     final client = _ensureClient();
-    final invitationTicket = _getInvitationTicket(options?.invitationUrl);
+    final invitationTicket = getInvitationTicket(options?.invitationUrl);
 
     final authParams = JsInteropUtils.stripNulls(JsInteropUtils.addCustomParams(
         interop.AuthorizationParams(
@@ -171,6 +153,24 @@ class Auth0FlutterPlugin extends Auth0FlutterWebPlatform {
 
   @override
   Future<bool> hasValidCredentials() => clientProxy!.isAuthenticated();
+
+  String? getInvitationTicket(final String? invitationUrl) {
+    if (invitationUrl == null || invitationUrl.isEmpty) {
+      return null;
+    }
+
+    final uri = Uri.tryParse(invitationUrl);
+
+    // If parsing fails or it's not a valid web/custom scheme URL,
+    // the input string is the ticket ID itself.
+    if (uri == null || !uri.hasAuthority) {
+      return invitationUrl;
+    }
+
+    // If it is a valid URL, return the 'invitation' query parameter,
+    // which will be the ticket ID if present, or null if not.
+    return uri.queryParameters['invitation'];
+  }
 
   Auth0FlutterWebClientProxy _ensureClient() {
     if (clientProxy == null) {

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -73,20 +73,20 @@ void main() {
   });
 
   test('handleRedirectCallback is called on load when auth params exist in URL',
-      () async {
-    final interop.RedirectLoginResult mockRedirectResult =
+          () async {
+        final interop.RedirectLoginResult mockRedirectResult =
         interop.RedirectLoginResult();
 
-    when(mockClientProxy.isAuthenticated())
-        .thenAnswer((final _) => Future.value(false));
-    when(mockClientProxy.handleRedirectCallback())
-        .thenAnswer((final _) => Future.value(mockRedirectResult));
+        when(mockClientProxy.isAuthenticated())
+            .thenAnswer((final _) => Future.value(false));
+        when(mockClientProxy.handleRedirectCallback())
+            .thenAnswer((final _) => Future.value(mockRedirectResult));
 
-    plugin.urlSearchProvider = () => '?code=abc&state=123';
-    await auth0.onLoad();
-    verify(mockClientProxy.handleRedirectCallback());
-    verifyNever(mockClientProxy.checkSession());
-  });
+        plugin.urlSearchProvider = () => '?code=abc&state=123';
+        await auth0.onLoad();
+        verify(mockClientProxy.handleRedirectCallback());
+        verifyNever(mockClientProxy.checkSession());
+      });
 
   test('handleRedirectCallback captures appState that was passed', () async {
     final Map<String, Object?> appState = <String, Object?>{
@@ -94,7 +94,7 @@ void main() {
     };
 
     final interop.RedirectLoginResult mockRedirectResult =
-        interop.RedirectLoginResult(
+    interop.RedirectLoginResult(
       appState: appState.jsify(),
     );
 
@@ -124,7 +124,7 @@ void main() {
     };
 
     final interop.RedirectLoginResult mockRedirectResult =
-        interop.RedirectLoginResult(
+    interop.RedirectLoginResult(
       appState: appState.jsify(),
     );
 
@@ -146,22 +146,22 @@ void main() {
   });
 
   test('onLoad throws the correct exception from handleRedirectCallback',
-      () async {
-    when(mockClientProxy.isAuthenticated())
-        .thenAnswer((final _) => Future.value(false));
+          () async {
+        when(mockClientProxy.isAuthenticated())
+            .thenAnswer((final _) => Future.value(false));
 
-    when(mockClientProxy.handleRedirectCallback())
-        .thenThrow(createJsException('test', 'test exception'));
+        when(mockClientProxy.handleRedirectCallback())
+            .thenThrow(createJsException('test', 'test exception'));
 
-    plugin.urlSearchProvider = () => '?code=abc&state=123';
+        plugin.urlSearchProvider = () => '?code=abc&state=123';
 
-    expect(
-        () async => auth0.onLoad(),
-        throwsA(predicate((final e) =>
+        expect(
+                () async => auth0.onLoad(),
+            throwsA(predicate((final e) =>
             e is WebException &&
-            e.code == 'test' &&
-            e.message == 'test exception')));
-  });
+                e.code == 'test' &&
+                e.message == 'test exception')));
+      });
 
   test('loginWithRedirect supports appState parameter', () async {
     when(mockClientProxy.isAuthenticated())
@@ -196,7 +196,7 @@ void main() {
 
     await auth0.loginWithRedirect(
         audience: 'http://localhost',
-        invitationUrl: 'https://invitation.uri',
+        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id', // Use a realistic URL
         organizationId: 'org-id',
         redirectUrl: 'http://redirect.uri',
         scopes: {'openid', 'read-books'},
@@ -209,7 +209,7 @@ void main() {
 
     expect(params, isNotNull);
     expect(params.audience, 'http://localhost');
-    expect(params.invitation, 'https://invitation.uri');
+    expect(params.invitation, 'real-ticket-id');
     expect(params.organization, 'org-id');
     expect(params.redirect_uri, 'http://redirect.uri');
     expect(params.scope, 'openid read-books');
@@ -309,9 +309,9 @@ void main() {
         .thenThrow(createJsException('test', 'test exception'));
 
     expect(
-        () async => auth0.credentials(),
+            () async => auth0.credentials(),
         throwsA(predicate((final e) =>
-            e is WebException &&
+        e is WebException &&
             e.code == 'test' &&
             e.message == 'test exception')));
   });
@@ -339,7 +339,7 @@ void main() {
     final credentials = await auth0.loginWithPopup(
         audience: 'http://my.api',
         organizationId: 'org123',
-        invitationUrl: 'http://invitation.url',
+        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id', // Use a realistic URL
         scopes: {'openid'},
         maxAge: 20,
         popupWindow: window,
@@ -352,8 +352,7 @@ void main() {
 
     expect(capture.first.authorizationParams.audience, 'http://my.api');
     expect(capture.first.authorizationParams.organization, 'org123');
-    expect(
-        capture.first.authorizationParams.invitation, 'http://invitation.url');
+    expect(capture.first.authorizationParams.invitation, 'real-ticket-id');
     expect(capture.first.authorizationParams.scope, 'openid');
     expect(capture.first.authorizationParams.max_age, 20);
     expect(capture.last.popup, window);
@@ -375,7 +374,7 @@ void main() {
         .thenAnswer((final _) => Future.value(webCredentials));
 
     final credentials =
-        await auth0.loginWithPopup(parameters: {'screen_hint': 'signup'});
+    await auth0.loginWithPopup(parameters: {'screen_hint': 'signup'});
 
     expect(credentials, isNotNull);
 
@@ -386,70 +385,97 @@ void main() {
   });
 
   test('loginWithPopup throws the correct exception from js.loginWithPopup',
-      () async {
-    when(mockClientProxy.loginWithPopup(any, any))
-        .thenThrow(createJsException('test', 'test exception'));
+          () async {
+        when(mockClientProxy.loginWithPopup(any, any))
+            .thenThrow(createJsException('test', 'test exception'));
 
-    expect(
-        () async => auth0.loginWithPopup(),
-        throwsA(predicate((final e) =>
+        expect(
+                () async => auth0.loginWithPopup(),
+            throwsA(predicate((final e) =>
             e is WebException &&
-            e.code == 'test' &&
-            e.message == 'test exception')));
-  });
+                e.code == 'test' &&
+                e.message == 'test exception')));
+      });
 
   test('loginWithPopup throws the correct exception from getTokenSilently',
-      () async {
-    when(mockClientProxy.loginWithPopup(any, any))
-        .thenAnswer((final _) => Future.value());
+          () async {
+        when(mockClientProxy.loginWithPopup(any, any))
+            .thenAnswer((final _) => Future.value());
 
-    when(mockClientProxy.getTokenSilently(any))
-        .thenThrow(createJsException('test', 'test exception'));
+        when(mockClientProxy.getTokenSilently(any))
+            .thenThrow(createJsException('test', 'test exception'));
 
-    expect(
-        () async => auth0.loginWithPopup(),
-        throwsA(predicate((final e) =>
+        expect(
+                () async => auth0.loginWithPopup(),
+            throwsA(predicate((final e) =>
             e is WebException &&
-            e.code == 'test' &&
-            e.message == 'test exception')));
-  });
+                e.code == 'test' &&
+                e.message == 'test exception')));
+      });
 
   group('invitationUrl handling', () {
     const fullInvitationUrl =
         'https://my-tenant.auth0.com/login/invitation?invitation=abc-123&organization=org_xyz';
     const invitationId = 'abc-123';
+    const invalidUrl = '::not-a-valid-url::';
+    const urlWithoutInvitation = 'https://google.com?q=test';
 
     group('loginWithRedirect', () {
-      test('correctly parses the ticket ID from a full invitation URL',
-          () async {
+      setUp(() {
         when(mockClientProxy.loginWithRedirect(any))
             .thenAnswer((_) => Future.value());
-
-        await auth0.loginWithRedirect(invitationUrl: fullInvitationUrl);
-
-        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
-            .captured
-            .single as interop.RedirectLoginOptions;
-        expect(captured.authorizationParams!.invitation, invitationId);
       });
 
-      test('correctly uses the ticket ID when it is passed directly',
-          () async {
-        when(mockClientProxy.loginWithRedirect(any))
-            .thenAnswer((_) => Future.value());
+      test('correctly parses the ticket ID from a full invitation URL',
+              () async {
+            await auth0.loginWithRedirect(invitationUrl: fullInvitationUrl);
 
-        await auth0.loginWithRedirect(invitationUrl: invitationId);
+            final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+                .captured
+                .single as interop.RedirectLoginOptions;
+            expect(captured.authorizationParams!.invitation, invitationId);
+          });
+
+      test('correctly uses the ticket ID when it is passed directly',
+              () async {
+            await auth0.loginWithRedirect(invitationUrl: invitationId);
+
+            final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+                .captured
+                .single as interop.RedirectLoginOptions;
+            expect(captured.authorizationParams!.invitation, invitationId);
+          });
+
+      test('treats an invalid URL as a ticket ID', () async {
+        await auth0.loginWithRedirect(invitationUrl: invalidUrl);
 
         final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
             .captured
             .single as interop.RedirectLoginOptions;
-        expect(captured.authorizationParams!.invitation, invitationId);
+        expect(captured.authorizationParams!.invitation, invalidUrl);
+      });
+
+      test(
+          'returns null for the ticket when a valid URL without the parameter is passed',
+              () async {
+            await auth0.loginWithRedirect(invitationUrl: urlWithoutInvitation);
+
+            final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+                .captured
+                .single as interop.RedirectLoginOptions;
+            expect(captured.authorizationParams!.invitation, isNull);
+          });
+
+      test('passes null when invitationUrl is an empty string', () async {
+        await auth0.loginWithRedirect(invitationUrl: '');
+
+        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+            .captured
+            .single as interop.RedirectLoginOptions;
+        expect(captured.authorizationParams!.invitation, isNull);
       });
 
       test('passes null when invitationUrl is not provided', () async {
-        when(mockClientProxy.loginWithRedirect(any))
-            .thenAnswer((_) => Future.value());
-
         await auth0.loginWithRedirect();
 
         final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
@@ -468,34 +494,34 @@ void main() {
       });
 
       test('correctly parses the ticket ID from a full invitation URL',
-          () async {
-        await auth0.loginWithPopup(invitationUrl: fullInvitationUrl);
+              () async {
+            await auth0.loginWithPopup(invitationUrl: fullInvitationUrl);
 
-        final captured =
+            final captured =
             verify(mockClientProxy.loginWithPopup(captureAny, any))
                 .captured
                 .single as interop.PopupLoginOptions;
-        expect(captured.authorizationParams!.invitation, invitationId);
-      });
+            expect(captured.authorizationParams!.invitation, invitationId);
+          });
 
       test('correctly uses the ticket ID when it is passed directly',
-          () async {
-        await auth0.loginWithPopup(invitationUrl: invitationId);
+              () async {
+            await auth0.loginWithPopup(invitationUrl: invitationId);
 
-        final captured =
+            final captured =
             verify(mockClientProxy.loginWithPopup(captureAny, any))
                 .captured
                 .single as interop.PopupLoginOptions;
-        expect(captured.authorizationParams!.invitation, invitationId);
-      });
+            expect(captured.authorizationParams!.invitation, invitationId);
+          });
 
       test('passes null when invitationUrl is not provided', () async {
         await auth0.loginWithPopup();
 
         final captured =
-            verify(mockClientProxy.loginWithPopup(captureAny, any))
-                .captured
-                .single as interop.PopupLoginOptions;
+        verify(mockClientProxy.loginWithPopup(captureAny, any))
+            .captured
+            .single as interop.PopupLoginOptions;
         expect(captured.authorizationParams!.invitation, isNull);
       });
     });

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -413,4 +413,91 @@ void main() {
             e.code == 'test' &&
             e.message == 'test exception')));
   });
+
+  group('invitationUrl handling', () {
+    const fullInvitationUrl =
+        'https://my-tenant.auth0.com/login/invitation?invitation=abc-123&organization=org_xyz';
+    const invitationId = 'abc-123';
+
+    group('loginWithRedirect', () {
+      test('correctly parses the ticket ID from a full invitation URL',
+          () async {
+        when(mockClientProxy.loginWithRedirect(any))
+            .thenAnswer((_) => Future.value());
+
+        await auth0.loginWithRedirect(invitationUrl: fullInvitationUrl);
+
+        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+            .captured
+            .single as interop.RedirectLoginOptions;
+        expect(captured.authorizationParams!.invitation, invitationId);
+      });
+
+      test('correctly uses the ticket ID when it is passed directly',
+          () async {
+        when(mockClientProxy.loginWithRedirect(any))
+            .thenAnswer((_) => Future.value());
+
+        await auth0.loginWithRedirect(invitationUrl: invitationId);
+
+        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+            .captured
+            .single as interop.RedirectLoginOptions;
+        expect(captured.authorizationParams!.invitation, invitationId);
+      });
+
+      test('passes null when invitationUrl is not provided', () async {
+        when(mockClientProxy.loginWithRedirect(any))
+            .thenAnswer((_) => Future.value());
+
+        await auth0.loginWithRedirect();
+
+        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+            .captured
+            .single as interop.RedirectLoginOptions;
+        expect(captured.authorizationParams!.invitation, isNull);
+      });
+    });
+
+    group('loginWithPopup', () {
+      setUp(() {
+        when(mockClientProxy.loginWithPopup(any, any))
+            .thenAnswer((_) => Future.value());
+        when(mockClientProxy.getTokenSilently(any))
+            .thenAnswer((_) => Future.value(webCredentials));
+      });
+
+      test('correctly parses the ticket ID from a full invitation URL',
+          () async {
+        await auth0.loginWithPopup(invitationUrl: fullInvitationUrl);
+
+        final captured =
+            verify(mockClientProxy.loginWithPopup(captureAny, any))
+                .captured
+                .single as interop.PopupLoginOptions;
+        expect(captured.authorizationParams!.invitation, invitationId);
+      });
+
+      test('correctly uses the ticket ID when it is passed directly',
+          () async {
+        await auth0.loginWithPopup(invitationUrl: invitationId);
+
+        final captured =
+            verify(mockClientProxy.loginWithPopup(captureAny, any))
+                .captured
+                .single as interop.PopupLoginOptions;
+        expect(captured.authorizationParams!.invitation, invitationId);
+      });
+
+      test('passes null when invitationUrl is not provided', () async {
+        await auth0.loginWithPopup();
+
+        final captured =
+            verify(mockClientProxy.loginWithPopup(captureAny, any))
+                .captured
+                .single as interop.PopupLoginOptions;
+        expect(captured.authorizationParams!.invitation, isNull);
+      });
+    });
+  });
 }

--- a/auth0_flutter/test/web/auth0_flutter_web_test.dart
+++ b/auth0_flutter/test/web/auth0_flutter_web_test.dart
@@ -1,5 +1,4 @@
 @Tags(['browser'])
-
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
@@ -196,7 +195,7 @@ void main() {
 
     await auth0.loginWithRedirect(
         audience: 'http://localhost',
-        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id', // Use a realistic URL
+        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id',
         organizationId: 'org-id',
         redirectUrl: 'http://redirect.uri',
         scopes: {'openid', 'read-books'},
@@ -209,6 +208,7 @@ void main() {
 
     expect(params, isNotNull);
     expect(params.audience, 'http://localhost');
+    // Assert that the extracted ticket ID is correct, not the full URL.
     expect(params.invitation, 'real-ticket-id');
     expect(params.organization, 'org-id');
     expect(params.redirect_uri, 'http://redirect.uri');
@@ -339,7 +339,7 @@ void main() {
     final credentials = await auth0.loginWithPopup(
         audience: 'http://my.api',
         organizationId: 'org123',
-        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id', // Use a realistic URL
+        invitationUrl: 'https://my-tenant.com/invite?invitation=real-ticket-id',
         scopes: {'openid'},
         maxAge: 20,
         popupWindow: window,
@@ -446,14 +446,14 @@ void main() {
             expect(captured.authorizationParams!.invitation, invitationId);
           });
 
-      test('treats an invalid URL as a ticket ID', () async {
-        await auth0.loginWithRedirect(invitationUrl: invalidUrl);
-
-        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
-            .captured
-            .single as interop.RedirectLoginOptions;
-        expect(captured.authorizationParams!.invitation, invalidUrl);
-      });
+      test('uses the original string as ticket ID when URL parsing fails',
+              () async {
+            await auth0.loginWithRedirect(invitationUrl: invalidUrl);
+            final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
+                .captured
+                .single as interop.RedirectLoginOptions;
+            expect(captured.authorizationParams!.invitation, invalidUrl);
+          });
 
       test(
           'returns null for the ticket when a valid URL without the parameter is passed',
@@ -468,16 +468,6 @@ void main() {
 
       test('passes null when invitationUrl is an empty string', () async {
         await auth0.loginWithRedirect(invitationUrl: '');
-
-        final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
-            .captured
-            .single as interop.RedirectLoginOptions;
-        expect(captured.authorizationParams!.invitation, isNull);
-      });
-
-      test('passes null when invitationUrl is not provided', () async {
-        await auth0.loginWithRedirect();
-
         final captured = verify(mockClientProxy.loginWithRedirect(captureAny))
             .captured
             .single as interop.RedirectLoginOptions;


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ X] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Resolves the inconsistency where the web platform required an invitation ticket ID for the `invitationUrl` parameter, while mobile platforms required the full URL.

This change introduces a helper function that checks if the provided `invitationUrl` is a full URL. If it is, it parses the `invitation` query parameter to extract the ticket ID. If it's not a full URL, it's assumed to be the ticket ID itself.

This makes the `invitationUrl` parameter behave consistently across all platforms, allowing developers to pass the full invitation URL without causing an "invitation not found" error on the web.

### 📎 References
https://github.com/auth0/auth0-flutter/issues/615

### 🎯 Testing

E2E testing for Web and added unit test case for the same.
