### PR TITLE
Release af-v1.13.0

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [af-v1.13.0](https://github.com/auth0/auth0-flutter/tree/af-v1.13.0) (2025-09-02)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v1.12.0...af-v1.13.0)
+
+**Fixed**
+- Resolves the inconsistency where the web platform required an invitation ticket ID for the  parameter, while mobile platforms required the full URL. [\#645](https://github.com/auth0/auth0-flutter/pull/645) ([utkrishtsahu](https://github.com/utkrishtsahu))
+- fix(android): SMS login to use phoneNumber instead of email [\#633](https://github.com/auth0/auth0-flutter/pull/633) ([hiiiP0wer](https://github.com/hiiiP0wer))
+- Adding fix for OnLoad() for refresh redirecting [\#624](https://github.com/auth0/auth0-flutter/pull/624) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
 ## [af-v1.12.0](https://github.com/auth0/auth0-flutter/tree/af-v1.12.0) (2025-07-10)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v1.11.0...af-v1.12.0)
 

--- a/auth0_flutter/darwin/auth0_flutter.podspec
+++ b/auth0_flutter/darwin/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.12.0'
+  s.version      = '1.13.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.12.0'
+  s.version      = '1.13.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '1.12.0';
+const String version = '1.13.0';

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '1.12.0'
+  s.version      = '1.13.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android / iOS Flutter apps.
-version: 1.12.0
+version: 1.13.0
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.24.0"
 
 dependencies:
-  auth0_flutter_platform_interface: ^1.12.0
+  auth0_flutter_platform_interface: ^1.13.0
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION

**Fixed**
- Resolves the inconsistency where the web platform required an invitation ticket ID for the  parameter, while mobile platforms required the full URL. [\#645](https://github.com/auth0/auth0-flutter/pull/645) ([utkrishtsahu](https://github.com/utkrishtsahu))
- fix(android): SMS login to use phoneNumber instead of email [\#633](https://github.com/auth0/auth0-flutter/pull/633) ([hiiiP0wer](https://github.com/hiiiP0wer))
- Adding fix for OnLoad() for refresh redirecting [\#624](https://github.com/auth0/auth0-flutter/pull/624) ([utkrishtsahu](https://github.com/utkrishtsahu))
