### PR TITLE
feat(android): Upgrade native SDK to 3.9.0 and adapt to breaking changes

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -443,6 +443,8 @@ final auth0 = Auth0('YOUR_AUTH0_DOMAIN', 'YOUR_AUTH0_CLIENT_ID',
 
 You can enable an additional level of user authentication before retrieving credentials using the local authentication supported by the device, for example PIN or fingerprint on Android, and Face ID or Touch ID on iOS.
 
+To enable this, pass a `LocalAuthentication` instance when you create your `Auth0` object.
+
 ```dart
 const localAuthentication =
     LocalAuthentication(title: 'Please authenticate to continue');
@@ -450,6 +452,7 @@ final auth0 = Auth0('YOUR_AUTH0_DOMAIN', 'YOUR_AUTH0_CLIENT_ID',
     localAuthentication: localAuthentication);
 final credentials = await auth0.credentialsManager.credentials();
 ```
+> ⚠️ On Android, your app's MainActivity.kt file must extend FlutterFragmentActivity instead of FlutterActivity for biometric prompts to work.
 
 Check the [API documentation](https://pub.dev/documentation/auth0_flutter_platform_interface/latest/auth0_flutter_platform_interface/LocalAuthentication-class.html) to learn more about the available `LocalAuthentication` properties.
 
@@ -490,10 +493,16 @@ The Credentials Manager will only throw `CredentialsManagerException` exceptions
 
 ```dart
 try {
-  final credentials = await auth0.credentialsManager.credentials();
-  // ...
+final credentials = await auth0.credentialsManager.credentials();
+// ...
 } on CredentialsManagerException catch (e) {
-  print(e);
+if (e.isNoCredentialsFound) {
+print("No credentials stored.");
+} else if (e.isTokenRenewFailed) {
+print("Failed to renew tokens.");
+} else {
+print(e);
+}
 }
 ```
 

--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:8.4.0"
+        classpath "com.android.tools.build:gradle:8.3.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -31,18 +31,18 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     if (project.android.hasProperty("namespace")) {
         namespace libApplicationId
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {
@@ -51,9 +51,10 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = [auth0Domain: "test-domain", auth0Scheme: "test"]
+        manifestPlaceholders = [auth0Domain: "dev-z0xy0f8x5xj51m2q.us.auth0.com", auth0Scheme: "https"]
+        consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-okio.pro', '../proguard/proguard-jetpack.pro'
     }
 
     buildTypes {
@@ -71,15 +72,20 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    //noinspection GradleDynamicVersion
-    implementation 'com.auth0.android:auth0:2.11.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'com.auth0.android:auth0:3.9.0'
+    implementation "androidx.biometric:biometric:1.1.0"
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.4.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
-    testImplementation 'org.robolectric:robolectric:4.6.1'
+    testImplementation 'org.robolectric:robolectric:4.8.1'
     testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     testImplementation 'com.auth0:java-jwt:3.19.1'
 }

--- a/auth0_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/auth0_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -73,8 +73,6 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     webAuthCallHandler.activity = binding.activity
     credentialsManagerCallHandler.activity = binding.activity
-
-    binding.addActivityResultListener(credentialsManagerCallHandler)
   }
 
   override fun onDetachedFromActivityForConfigChanges() {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/MethodCallRequest.kt
@@ -31,7 +31,7 @@ class MethodCallRequest {
             )
 
             val accountMap = args["_account"] as Map<String, String>
-            val account = Auth0(
+            val account = Auth0.getInstance(
                 accountMap["clientId"] as String,
                 accountMap["domain"] as String
             )

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
@@ -8,6 +8,7 @@ import io.flutter.plugin.common.MethodChannel
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
@@ -32,7 +33,7 @@ class Auth0FlutterPluginTest {
                 )
             }
 
-            assertMethodcallHandler<Auth0FlutterAuthMethodCallHandler>(0)
+            assertMethodcallHandler<Auth0FlutterWebAuthMethodCallHandler>(0)
             assertMethodcallHandler<Auth0FlutterAuthMethodCallHandler>(1)
             assertMethodcallHandler<CredentialsManagerMethodCallHandler>(2)
 
@@ -89,7 +90,7 @@ class Auth0FlutterPluginTest {
             fun <TMethodCallHandler : MethodChannel.MethodCallHandler> getHandler(i: Int): TMethodCallHandler {
                 val captor = argumentCaptor<MethodChannel.MethodCallHandler>()
 
-                verify(constructed[i]).setMethodCallHandler(captor.capture())
+                verify(constructed[i], atLeastOnce()).setMethodCallHandler(captor.capture())
 
                 @Suppress("UNCHECKED_CAST")
                 return captor.firstValue as TMethodCallHandler
@@ -104,7 +105,7 @@ class Auth0FlutterPluginTest {
     }
 
     @Test
-    fun `should call binding addActivityResultListener for CredentialsManager on onAttachedToActivity`() {
+    fun `should NOT call binding addActivityResultListener on onAttachedToActivity`() {
         mockConstruction(MethodChannel::class.java).use {
             val plugin = Auth0FlutterPlugin()
 
@@ -120,7 +121,7 @@ class Auth0FlutterPluginTest {
 
             plugin.onAttachedToActivity(mockActivityBindings)
 
-            verify(mockActivityBindings).addActivityResultListener(
+            verify(mockActivityBindings, never()).addActivityResultListener(
                 any<CredentialsManagerMethodCallHandler>()
             )
         }

--- a/auth0_flutter/example/android/app/build.gradle
+++ b/auth0_flutter/example/android/app/build.gradle
@@ -25,17 +25,18 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
+
     if (project.android.hasProperty("namespace")) {
         namespace exampleAppApplicationId
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {
@@ -47,7 +48,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId exampleAppApplicationId
         minSdkVersion 24
-        targetSdk 34
+        targetSdk 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -93,6 +94,9 @@ flutter {
 
 dependencies {
     kover(project(":auth0_flutter"))
+    implementation "androidx.credentials:credentials-play-services-auth:1.3.0"
+    implementation "androidx.credentials:credentials:1.3.0"
+    implementation 'com.google.code.gson:gson:2.8.9'
 }
 
 koverReport {

--- a/auth0_flutter/example/android/app/src/main/kotlin/com/auth0/auth0_flutter_example/MainActivity.kt
+++ b/auth0_flutter/example/android/app/src/main/kotlin/com/auth0/auth0_flutter_example/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.auth0.auth0_flutter_example
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterFragmentActivity() {
 }

--- a/auth0_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/auth0_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jan 03 12:46:32 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/auth0_flutter/example/android/settings.gradle
+++ b/auth0_flutter/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.4.2" apply false
+    id "com.android.application" version "8.3.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 


### PR DESCRIPTION

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This pull request upgrades the native auth0-android SDK from version 2.11.0 to 3.9.0 and adapts the auth0-flutter plugin to the breaking changes introduced in the new version.

The primary goal is to ensure the Flutter plugin remains up-to-date with the latest features and platform requirements of the underlying native Android library.

### 📎 References

Jira Ticket: SDK-6921

### 🎯 Testing

This PR has been tested manually on an Android device to ensure all key flows are functional after the upgrade.
Also updated UT cases for the same.
