### PR TITLE
docs: Add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Build Status](https://img.shields.io/github/actions/workflow/status/auth0/auth0-flutter/main.yml?style=flat)
 [![Codecov](https://codecov.io/gh/auth0/auth0-flutter/branch/main/graph/badge.svg)](https://codecov.io/gh/auth0/auth0-flutter)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-flutter)
 
 Auth0 SDK for Android, iOS, macOS, and web Flutter apps.
 


### PR DESCRIPTION

This pull request adds the 'Ask DeepWiki' badge to the repository's README file.

### Purpose
The badge provides a direct and convenient link for users and contributors to ask questions and get information about this codebase via DeepWiki, improving the repository's overall supportability and accessibility.

### Automation Context
This change was applied via an automated script to ensure consistency across multiple repositories. No other files or functional code have been modified.
