### PR TITLE
fix: Fixes the build error when running the `dart run build_runner build --delete-conflicting-outputs` command

### DIFF
--- a/auth0_flutter/build.yaml
+++ b/auth0_flutter/build.yaml
@@ -1,0 +1,8 @@
+## This file is required to prevent deleting the mock file for the `auth0_flutter_web_test.dart` when running the build_runner command
+targets:
+  $default:
+    builders:
+      mockito|mockBuilder:
+        generate_for:
+          exclude:
+            - test/web/auth0_flutter_web_test.dart


### PR DESCRIPTION

### 📋 Changes
This PR fixes the build error when running the `dart run build_runner build --delete-conflicting-outputs` command. 
The command deletes the generated mock file for the `auth0_flutter_web_test.dart` file and fails to re-generae it which resulted in the error

### 📎 References

#686 

### 🎯 Testing
This was tested manually to ensure this compiles successfully
