### PR TITLE
Release afpi-v2.0.1

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [afpi-v2.0.1](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.1) (2026-04-15)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.0...afpi-v2.0.1)
+
+**Changed**
+- feat: Expose isRetryable property on CredentialsManagerException, ApiException, and WebAuthenticationException [\#786](https://github.com/auth0/auth0-flutter/pull/786) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
+**Fixed**
+- Set explicit type for .other in switch in FlutterError [\#808](https://github.com/auth0/auth0-flutter/pull/808) ([crazycatk](https://github.com/crazycatk))
+
 ## [afpi-v2.0.0](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.0) (2026-03-18)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.0-beta.1...afpi-v2.0.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 2.0.0
+version: 2.0.1
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Changed**
- feat: Expose isRetryable property on CredentialsManagerException, ApiException, and WebAuthenticationException [\#786](https://github.com/auth0/auth0-flutter/pull/786) ([utkrishtsahu](https://github.com/utkrishtsahu))

**Fixed**
- Set explicit type for .other in switch in FlutterError [\#808](https://github.com/auth0/auth0-flutter/pull/808) ([crazycatk](https://github.com/crazycatk))
