### PR TITLE
Handle Android process death during web authentication

### DIFF
--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -397,6 +397,41 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 
 > 💡 See also [this blog post](https://developer.okta.com/blog/2022/01/13/mobile-sso) for a detailed overview of Single Sign-On (SSO) on iOS.
 
+### Android: Handle Process Death During Login
+
+On Android, some device manufacturers (Samsung, Xiaomi, Huawei, Oppo, Vivo) aggressively kill backgrounded apps to reclaim memory. If the OS kills your app while the user is completing authentication in the browser, the SDK automatically recovers the PKCE state and completes the token exchange when the app is restored.
+
+To receive the recovered credentials, listen to the `onCredentialsRecovered` stream early in your app lifecycle:
+
+```dart
+late StreamSubscription<Credentials> _processDeathSub;
+
+@override
+void initState() {
+  super.initState();
+  _processDeathSub = auth0
+      .webAuthentication()
+      .onCredentialsRecovered
+      .listen((credentials) {
+    // User was authenticated after process death recovery
+    setState(() {
+      _isLoggedIn = true;
+      _credentials = credentials;
+    });
+  });
+}
+
+@override
+void dispose() {
+  _processDeathSub.cancel();
+  super.dispose();
+}
+```
+
+> ⚠️ Without this listener, the credentials are recovered internally but your app will not receive them — the user will appear logged out despite a successful login.
+
+> 💡 This is an Android-only API. On iOS, `ASWebAuthenticationSession` handles the lifecycle automatically. On web, state is persisted in localStorage.
+
 ### Common Tasks
 
 ### 📱 Mobile/macOS
@@ -405,6 +440,7 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 - [Retrieve stored credentials](EXAMPLES.md#retrieve-stored-credentials) - fetch the user's credentials from the storage, automatically renewing them if they have expired.
 - [Retrieve user information](EXAMPLES.md#retrieve-user-information) - fetch the latest user information from the `/userinfo` endpoint.
 - [Native to Web SSO](EXAMPLES.md#native-to-web-sso) - obtain a session transfer token to authenticate a WebView without re-prompting the user.
+- [Handle Android process death](#android-handle-process-death-during-login) - recover credentials when the OS kills your app during login.
 
 ### 🌐 Web
 
@@ -418,6 +454,7 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 
 - [login](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/WebAuthentication/login.html)
 - [logout](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/WebAuthentication/logout.html)
+- [onCredentialsRecovered](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/WebAuthentication/onCredentialsRecovered.html) - stream of credentials recovered after Android process death
 
 #### API
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -69,6 +69,7 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         webAuthMethodChannel.invokeMethod("webAuth#onLoginResult", credentialsMap)
       } else {
         pendingRecoveredCredentials = credentialsMap
+        pendingRecoveryError = null
       }
     }
 
@@ -83,6 +84,7 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         webAuthMethodChannel.invokeMethod("webAuth#onLoginError", errorMap)
       } else {
         pendingRecoveryError = errorMap
+        pendingRecoveredCredentials = null
       }
     }
   }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -1,7 +1,10 @@
 package com.auth0.auth0_flutter
 
 import androidx.annotation.NonNull
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.callback.Callback
 import com.auth0.android.provider.WebAuthProvider
+import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.request_handlers.api.*
 import com.auth0.auth0_flutter.request_handlers.credentials_manager.*
@@ -26,6 +29,9 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private lateinit var dpopMethodChannel : MethodChannel
   private lateinit var binding: FlutterPlugin.FlutterPluginBinding
   private lateinit var authCallHandler: Auth0FlutterAuthMethodCallHandler
+  private var pendingRecoveredCredentials: Map<String, Any?>? = null
+  private var pendingRecoveryError: Map<String, Any?>? = null
+  private var dartReady = false
   private val webAuthCallHandler = Auth0FlutterWebAuthMethodCallHandler(listOf(
     LoginWebAuthRequestHandler(),
     LogoutWebAuthRequestHandler { request: MethodCallRequest -> WebAuthProvider.logout(request.account) },
@@ -44,13 +50,50 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     ClearDPoPKeyApiRequestHandler()
   ))
 
+  private val processDeathCallback = object : Callback<Credentials, AuthenticationException> {
+    override fun onSuccess(credentials: Credentials) {
+      val scopes = credentials.scope?.split(" ") ?: listOf()
+      val formattedDate = credentials.expiresAt.toInstant().toString()
+
+      val credentialsMap = mapOf(
+        "accessToken" to credentials.accessToken,
+        "idToken" to credentials.idToken,
+        "refreshToken" to credentials.refreshToken,
+        "userProfile" to credentials.user.toMap(),
+        "expiresAt" to formattedDate,
+        "scopes" to scopes,
+        "tokenType" to credentials.type
+      )
+
+      if (dartReady) {
+        webAuthMethodChannel.invokeMethod("webAuth#onLoginResult", credentialsMap)
+      } else {
+        pendingRecoveredCredentials = credentialsMap
+      }
+    }
+
+    override fun onFailure(exception: AuthenticationException) {
+      val errorMap = mapOf(
+        "code" to exception.getCode(),
+        "description" to exception.getDescription(),
+        "_isRetryable" to exception.isNetworkError
+      )
+
+      if (dartReady) {
+        webAuthMethodChannel.invokeMethod("webAuth#onLoginError", errorMap)
+      } else {
+        pendingRecoveryError = errorMap
+      }
+    }
+  }
+
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     binding = flutterPluginBinding
     val messenger = binding.binaryMessenger
     val context = binding.applicationContext
 
     webAuthMethodChannel = MethodChannel(messenger, "auth0.com/auth0_flutter/web_auth")
-    webAuthMethodChannel.setMethodCallHandler(webAuthCallHandler)
+    webAuthMethodChannel.setMethodCallHandler(this)
 
     credentialsManagerMethodChannel = MethodChannel(messenger, "auth0.com/auth0_flutter/credentials_manager")
     credentialsManagerMethodChannel.setMethodCallHandler(credentialsManagerCallHandler)
@@ -82,7 +125,23 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     dpopMethodChannel.setMethodCallHandler(dpopCallHandler)
   }
 
-  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {}
+  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+    when (call.method) {
+      "webAuth#dartReady" -> {
+        dartReady = true
+        pendingRecoveredCredentials?.let {
+          webAuthMethodChannel.invokeMethod("webAuth#onLoginResult", it)
+          pendingRecoveredCredentials = null
+        }
+        pendingRecoveryError?.let {
+          webAuthMethodChannel.invokeMethod("webAuth#onLoginError", it)
+          pendingRecoveryError = null
+        }
+        result.success(null)
+      }
+      else -> webAuthCallHandler.onMethodCall(call, result)
+    }
+  }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     webAuthMethodChannel.setMethodCallHandler(null)
@@ -94,17 +153,20 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     webAuthCallHandler.activity = binding.activity
     credentialsManagerCallHandler.activity = binding.activity
+    WebAuthProvider.addCallback(processDeathCallback)
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
-    // Not yet implemented
+    WebAuthProvider.removeCallback(processDeathCallback)
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    // Not yet implemented
+    webAuthCallHandler.activity = binding.activity
+    credentialsManagerCallHandler.activity = binding.activity
+    WebAuthProvider.addCallback(processDeathCallback)
   }
 
   override fun onDetachedFromActivity() {
-    // Not yet implemented
+    WebAuthProvider.removeCallback(processDeathCallback)
   }
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
@@ -103,7 +103,8 @@ class Auth0FlutterPluginTest {
                 return captor.firstValue as TMethodCallHandler
             }
 
-            assert(getHandler<Auth0FlutterWebAuthMethodCallHandler>(0).activity == mockActivity)
+            val webAuthHandler = getHandler<MethodChannel.MethodCallHandler>(0)
+            assert(webAuthHandler is Auth0FlutterPlugin)
             assert(getHandler<CredentialsManagerMethodCallHandler>(1).activity == mockActivity)
             assert(getHandler<CredentialsManagerMethodCallHandler>(1).context == mockContext)
 

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -167,6 +167,43 @@ class WebAuthentication {
     Auth0FlutterWebAuthPlatform.instance.cancel();
   }
 
+  /// Stream of [Credentials] recovered after Android process death.
+  ///
+  /// On Android, if the OS kills the app process while the user is in the
+  /// browser completing authentication, the native SDK
+  /// recovers the PKCE state and completes the token exchange automatically
+  /// when the app is restored. This stream emits those recovered credentials.
+  ///
+  /// Listen to this stream early in your app lifecycle (e.g., in `initState`)
+  /// to handle the case where login completes after process death.
+  ///
+  /// ## Note: This is an Android specific API
+  ///
+  /// Usage example:
+  ///
+  /// ```dart
+  /// late StreamSubscription<Credentials> _processDeathSub;
+  ///
+  /// @override
+  /// void initState() {
+  ///   super.initState();
+  ///   _processDeathSub = auth0
+  ///       .webAuthentication()
+  ///       .onCredentialsRecovered
+  ///       .listen((credentials) {
+  ///     setState(() => _credentials = credentials);
+  ///   });
+  /// }
+  ///
+  /// @override
+  /// void dispose() {
+  ///   _processDeathSub.cancel();
+  ///   super.dispose();
+  /// }
+  /// ```
+  Stream<Credentials> get onCredentialsRecovered =>
+      Auth0FlutterWebAuthPlatform.instance.onCredentialsRecovered;
+
   WebAuthRequest<TOptions>
       _createWebAuthRequest<TOptions extends RequestOptions>(
               final TOptions options) =>

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_auth_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_auth_platform.dart
@@ -25,4 +25,9 @@ abstract class Auth0FlutterWebAuthPlatform extends PlatformInterface {
   void cancel(){
     throw UnimplementedError('webAuth.cancel() has not been implemented');
   }
+
+  Stream<Credentials> get onCredentialsRecovered {
+    throw UnimplementedError(
+        'webAuth.onCredentialsRecovered has not been implemented');
+  }
 }

--- a/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_auth_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/auth0_flutter_web_auth_platform.dart
@@ -26,8 +26,5 @@ abstract class Auth0FlutterWebAuthPlatform extends PlatformInterface {
     throw UnimplementedError('webAuth.cancel() has not been implemented');
   }
 
-  Stream<Credentials> get onCredentialsRecovered {
-    throw UnimplementedError(
-        'webAuth.onCredentialsRecovered has not been implemented');
-  }
+  Stream<Credentials> get onCredentialsRecovered => const Stream.empty();
 }

--- a/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
+++ b/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
@@ -17,12 +17,19 @@ const String logoutMethod = 'webAuth#logout';
 const String cancelMethod = 'webAuth#cancel';
 
 class MethodChannelAuth0FlutterWebAuth extends Auth0FlutterWebAuthPlatform {
-  final StreamController<Credentials> _credentialsRecoveredController =
-      StreamController<Credentials>.broadcast();
+  late final StreamController<Credentials> _credentialsRecoveredController =
+      StreamController<Credentials>.broadcast(onListen: _onFirstListen);
+  bool _dartReadySent = false;
 
   MethodChannelAuth0FlutterWebAuth() {
     _channel.setMethodCallHandler(_handleNativeCallback);
-    _channel.invokeMethod('webAuth#dartReady').catchError((final _) {});
+  }
+
+  void _onFirstListen() {
+    if (!_dartReadySent) {
+      _dartReadySent = true;
+      _channel.invokeMethod('webAuth#dartReady').catchError((final _) {});
+    }
   }
 
   Future<dynamic> _handleNativeCallback(final MethodCall call) async {
@@ -33,6 +40,14 @@ class MethodChannelAuth0FlutterWebAuth extends Auth0FlutterWebAuthPlatform {
         _credentialsRecoveredController.add(credentials);
         break;
       case 'webAuth#onLoginError':
+        final map =
+            Map<String, dynamic>.from(call.arguments as Map);
+        final code = map['code'] as String? ?? 'UNKNOWN';
+        final description = map['description'] as String? ??
+            'Process death recovery failed';
+        _credentialsRecoveredController
+            .addError(WebAuthenticationException(
+                code, description, map));
         break;
     }
   }

--- a/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
+++ b/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
@@ -22,7 +22,7 @@ class MethodChannelAuth0FlutterWebAuth extends Auth0FlutterWebAuthPlatform {
 
   MethodChannelAuth0FlutterWebAuth() {
     _channel.setMethodCallHandler(_handleNativeCallback);
-    _channel.invokeMethod('webAuth#dartReady');
+    _channel.invokeMethod('webAuth#dartReady').catchError((final _) {});
   }
 
   Future<dynamic> _handleNativeCallback(final MethodCall call) async {

--- a/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
+++ b/auth0_flutter_platform_interface/lib/src/method_channel_auth0_flutter_web_auth.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 import 'auth0_flutter_web_auth_platform.dart';
@@ -15,6 +17,30 @@ const String logoutMethod = 'webAuth#logout';
 const String cancelMethod = 'webAuth#cancel';
 
 class MethodChannelAuth0FlutterWebAuth extends Auth0FlutterWebAuthPlatform {
+  final StreamController<Credentials> _credentialsRecoveredController =
+      StreamController<Credentials>.broadcast();
+
+  MethodChannelAuth0FlutterWebAuth() {
+    _channel.setMethodCallHandler(_handleNativeCallback);
+    _channel.invokeMethod('webAuth#dartReady');
+  }
+
+  Future<dynamic> _handleNativeCallback(final MethodCall call) async {
+    switch (call.method) {
+      case 'webAuth#onLoginResult':
+        final map = Map<String, dynamic>.from(call.arguments as Map);
+        final credentials = Credentials.fromMap(map);
+        _credentialsRecoveredController.add(credentials);
+        break;
+      case 'webAuth#onLoginError':
+        break;
+    }
+  }
+
+  @override
+  Stream<Credentials> get onCredentialsRecovered =>
+      _credentialsRecoveredController.stream;
+
   @override
   Future<Credentials> login(
       final WebAuthRequest<WebAuthLoginOptions> request) async {

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -353,4 +353,61 @@ void main() {
       await expectLater(actual, throwsA(isA<WebAuthenticationException>()));
     });
   });
+
+  group('onCredentialsRecovered', () {
+    test('emits credentials when native sends onLoginResult', () async {
+      final instance = MethodChannelAuth0FlutterWebAuth();
+      final future =
+          instance.onCredentialsRecovered.first;
+
+      TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        'auth0.com/auth0_flutter/web_auth',
+        const StandardMethodCodec()
+            .encodeMethodCall(const MethodCall(
+                'webAuth#onLoginResult', MethodCallHandler.loginResult)),
+        (final _) {},
+      );
+
+      final credentials = await future;
+      expect(credentials.accessToken, 'accessToken');
+      expect(credentials.idToken, 'idToken');
+      expect(credentials.refreshToken, 'refreshToken');
+    });
+
+    test('emits error when native sends onLoginError', () async {
+      final instance = MethodChannelAuth0FlutterWebAuth();
+      final future =
+          instance.onCredentialsRecovered.first;
+
+      TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        'auth0.com/auth0_flutter/web_auth',
+        const StandardMethodCodec()
+            .encodeMethodCall(const MethodCall(
+                'webAuth#onLoginError', {
+          'code': 'a]network_error',
+          'description': 'Network request failed',
+          '_isRetryable': true,
+        })),
+        (final _) {},
+      );
+
+      await expectLater(
+          future, throwsA(isA<WebAuthenticationException>()));
+    });
+
+    test(
+        'sends dartReady only after first listener attaches',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => null);
+
+      MethodChannelAuth0FlutterWebAuth();
+
+      verifyNever(mocked.methodCallHandler(any));
+    });
+  });
 }

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -62,7 +62,7 @@ void main() {
               options: WebAuthLoginOptions()));
 
       expect(
-          verify(mocked.methodCallHandler(captureAny)).captured.single.method,
+          verify(mocked.methodCallHandler(captureAny)).captured.last.method,
           'webAuth#login');
     });
 
@@ -88,7 +88,7 @@ void main() {
                       leeway: 10, issuer: 'test-issuer', maxAge: 20))));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
       expect(verificationResult.arguments['_account']['domain'], 'test-domain');
       expect(verificationResult.arguments['_account']['clientId'],
           'test-clientId');
@@ -123,7 +123,7 @@ void main() {
               options: WebAuthLoginOptions()));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
       expect(verificationResult.arguments['scopes'], isEmpty);
       expect(verificationResult.arguments['audience'], isNull);
       expect(verificationResult.arguments['redirectUrl'], isNull);
@@ -192,7 +192,7 @@ void main() {
                           SafariViewControllerPresentationStyle.formSheet))));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
 
       expect(
           verificationResult.arguments['safariViewController']
@@ -212,7 +212,7 @@ void main() {
               options: WebAuthLoginOptions()));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
 
       expect(verificationResult.arguments.containsKey('safariViewController'),
           false);
@@ -268,7 +268,7 @@ void main() {
               options: WebAuthLogoutOptions()));
 
       expect(
-          verify(mocked.methodCallHandler(captureAny)).captured.single.method,
+          verify(mocked.methodCallHandler(captureAny)).captured.last.method,
           'webAuth#logout');
     });
 
@@ -286,7 +286,7 @@ void main() {
                   allowedBrowsers: ['com.android.chrome', 'org.mozilla.firefox'])));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
       expect(verificationResult.arguments['_account']['domain'], 'test-domain');
       expect(verificationResult.arguments['_account']['clientId'],
           'test-clientId');
@@ -311,7 +311,7 @@ void main() {
                   allowedBrowsers: ['com.android.chrome'])));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
       expect(
           verificationResult.arguments['allowedBrowsers'], ['com.android.chrome']);
     });
@@ -328,7 +328,7 @@ void main() {
               options: WebAuthLogoutOptions()));
 
       final verificationResult =
-          verify(mocked.methodCallHandler(captureAny)).captured.single;
+          verify(mocked.methodCallHandler(captureAny)).captured.last;
       expect(verificationResult.arguments['useHTTPS'], false);
       expect(verificationResult.arguments['returnTo'], isNull);
       expect(verificationResult.arguments['scheme'], isNull);


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

On Android devices with aggressive battery management (Samsung, Xiaomi, Huawei, Oppo, Vivo), the OS kills the app process while the user is in the browser completing Auth0 login. When the browser redirects back, the app restarts fresh and the in-memory PKCE callback is lost — the authorization code is never exchanged for tokens. In Auth0 tenant logs, a successful login ("s") appears but no corresponding token exchange.

The native Auth0.Android SDK (since v3.4.0, [PR #784](https://github.com/auth0/Auth0.Android/pull/784)) already handles process death — AuthenticationActivity serializes OAuthManager state (PKCE code_verifier, state nonce) into the Activity Bundle and restores it on recreation. The recovered credentials are delivered via WebAuthProvider.addCallback(). The Flutter plugin never registered this callback, so recovered credentials were silently discarded.

**What changed:**

- Auth0FlutterPlugin.kt — Registers a processDeathCallback via WebAuthProvider.addCallback() / removeCallback() in Activity lifecycle methods. Includes a buffering mechanism: credentials recovered before the Dart isolate is ready are stored in pendingRecoveredCredentials and flushed when Dart sends webAuth#dartReady. The plugin now handles the webAuthMethodChannel directly (intercepting dartReady, delegating all other calls to webAuthCallHandler).
- 
- auth0_flutter_web_auth_platform.dart — Added onCredentialsRecovered stream getter to the abstract platform interface.
- 
- method_channel_auth0_flutter_web_auth.dart — Listens for native → Dart webAuth#onLoginResult method calls via setMethodCallHandler, emits credentials through a broadcast StreamController. Sends webAuth#dartReady in the constructor to signal readiness to the native side.
- 
- web_authentication.dart — Exposes public Stream<Credentials> get onCredentialsRecovered API with documentation.
- 
- README.md — Added "Android: Handle Process Death During Login" section with usage example, a Common Tasks bullet, and an API reference entry for onCredentialsRecovered.

**New public API:**

`Stream<Credentials> get onCredentialsRecovered`

**Developer usage:**

```
auth0.webAuthentication().onCredentialsRecovered.listen((credentials) {
  setState(() => _credentials = credentials);
});
```

### 📎 References

ESD-59215

### 🎯 Testing

Unit tests: Not added — the fix bridges native SDK behavior (WebAuthProvider.addCallback) that requires a real Android Activity lifecycle and process death simulation, which cannot be meaningfully unit tested.

Manual end-to-end testing (verified on Pixel 7a, device 38261JEHN01576):

1. Build and install the app with the fix: flutter build apk --debug
2. Add onCredentialsRecovered listener in your app's initState()
3. Launch the app, tap Login — browser opens with Auth0 Universal Login page
4. While the browser is showing, kill the app process:

adb shell am kill <your.package.name>
⚠️ "Don't keep activities" in Developer Options is not sufficient — it only destroys the Activity but keeps the process alive. You must use adb shell am kill to simulate true process death.

5.Complete login in the browser — the redirect fires, Android restores the app
6.Verify: onCredentialsRecovered stream emits credentials with valid accessToken, idToken, refreshToken, expiresAt, and tokenType

**Test result:** PASS — all token fields present, user authenticated successfully after process death recovery.
