### PR TITLE
Release afpi-v2.0.2

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [afpi-v2.0.2](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.2) (2026-05-07)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.1...afpi-v2.0.2)
+
+**Added**
+- Handle Android process death during web authentication [\#820](https://github.com/auth0/auth0-flutter/pull/820) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
 ## [afpi-v2.0.1](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.1) (2026-04-15)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.0...afpi-v2.0.1)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 2.0.1
+version: 2.0.2
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Added**
- Handle Android process death during web authentication [\#820](https://github.com/auth0/auth0-flutter/pull/820) ([utkrishtsahu](https://github.com/utkrishtsahu))
