### PR TITLE
fix: use safe casts in UserProfileExtensions to prevent ClassCastException

### DIFF
--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
@@ -13,7 +13,7 @@ fun UserProfile.toMap(): Map<String, Any?> {
         "nickname" to this.nickname,
         "preferred_username" to this.preferredUsername,
         "profile" to this.profileURL,
-        "picture" to (getExtraInfo()["picture"] as? String),
+        "picture" to (runCatching { this.pictureURL }.getOrNull() ?: getExtraInfo()["picture"] as? String),
         "website" to this.websiteURL,
         "email" to this.email,
         "email_verified" to this.isEmailVerified,
@@ -66,7 +66,7 @@ val UserProfile.updatedAt: String?
     get() = getExtraInfo()["updated_at"] as? String
 
 val UserProfile.address: Map<String, String>?
-    get() = @Suppress("UNCHECKED_CAST") (getExtraInfo()["address"] as? Map<String, String>)
+    get() = getExtraInfo()["address"] as? Map<String, String>
 
 val UserProfile.customClaims: Map<String, Any>
     get() = getCustomClaims(getExtraInfo())

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/UserProfileExtensions.kt
@@ -13,7 +13,7 @@ fun UserProfile.toMap(): Map<String, Any?> {
         "nickname" to this.nickname,
         "preferred_username" to this.preferredUsername,
         "profile" to this.profileURL,
-        "picture" to this.pictureURL,
+        "picture" to (getExtraInfo()["picture"] as? String),
         "website" to this.websiteURL,
         "email" to this.email,
         "email_verified" to this.isEmailVerified,
@@ -33,40 +33,40 @@ val UserProfile.sub: String
     get() = getExtraInfo()["sub"] as String
 
 val UserProfile.middleName: String?
-    get() = getExtraInfo()["middle_name"] as String?
+    get() = getExtraInfo()["middle_name"] as? String
 
 val UserProfile.preferredUsername: String?
-    get() = getExtraInfo()["preferred_username"] as String?
+    get() = getExtraInfo()["preferred_username"] as? String
 
 val UserProfile.profileURL: String?
-    get() = getExtraInfo()["profile"] as String?
+    get() = getExtraInfo()["profile"] as? String
 
 val UserProfile.websiteURL: String?
-    get() = getExtraInfo()["website"] as String?
+    get() = getExtraInfo()["website"] as? String
 
 val UserProfile.gender: String?
-    get() = getExtraInfo()["gender"] as String?
+    get() = getExtraInfo()["gender"] as? String
 
 val UserProfile.birthdate: String?
-    get() = getExtraInfo()["birthdate"] as String?
+    get() = getExtraInfo()["birthdate"] as? String
 
 val UserProfile.zoneinfo: String?
-    get() = getExtraInfo()["zoneinfo"] as String?
+    get() = getExtraInfo()["zoneinfo"] as? String
 
 val UserProfile.locale: String?
-    get() = getExtraInfo()["locale"] as String?
+    get() = getExtraInfo()["locale"] as? String
 
 val UserProfile.phoneNumber: String?
-    get() = getExtraInfo()["phone_number"] as String?
+    get() = getExtraInfo()["phone_number"] as? String
 
 val UserProfile.isPhoneNumberVerified: Boolean?
-    get() = getExtraInfo()["phone_number_verified"] as Boolean?
+    get() = getExtraInfo()["phone_number_verified"] as? Boolean
 
 val UserProfile.updatedAt: String?
-    get() = getExtraInfo()["updated_at"] as String?
+    get() = getExtraInfo()["updated_at"] as? String
 
 val UserProfile.address: Map<String, String>?
-    get() = getExtraInfo()["address"] as Map<String, String>?
+    get() = @Suppress("UNCHECKED_CAST") (getExtraInfo()["address"] as? Map<String, String>)
 
 val UserProfile.customClaims: Map<String, Any>
     get() = getCustomClaims(getExtraInfo())

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/UserProfileExtensionsTest.kt
@@ -66,6 +66,50 @@ class UserProfileExtensionsTest {
     }
 
     @Test
+    fun `should return null for picture when it is a non-string value`() {
+        val user = UserProfile(
+            "",
+            null, null, null, null, null, null, null, null,
+            mapOf("sub" to "test-sub", "picture" to mapOf("url" to "http://test.com")),
+            null, null, null
+        )
+        assertThat(user.toMap()["picture"], equalTo(null))
+    }
+
+    @Test
+    fun `should return null for string claims when they are non-string values`() {
+        val user = UserProfile(
+            "",
+            null, null, null, null, null, null, null, null,
+            mapOf(
+                "sub" to "test-sub",
+                "middle_name" to mapOf("value" to "test"),
+                "preferred_username" to mapOf("value" to "test"),
+                "profile" to mapOf("value" to "test"),
+                "website" to mapOf("value" to "test"),
+                "gender" to mapOf("value" to "test"),
+                "birthdate" to mapOf("value" to "test"),
+                "zoneinfo" to mapOf("value" to "test"),
+                "locale" to mapOf("value" to "test"),
+                "phone_number" to mapOf("value" to "test"),
+                "updated_at" to mapOf("value" to "test"),
+            ),
+            null, null, null
+        )
+
+        assertThat(user.middleName, equalTo(null))
+        assertThat(user.preferredUsername, equalTo(null))
+        assertThat(user.profileURL, equalTo(null))
+        assertThat(user.websiteURL, equalTo(null))
+        assertThat(user.gender, equalTo(null))
+        assertThat(user.birthdate, equalTo(null))
+        assertThat(user.zoneinfo, equalTo(null))
+        assertThat(user.locale, equalTo(null))
+        assertThat(user.phoneNumber, equalTo(null))
+        assertThat(user.updatedAt, equalTo(null))
+    }
+
+    @Test
     fun `should configure the extension properties`() {
         val user = UserProfile(
             "",


### PR DESCRIPTION
## Summary

Fixes a fatal `ClassCastException` on Android when a social provider returns standard OIDC claims (e.g. `picture`, `profile`) as JSON objects instead of plain strings.

Closes #830

## Problem

`UserProfileExtensions.kt` used unsafe Kotlin casts (`as String?`) for all string-typed OIDC claims read from `getExtraInfo()`. When GSON deserializes a JSON object value it produces a `LinkedTreeMap`. An unsafe `as String?` cast only short-circuits for `null` — it still throws `ClassCastException` for any non-null, non-String value. This caused an immediate crash after login whenever the user profile contained a claim with a non-string value.

Additionally, `picture` was read via `this.pictureURL` which delegates to the base `UserProfile` class property — also an unsafe cast and not overridable by an extension property.

## Changes

### `picture` in `toMap()`
- Tries `runCatching { this.pictureURL }.getOrNull()` first — preserves the base class value (e.g. set via constructor) and catches any `ClassCastException` from the SDK.
- Falls back to `getExtraInfo()["picture"] as? String` — returns `null` instead of crashing if the value is a non-string type.

This two-step approach is necessary because:
- `pictureURL` is a base class member property — extension properties cannot override member properties in Kotlin.
- The base class property does its own unsafe cast internally, so we wrap it in `runCatching` rather than bypassing it entirely.

### All string extension properties
Replaced every `as T?` unsafe cast with `as? T` safe cast. Returns `null` instead of throwing when the value is an unexpected type.

Affected: `middleName`, `preferredUsername`, `profileURL`, `websiteURL`, `gender`, `birthdate`, `zoneinfo`, `locale`, `phoneNumber`, `isPhoneNumberVerified`, `updatedAt`.


## Testing

Added unit tests for the crash scenarios:

- `picture` as a JSON object returns `null` instead of crashing
- All string claims as non-string values return `null` instead of crashing

