### PR TITLE
Release afpi-v2.1.0

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**
 - auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- feat: Flutter Windows support (GA) [#834](https://github.com/auth0/auth0-flutter/pull/834)([NandanPrabhu](https://github.com/NandanPrabhu))
 
 ## [afpi-v2.0.2](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.2) (2026-05-07)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.1...afpi-v2.0.2)

--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [afpi-v2.1.0](https://github.com/auth0/auth0-flutter/tree/afpi-v2.1.0) (2026-05-21)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.2...afpi-v2.1.0)
+
+**Added**
+- auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [afpi-v2.0.2](https://github.com/auth0/auth0-flutter/tree/afpi-v2.0.2) (2026-05-07)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.0.1...afpi-v2.0.2)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 2.1.0-beta.1
+version: 2.1.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Added**
- auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
