### PR TITLE
Release af-v2.1.0

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**
 - auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- feat: Flutter Windows support (GA) [#834](https://github.com/auth0/auth0-flutter/pull/834)([NandanPrabhu](https://github.com/NandanPrabhu))
 
 ## [af-v2.0.2](https://github.com/auth0/auth0-flutter/tree/af-v2.0.2) (2026-05-07)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v2.0.1...af-v2.0.2)

--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [af-v2.1.0](https://github.com/auth0/auth0-flutter/tree/af-v2.1.0) (2026-05-21)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v2.0.2...af-v2.1.0)
+
+**Added**
+- auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [af-v2.0.2](https://github.com/auth0/auth0-flutter/tree/af-v2.0.2) (2026-05-07)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v2.0.1...af-v2.0.2)
 

--- a/auth0_flutter/darwin/auth0_flutter.podspec
+++ b/auth0_flutter/darwin/auth0_flutter.podspec
@@ -4,9 +4,9 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.1.0-beta.1'
+  s.version      = '2.1.0'
   s.summary      = 'Auth0 SDK for Flutter'
-  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'
   s.license      = { :file => '../LICENSE' }
   s.author       = { 'Auth0' => 'support@auth0.com' }

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,9 +4,9 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.1.0-beta.1'
+  s.version      = '2.1.0'
   s.summary      = 'Auth0 SDK for Flutter'
-  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.description  = 'Auth0 SDK for Flutter iOS, Android, macOS, Windows, and web.'
   s.homepage     = 'https://auth0.com'
   s.license      = { :file => '../LICENSE' }
   s.author       = { 'Auth0' => 'support@auth0.com' }

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
   s.version      = '2.1.0'
   s.summary      = 'Auth0 SDK for Flutter'
-  s.description  = 'Auth0 SDK for Flutter iOS, Android, macOS, Windows, and web.'
+  s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'
   s.license      = { :file => '../LICENSE' }
   s.author       = { 'Auth0' => 'support@auth0.com' }

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '2.1.0-beta.1';
+const String version = '2.1.0';

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -4,9 +4,9 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.1.0-beta.1'
+  s.version      = '2.1.0'
   s.summary      = 'Auth0 SDK for Flutter'
-  s.description  = 'Auth0 SDK for Flutter Android and iOS apps.'
+  s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'
   s.license      = { :file => '../LICENSE' }
   s.author       = { 'Auth0' => 'support@auth0.com' }

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android, iOS, macOS, Windows, and web Flutter apps.
-version: 2.1.0-beta.1
+version: 2.1.0
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.24.0"
 
 dependencies:
-  auth0_flutter_platform_interface: ^2.1.0-beta.1
+  auth0_flutter_platform_interface: ^2.1.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/auth0_flutter/windows/test/auth0_api_client_telemetry_test.cpp
+++ b/auth0_flutter/windows/test/auth0_api_client_telemetry_test.cpp
@@ -66,13 +66,13 @@ TEST(BuildAuth0ClientHeaderTest, ContainsNoStandardBase64Chars)
 
 TEST(BuildAuth0ClientHeaderTest, DecodestoValidJson)
 {
-    auto header = BuildAuth0ClientHeader("auth0-flutter", "2.1.0-beta.1");
+    auto header = BuildAuth0ClientHeader("auth0-flutter", "2.1.0");
     auto decoded = Base64UrlDecode(header);
 
     EXPECT_NE(decoded.find("\"name\""), std::string::npos);
     EXPECT_NE(decoded.find("\"auth0-flutter\""), std::string::npos);
     EXPECT_NE(decoded.find("\"version\""), std::string::npos);
-    EXPECT_NE(decoded.find("\"2.1.0-beta.1\""), std::string::npos);
+    EXPECT_NE(decoded.find("\"2.1.0\""), std::string::npos);
     EXPECT_NE(decoded.find("\"env\""), std::string::npos);
     EXPECT_NE(decoded.find("\"Windows\""), std::string::npos);
 }


### PR DESCRIPTION

**Added**
- auth0_flutter from v2.1.0-beta.1 to v2.1.0 (GA)  [\#843](https://github.com/auth0/auth0-flutter/pull/843) ([NandanPrabhu](https://github.com/NandanPrabhu))
- feat: Flutter Windows support (GA) [#834](https://github.com/auth0/auth0-flutter/pull/834)([NandanPrabhu](https://github.com/NandanPrabhu))
