### PR TITLE
feat: add Partial Custom Tabs support for Android

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -10,6 +10,7 @@
   - [Using `SFSafariViewController` (iOS only)](#using-sfsafariviewcontroller-ios-only)
     - [1. Configure a custom URL scheme](#1-configure-a-custom-url-scheme)
     - [2. Capture the callback URL](#2-capture-the-callback-url)
+  - [Using Partial Custom Tabs (Android only)](#using-partial-custom-tabs-android-only)
   - [Errors](#errors)
   - [Android: Custom schemes](#android-custom-schemes)
 - [🪟 Windows Web Authentication](#-windows-web-authentication)
@@ -56,6 +57,7 @@
   - [Using `SFSafariViewController` (iOS only)](#using-sfsafariviewcontroller-ios-only)
     - [1. Configure a custom URL scheme](#1-configure-a-custom-url-scheme)
     - [2. Capture the callback URL](#2-capture-the-callback-url)
+  - [Using Partial Custom Tabs (Android only)](#using-partial-custom-tabs-android-only)
   - [Errors](#errors)
   - [Android: Custom schemes](#android-custom-schemes)
 - [🪟 Windows Web Authentication](#-windows-web-authentication)
@@ -369,6 +371,43 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 ```
 
 </details>
+
+### Using Partial Custom Tabs (Android only)
+
+On Android, auth0_flutter supports [Partial Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/guide-partial-custom-tabs), which display the authentication page as a bottom sheet or side sheet instead of a full-screen browser tab. This requires Chrome 107+ (bottom sheet) or Chrome 120+ (side sheet). On older browsers, the options are ignored and the tab opens full-screen.
+
+```dart
+await auth0.webAuthentication().login(
+    customTabsOptions: const CustomTabsOptions(
+        initialHeight: 700,
+        toolbarCornerRadius: 16,
+        resizable: false,
+        backgroundInteractionEnabled: true,
+        allowedBrowsers: ['com.android.chrome'],
+    ));
+```
+
+The available options are:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `initialHeight` | `int?` | Bottom sheet height in dp. Chrome enforces a minimum of 50% of screen height. |
+| `resizable` | `bool?` | Whether the user can drag to resize the bottom sheet. Defaults to `true`. |
+| `toolbarCornerRadius` | `int?` | Top corner radius in dp (0–16). Only applies in bottom sheet mode. |
+| `initialWidth` | `int?` | Side sheet width in dp. Only applies on screens wider than `sideSheetBreakpoint`. |
+| `sideSheetBreakpoint` | `int?` | Screen width threshold (dp) to switch between bottom sheet and side sheet. Defaults to the browser's built-in value (typically 840dp). |
+| `backgroundInteractionEnabled` | `bool?` | Whether the user can interact with the app behind the partial tab. Defaults to `false`. |
+| `allowedBrowsers` | `List<String>` | Allowlist of browser packages for Custom Tabs. |
+
+You can also use `customTabsOptions` during logout:
+
+```dart
+await auth0.webAuthentication().logout(
+    customTabsOptions: const CustomTabsOptions(
+        initialHeight: 500,
+        toolbarCornerRadius: 12,
+    ));
+```
 
 ### Errors
 

--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -73,7 +73,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.auth0.android:auth0:3.12.0'
+    implementation 'com.auth0.android:auth0:3.16.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -44,14 +44,56 @@ class LoginWebAuthRequestHandler(
             builder.withInvitationUrl(args["invitationUrl"] as String)
         }
 
-        val allowedBrowsers = (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        if(allowedBrowsers.isNotEmpty()) {
-            builder.withCustomTabsOptions(
-                CustomTabsOptions.newBuilder().withBrowserPicker(
+        val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
+        val allowedBrowsers = if (customTabsOptionsMap != null) {
+            (customTabsOptionsMap["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+        } else {
+            (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+        }
+
+        if (customTabsOptionsMap != null || allowedBrowsers.isNotEmpty()) {
+            val ctBuilder = CustomTabsOptions.newBuilder()
+
+            if (allowedBrowsers.isNotEmpty()) {
+                ctBuilder.withBrowserPicker(
                     BrowserPicker.newBuilder()
                         .withAllowedPackages(allowedBrowsers).build()
-                ).build()
-            )
+                )
+            }
+
+            if (customTabsOptionsMap != null) {
+                val initialHeight = customTabsOptionsMap["initialHeight"] as? Int
+                if (initialHeight != null && initialHeight > 0) {
+                    ctBuilder.withInitialHeight(initialHeight)
+                }
+
+                val resizable = customTabsOptionsMap["resizable"] as? Boolean
+                if (resizable != null) {
+                    ctBuilder.withResizable(resizable)
+                }
+
+                val toolbarCornerRadius = customTabsOptionsMap["toolbarCornerRadius"] as? Int
+                if (toolbarCornerRadius != null && toolbarCornerRadius > 0) {
+                    ctBuilder.withToolbarCornerRadius(toolbarCornerRadius)
+                }
+
+                val initialWidth = customTabsOptionsMap["initialWidth"] as? Int
+                if (initialWidth != null && initialWidth > 0) {
+                    ctBuilder.withInitialWidth(initialWidth)
+                }
+
+                val sideSheetBreakpoint = customTabsOptionsMap["sideSheetBreakpoint"] as? Int
+                if (sideSheetBreakpoint != null && sideSheetBreakpoint > 0) {
+                    ctBuilder.withSideSheetBreakpoint(sideSheetBreakpoint)
+                }
+
+                val backgroundInteractionEnabled = customTabsOptionsMap["backgroundInteractionEnabled"] as? Boolean
+                if (backgroundInteractionEnabled == true) {
+                    ctBuilder.withBackgroundInteractionEnabled(true)
+                }
+            }
+
+            builder.withCustomTabsOptions(ctBuilder.build())
         }
 
         if (args["leeway"] is Int) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -3,12 +3,11 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.provider.BrowserPicker
-import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
+import com.auth0.auth0_flutter.utils.buildCustomTabsOptions
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
 
@@ -44,57 +43,7 @@ class LoginWebAuthRequestHandler(
             builder.withInvitationUrl(args["invitationUrl"] as String)
         }
 
-        val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
-        val allowedBrowsers = if (customTabsOptionsMap != null) {
-            (customTabsOptionsMap["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        } else {
-            (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        }
-
-        if (customTabsOptionsMap != null || allowedBrowsers.isNotEmpty()) {
-            val ctBuilder = CustomTabsOptions.newBuilder()
-
-            if (allowedBrowsers.isNotEmpty()) {
-                ctBuilder.withBrowserPicker(
-                    BrowserPicker.newBuilder()
-                        .withAllowedPackages(allowedBrowsers).build()
-                )
-            }
-
-            if (customTabsOptionsMap != null) {
-                val initialHeight = customTabsOptionsMap["initialHeight"] as? Int
-                if (initialHeight != null && initialHeight > 0) {
-                    ctBuilder.withInitialHeight(initialHeight)
-                }
-
-                val resizable = customTabsOptionsMap["resizable"] as? Boolean
-                if (resizable != null) {
-                    ctBuilder.withResizable(resizable)
-                }
-
-                val toolbarCornerRadius = customTabsOptionsMap["toolbarCornerRadius"] as? Int
-                if (toolbarCornerRadius != null && toolbarCornerRadius > 0) {
-                    ctBuilder.withToolbarCornerRadius(toolbarCornerRadius)
-                }
-
-                val initialWidth = customTabsOptionsMap["initialWidth"] as? Int
-                if (initialWidth != null && initialWidth > 0) {
-                    ctBuilder.withInitialWidth(initialWidth)
-                }
-
-                val sideSheetBreakpoint = customTabsOptionsMap["sideSheetBreakpoint"] as? Int
-                if (sideSheetBreakpoint != null && sideSheetBreakpoint > 0) {
-                    ctBuilder.withSideSheetBreakpoint(sideSheetBreakpoint)
-                }
-
-                val backgroundInteractionEnabled = customTabsOptionsMap["backgroundInteractionEnabled"] as? Boolean
-                if (backgroundInteractionEnabled == true) {
-                    ctBuilder.withBackgroundInteractionEnabled(true)
-                }
-            }
-
-            builder.withCustomTabsOptions(ctBuilder.build())
-        }
+        buildCustomTabsOptions(args)?.let { builder.withCustomTabsOptions(it) }
 
         if (args["leeway"] is Int) {
             builder.withIdTokenVerificationLeeway(args["leeway"] as Int)

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
@@ -3,10 +3,9 @@ package com.auth0.auth0_flutter.request_handlers.web_auth
 import android.content.Context
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.provider.BrowserPicker
-import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import com.auth0.auth0_flutter.utils.buildCustomTabsOptions
 import io.flutter.plugin.common.MethodChannel
 
 class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallRequest) -> WebAuthProvider.LogoutBuilder) :
@@ -33,57 +32,7 @@ class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallReques
             builder.withFederated()
         }
 
-        val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
-        val allowedBrowsers = if (customTabsOptionsMap != null) {
-            (customTabsOptionsMap["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        } else {
-            (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        }
-
-        if (customTabsOptionsMap != null || allowedBrowsers.isNotEmpty()) {
-            val ctBuilder = CustomTabsOptions.newBuilder()
-
-            if (allowedBrowsers.isNotEmpty()) {
-                ctBuilder.withBrowserPicker(
-                    BrowserPicker.newBuilder()
-                        .withAllowedPackages(allowedBrowsers).build()
-                )
-            }
-
-            if (customTabsOptionsMap != null) {
-                val initialHeight = customTabsOptionsMap["initialHeight"] as? Int
-                if (initialHeight != null && initialHeight > 0) {
-                    ctBuilder.withInitialHeight(initialHeight)
-                }
-
-                val resizable = customTabsOptionsMap["resizable"] as? Boolean
-                if (resizable != null) {
-                    ctBuilder.withResizable(resizable)
-                }
-
-                val toolbarCornerRadius = customTabsOptionsMap["toolbarCornerRadius"] as? Int
-                if (toolbarCornerRadius != null && toolbarCornerRadius > 0) {
-                    ctBuilder.withToolbarCornerRadius(toolbarCornerRadius)
-                }
-
-                val initialWidth = customTabsOptionsMap["initialWidth"] as? Int
-                if (initialWidth != null && initialWidth > 0) {
-                    ctBuilder.withInitialWidth(initialWidth)
-                }
-
-                val sideSheetBreakpoint = customTabsOptionsMap["sideSheetBreakpoint"] as? Int
-                if (sideSheetBreakpoint != null && sideSheetBreakpoint > 0) {
-                    ctBuilder.withSideSheetBreakpoint(sideSheetBreakpoint)
-                }
-
-                val backgroundInteractionEnabled = customTabsOptionsMap["backgroundInteractionEnabled"] as? Boolean
-                if (backgroundInteractionEnabled == true) {
-                    ctBuilder.withBackgroundInteractionEnabled(true)
-                }
-            }
-
-            builder.withCustomTabsOptions(ctBuilder.build())
-        }
+        buildCustomTabsOptions(args)?.let { builder.withCustomTabsOptions(it) }
 
         builder.start(context, object : Callback<Void?, AuthenticationException> {
             override fun onFailure(exception: AuthenticationException) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
@@ -33,15 +33,56 @@ class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallReques
             builder.withFederated()
         }
 
-        val allowedBrowsers =
+        val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
+        val allowedBrowsers = if (customTabsOptionsMap != null) {
+            (customTabsOptionsMap["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+        } else {
             (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
-        if (allowedBrowsers.isNotEmpty()) {
-            builder.withCustomTabsOptions(
-                CustomTabsOptions.newBuilder().withBrowserPicker(
+        }
+
+        if (customTabsOptionsMap != null || allowedBrowsers.isNotEmpty()) {
+            val ctBuilder = CustomTabsOptions.newBuilder()
+
+            if (allowedBrowsers.isNotEmpty()) {
+                ctBuilder.withBrowserPicker(
                     BrowserPicker.newBuilder()
                         .withAllowedPackages(allowedBrowsers).build()
-                ).build()
-            )
+                )
+            }
+
+            if (customTabsOptionsMap != null) {
+                val initialHeight = customTabsOptionsMap["initialHeight"] as? Int
+                if (initialHeight != null && initialHeight > 0) {
+                    ctBuilder.withInitialHeight(initialHeight)
+                }
+
+                val resizable = customTabsOptionsMap["resizable"] as? Boolean
+                if (resizable != null) {
+                    ctBuilder.withResizable(resizable)
+                }
+
+                val toolbarCornerRadius = customTabsOptionsMap["toolbarCornerRadius"] as? Int
+                if (toolbarCornerRadius != null && toolbarCornerRadius > 0) {
+                    ctBuilder.withToolbarCornerRadius(toolbarCornerRadius)
+                }
+
+                val initialWidth = customTabsOptionsMap["initialWidth"] as? Int
+                if (initialWidth != null && initialWidth > 0) {
+                    ctBuilder.withInitialWidth(initialWidth)
+                }
+
+                val sideSheetBreakpoint = customTabsOptionsMap["sideSheetBreakpoint"] as? Int
+                if (sideSheetBreakpoint != null && sideSheetBreakpoint > 0) {
+                    ctBuilder.withSideSheetBreakpoint(sideSheetBreakpoint)
+                }
+
+                val backgroundInteractionEnabled = customTabsOptionsMap["backgroundInteractionEnabled"] as? Boolean
+                if (backgroundInteractionEnabled == true) {
+                    ctBuilder.withBackgroundInteractionEnabled(true)
+                }
+            }
+
+            builder.withCustomTabsOptions(ctBuilder.build())
         }
 
         builder.start(context, object : Callback<Void?, AuthenticationException> {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/customTabsOptionsBuilder.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/customTabsOptionsBuilder.kt
@@ -1,0 +1,70 @@
+package com.auth0.auth0_flutter.utils
+
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
+
+/**
+ * Builds a [CustomTabsOptions] from the method channel arguments.
+ *
+ * Resolution logic:
+ * - If `customTabsOptions` map is present in [args], its values (including `allowedBrowsers`) are used.
+ * - Otherwise, falls back to top-level `allowedBrowsers` from [args] (deprecated legacy path).
+ * - Returns `null` if neither is provided.
+ */
+fun buildCustomTabsOptions(args: Map<String, Any?>): CustomTabsOptions? {
+    val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
+
+    // Resolve allowedBrowsers: customTabsOptions takes precedence over top-level
+    val allowedBrowsers = if (customTabsOptionsMap != null) {
+        (customTabsOptionsMap["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+    } else {
+        (args["allowedBrowsers"] as? List<*>)?.filterIsInstance<String>().orEmpty()
+    }
+
+    if (customTabsOptionsMap == null && allowedBrowsers.isEmpty()) {
+        return null
+    }
+
+    val ctBuilder = CustomTabsOptions.newBuilder()
+
+    if (allowedBrowsers.isNotEmpty()) {
+        ctBuilder.withBrowserPicker(
+            BrowserPicker.newBuilder()
+                .withAllowedPackages(allowedBrowsers).build()
+        )
+    }
+
+    if (customTabsOptionsMap != null) {
+        val initialHeight = customTabsOptionsMap["initialHeight"] as? Int
+        if (initialHeight != null && initialHeight > 0) {
+            ctBuilder.withInitialHeight(initialHeight)
+        }
+
+        val resizable = customTabsOptionsMap["resizable"] as? Boolean
+        if (resizable != null) {
+            ctBuilder.withResizable(resizable)
+        }
+
+        val toolbarCornerRadius = customTabsOptionsMap["toolbarCornerRadius"] as? Int
+        if (toolbarCornerRadius != null && toolbarCornerRadius > 0) {
+            ctBuilder.withToolbarCornerRadius(toolbarCornerRadius)
+        }
+
+        val initialWidth = customTabsOptionsMap["initialWidth"] as? Int
+        if (initialWidth != null && initialWidth > 0) {
+            ctBuilder.withInitialWidth(initialWidth)
+        }
+
+        val sideSheetBreakpoint = customTabsOptionsMap["sideSheetBreakpoint"] as? Int
+        if (sideSheetBreakpoint != null && sideSheetBreakpoint > 0) {
+            ctBuilder.withSideSheetBreakpoint(sideSheetBreakpoint)
+        }
+
+        val backgroundInteractionEnabled = customTabsOptionsMap["backgroundInteractionEnabled"] as? Boolean
+        if (backgroundInteractionEnabled == true) {
+            ctBuilder.withBackgroundInteractionEnabled(true)
+        }
+    }
+
+    return ctBuilder.build()
+}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/customTabsOptionsBuilder.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/utils/customTabsOptionsBuilder.kt
@@ -11,7 +11,7 @@ import com.auth0.android.provider.CustomTabsOptions
  * - Otherwise, falls back to top-level `allowedBrowsers` from [args] (deprecated legacy path).
  * - Returns `null` if neither is provided.
  */
-fun buildCustomTabsOptions(args: Map<String, Any?>): CustomTabsOptions? {
+fun buildCustomTabsOptions(args: Map<*, *>): CustomTabsOptions? {
     val customTabsOptionsMap = args["customTabsOptions"] as? Map<*, *>
 
     // Resolve allowedBrowsers: customTabsOptions takes precedence over top-level

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandlerTest.kt
@@ -47,6 +47,7 @@ class CredentialsManagerMethodCallHandlerTest {
             val ctx: Context = mock()
             val mockPrefs: SharedPreferences = mock()
             `when`(ctx.getSharedPreferences(any(), any())).thenReturn(mockPrefs)
+            `when`(ctx.applicationContext).thenReturn(ctx)
             ctx
         } else {
             context
@@ -332,6 +333,7 @@ class CredentialsManagerMethodCallHandlerTest {
         val mockPrefs: SharedPreferences = mock()
 
         `when`(context.getSharedPreferences(any(), any())).thenReturn(mockPrefs)
+        `when`(context.applicationContext).thenReturn(context)
 
         handler.activity = activity
         handler.context = context

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CustomTabsOptionsBuilderTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/CustomTabsOptionsBuilderTest.kt
@@ -1,0 +1,147 @@
+package com.auth0.auth0_flutter
+
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
+import com.auth0.auth0_flutter.utils.buildCustomTabsOptions
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomTabsOptionsBuilderTest {
+
+    private fun getPrivateField(obj: Any, fieldName: String): Any? {
+        val field = obj.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(obj)
+    }
+
+    private fun getPrivateIntField(obj: Any, fieldName: String): Int {
+        val field = obj.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.getInt(obj)
+    }
+
+    private fun getPrivateBooleanField(obj: Any, fieldName: String): Boolean {
+        val field = obj.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.getBoolean(obj)
+    }
+
+    @Test
+    fun `returns null when neither customTabsOptions nor allowedBrowsers is provided`() {
+        val args = hashMapOf<String, Any?>()
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, nullValue())
+    }
+
+    @Test
+    fun `returns null when allowedBrowsers is empty and customTabsOptions is absent`() {
+        val args = hashMapOf<String, Any?>("allowedBrowsers" to listOf<String>())
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, nullValue())
+    }
+
+    @Test
+    fun `builds options with initialHeight`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "allowedBrowsers" to listOf<String>()
+            )
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+        assertThat(getPrivateIntField(result!!, "initialHeight"), equalTo(700))
+    }
+
+    @Test
+    fun `builds options with all partial tab properties`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "resizable" to false,
+                "toolbarCornerRadius" to 16,
+                "initialWidth" to 500,
+                "sideSheetBreakpoint" to 840,
+                "backgroundInteractionEnabled" to true,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+        assertThat(getPrivateIntField(result!!, "initialHeight"), equalTo(700))
+        assertThat(getPrivateIntField(result, "toolbarCornerRadius"), equalTo(16))
+        assertThat(getPrivateIntField(result, "initialWidth"), equalTo(500))
+        assertThat(getPrivateIntField(result, "sideSheetBreakpoint"), equalTo(840))
+        assertThat(getPrivateBooleanField(result, "backgroundInteractionEnabled"), equalTo(true))
+    }
+
+    @Test
+    fun `uses allowedBrowsers from customTabsOptions when both are provided`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("org.mozilla.firefox"),
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 500,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+
+        val picker = getPrivateField(result!!, "browserPicker") as BrowserPicker
+        val packagesField = picker.javaClass.getDeclaredField("allowedPackages")
+        packagesField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val packages = packagesField.get(picker) as List<String>
+        assertThat(packages, equalTo(listOf("com.android.chrome")))
+    }
+
+    @Test
+    fun `falls back to top-level allowedBrowsers when customTabsOptions is absent`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("com.android.chrome", "org.mozilla.firefox")
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+
+        val picker = getPrivateField(result!!, "browserPicker") as BrowserPicker
+        val packagesField = picker.javaClass.getDeclaredField("allowedPackages")
+        packagesField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val packages = packagesField.get(picker) as List<String>
+        assertThat(packages, equalTo(listOf("com.android.chrome", "org.mozilla.firefox")))
+    }
+
+    @Test
+    fun `ignores initialHeight when zero or negative`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 0,
+                "allowedBrowsers" to listOf<String>()
+            )
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+        assertThat(getPrivateIntField(result!!, "initialHeight"), equalTo(0))
+    }
+
+    @Test
+    fun `handles missing optional fields gracefully`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "allowedBrowsers" to listOf<String>()
+            )
+        )
+        val result = buildCustomTabsOptions(args)
+        assertThat(result, notNullValue())
+        assertThat(getPrivateIntField(result!!, "initialHeight"), equalTo(0))
+        assertThat(getPrivateIntField(result, "initialWidth"), equalTo(0))
+        assertThat(getPrivateIntField(result, "sideSheetBreakpoint"), equalTo(0))
+        assertThat(getPrivateBooleanField(result, "backgroundInteractionEnabled"), equalTo(false))
+    }
+}

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -392,4 +392,74 @@ class LoginWebAuthRequestHandlerTest {
         }
     }
 
+    @Test
+    fun `handler should apply customTabsOptions with initialHeight`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "allowedBrowsers" to listOf<String>()
+            )
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should apply customTabsOptions with all partial tab options`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "resizable" to false,
+                "toolbarCornerRadius" to 16,
+                "initialWidth" to 500,
+                "sideSheetBreakpoint" to 840,
+                "backgroundInteractionEnabled" to true,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should not apply customTabsOptions when not specified`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf<String>()
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder, never()).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should use allowedBrowsers from customTabsOptions over top-level`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("org.mozilla.firefox"),
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should fall back to top-level allowedBrowsers when customTabsOptions is absent`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("com.android.chrome", "org.mozilla.firefox")
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -3,8 +3,6 @@ package com.auth0.auth0_flutter
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.provider.BrowserPicker
-import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
@@ -393,7 +391,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should apply customTabsOptions with initialHeight`() {
+    fun `handler should apply customTabsOptions when initialHeight is specified`() {
         val args = hashMapOf<String, Any?>(
             "customTabsOptions" to mapOf(
                 "initialHeight" to 700,
@@ -407,7 +405,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should apply customTabsOptions with all partial tab options`() {
+    fun `handler should apply customTabsOptions when all partial tab options are specified`() {
         val args = hashMapOf<String, Any?>(
             "customTabsOptions" to mapOf(
                 "initialHeight" to 700,
@@ -426,7 +424,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should not apply customTabsOptions when not specified`() {
+    fun `handler should not apply customTabsOptions when not specified and allowedBrowsers is empty`() {
         val args = hashMapOf<String, Any?>(
             "allowedBrowsers" to listOf<String>()
         )
@@ -437,7 +435,7 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should use allowedBrowsers from customTabsOptions over top-level`() {
+    fun `handler should prefer customTabsOptions over top-level allowedBrowsers`() {
         val args = hashMapOf<String, Any?>(
             "allowedBrowsers" to listOf("org.mozilla.firefox"),
             "customTabsOptions" to mapOf(

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
@@ -3,8 +3,6 @@ package com.auth0.auth0_flutter
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
-import com.auth0.android.provider.BrowserPicker
-import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.request_handlers.web_auth.LogoutWebAuthRequestHandler
@@ -204,7 +202,7 @@ class LogoutWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should apply customTabsOptions with initialHeight`() {
+    fun `handler should apply customTabsOptions when initialHeight is specified`() {
         val args = hashMapOf<String, Any?>(
             "customTabsOptions" to mapOf(
                 "initialHeight" to 700,
@@ -218,7 +216,7 @@ class LogoutWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should apply customTabsOptions with all partial tab options`() {
+    fun `handler should apply customTabsOptions when all partial tab options are specified`() {
         val args = hashMapOf<String, Any?>(
             "customTabsOptions" to mapOf(
                 "initialHeight" to 500,
@@ -237,7 +235,7 @@ class LogoutWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should not apply customTabsOptions when not specified`() {
+    fun `handler should not apply customTabsOptions when not specified and allowedBrowsers is empty`() {
         val args = hashMapOf<String, Any?>(
             "allowedBrowsers" to listOf<String>()
         )
@@ -248,7 +246,7 @@ class LogoutWebAuthRequestHandlerTest {
     }
 
     @Test
-    fun `handler should use allowedBrowsers from customTabsOptions over top-level`() {
+    fun `handler should prefer customTabsOptions over top-level allowedBrowsers`() {
         val args = hashMapOf<String, Any?>(
             "allowedBrowsers" to listOf("org.mozilla.firefox"),
             "customTabsOptions" to mapOf(

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LogoutWebAuthRequestHandlerTest.kt
@@ -202,4 +202,74 @@ class LogoutWebAuthRequestHandlerTest {
             verify(builder, never()).withCustomTabsOptions(any())
         }
     }
+
+    @Test
+    fun `handler should apply customTabsOptions with initialHeight`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 700,
+                "allowedBrowsers" to listOf<String>()
+            )
+        )
+
+        runHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should apply customTabsOptions with all partial tab options`() {
+        val args = hashMapOf<String, Any?>(
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 500,
+                "resizable" to false,
+                "toolbarCornerRadius" to 12,
+                "initialWidth" to 400,
+                "sideSheetBreakpoint" to 840,
+                "backgroundInteractionEnabled" to true,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+
+        runHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should not apply customTabsOptions when not specified`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf<String>()
+        )
+
+        runHandler(args) { _, builder ->
+            verify(builder, never()).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should use allowedBrowsers from customTabsOptions over top-level`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("org.mozilla.firefox"),
+            "customTabsOptions" to mapOf(
+                "initialHeight" to 500,
+                "allowedBrowsers" to listOf("com.android.chrome")
+            )
+        )
+
+        runHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
+
+    @Test
+    fun `handler should fall back to top-level allowedBrowsers when customTabsOptions is absent`() {
+        val args = hashMapOf<String, Any?>(
+            "allowedBrowsers" to listOf("com.android.chrome", "org.mozilla.firefox")
+        )
+
+        runHandler(args) { _, builder ->
+            verify(builder).withCustomTabsOptions(any())
+        }
+    }
 }

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -13,6 +13,7 @@ export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
         IdTokenValidationConfig,
         SafariViewController,
         SafariViewControllerPresentationStyle,
+        CustomTabsOptions,
         Credentials,
         SSOCredentials,
         UserProfile,

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -69,14 +69,11 @@ class WebAuthentication {
   /// domain –or custom domain, if you have one.
   /// * (iOS/macOS only): [useEphemeralSession] controls whether shared persistent
   /// storage is used for cookies. [Read more on the effects this setting has](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/FAQ.md#2-how-can-i-disable-the-ios-login-alert-box).
+  /// * (android only): [customTabsOptions] configures Chrome Custom Tabs,
+  /// including Partial Custom Tabs (bottom sheet / side sheet) on Chrome 107+.
+  /// See [CustomTabsOptions] for available settings.
   /// * (android only): [allowedBrowsers] Defines an allowlist of browser
-  /// packages
-  /// When the user's default browser is in the allowlist, it uses the default
-  /// browser
-  /// When the user's default browser is not in the allowlist, but the user has
-  /// another allowed browser installed, the allowed browser is used instead
-  /// When the user's default browser is not in the allowlist, and the user has
-  /// no other allowed browser installed, an error is returned
+  /// packages. **Deprecated**: use [customTabsOptions] instead.
   /// * [useDPoP] enables DPoP for enhanced token security.
   /// See README for details. Defaults to `false`.
   Future<Credentials> login(
@@ -91,6 +88,8 @@ class WebAuthentication {
       final String? organizationId,
       final String? invitationUrl,
       final bool useHTTPS = false,
+      final CustomTabsOptions? customTabsOptions,
+      @Deprecated('Use customTabsOptions instead')
       final List<String> allowedBrowsers = const [],
       final bool useEphemeralSession = false,
       final Map<String, String> parameters = const {},
@@ -111,6 +110,8 @@ class WebAuthentication {
             useHTTPS: useHTTPS,
             useEphemeralSession: useEphemeralSession,
             safariViewController: safariViewController,
+            customTabsOptions: customTabsOptions,
+            // ignore: deprecated_member_use_from_same_package
             allowedBrowsers: allowedBrowsers,
             useDPoP: useDPoP)));
 
@@ -135,17 +136,15 @@ class WebAuthentication {
   /// versions of iOS and macOS. Requires an Associated Domain configured with
   /// the `webcredentials` service type, set to your Auth0 domain –or custom
   /// domain, if you have one.
+  /// * (android only): [customTabsOptions] configures Chrome Custom Tabs,
+  /// including Partial Custom Tabs (bottom sheet / side sheet) on Chrome 107+.
   /// * (android only): [allowedBrowsers] Defines an allowlist of browser
-  /// packages
-  /// When the user's default browser is in the allowlist, it uses the default
-  /// browser
-  /// When the user's default browser is not in the allowlist, but the user has
-  /// another allowed browser installed, the allowed browser is used instead
-  /// When the user's default browser is not in the allowlist, and the user has
-  /// no other allowed browser installed, an error is returned
+  /// packages. **Deprecated**: use [customTabsOptions] instead.
   Future<void> logout(
       {final String? returnTo,
       final bool useHTTPS = false,
+      final CustomTabsOptions? customTabsOptions,
+      @Deprecated('Use customTabsOptions instead')
       final List<String> allowedBrowsers = const [],
       final bool federated = false}) async {
     await Auth0FlutterWebAuthPlatform.instance.logout(_createWebAuthRequest(
@@ -154,6 +153,8 @@ class WebAuthentication {
           scheme: _scheme,
           useHTTPS: useHTTPS,
           federated: federated,
+          customTabsOptions: customTabsOptions,
+          // ignore: deprecated_member_use_from_same_package
           allowedBrowsers: allowedBrowsers),
     ));
     await _credentialsManager?.clearCredentials();

--- a/auth0_flutter/test/mobile/web_authentication_test.dart
+++ b/auth0_flutter/test/mobile/web_authentication_test.dart
@@ -357,6 +357,125 @@ void main() {
     });
   });
 
+  group('CustomTabsOptions (Android)', () {
+    group('login', () {
+      test('passes customTabsOptions to the platform when specified', () async {
+        when(mockedPlatform.login(any))
+            .thenAnswer((final _) async => TestPlatform.loginResult);
+        when(mockedCMPlatform.saveCredentials(any))
+            .thenAnswer((final _) async => true);
+
+        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
+            customTabsOptions: const CustomTabsOptions(
+                initialHeight: 700,
+                toolbarCornerRadius: 16,
+                resizable: false,
+                backgroundInteractionEnabled: true,
+                allowedBrowsers: ['com.android.chrome'],
+            ));
+
+        final verificationResult = verify(mockedPlatform.login(captureAny))
+            .captured
+            .single as WebAuthRequest<WebAuthLoginOptions>;
+        expect(verificationResult.options.customTabsOptions, isNotNull);
+        expect(
+            verificationResult.options.customTabsOptions!.initialHeight, 700);
+        expect(
+            verificationResult
+                .options.customTabsOptions!.toolbarCornerRadius,
+            16);
+        expect(
+            verificationResult.options.customTabsOptions!.resizable,
+            false);
+        expect(
+            verificationResult
+                .options.customTabsOptions!.backgroundInteractionEnabled,
+            true);
+        expect(verificationResult.options.customTabsOptions!.allowedBrowsers,
+            ['com.android.chrome']);
+      });
+
+      test('customTabsOptions defaults to null when not specified', () async {
+        when(mockedPlatform.login(any))
+            .thenAnswer((final _) async => TestPlatform.loginResult);
+        when(mockedCMPlatform.saveCredentials(any))
+            .thenAnswer((final _) async => true);
+
+        await Auth0('test-domain', 'test-clientId').webAuthentication().login();
+
+        final verificationResult = verify(mockedPlatform.login(captureAny))
+            .captured
+            .single as WebAuthRequest<WebAuthLoginOptions>;
+        expect(verificationResult.options.customTabsOptions, isNull);
+      });
+
+      test('passes customTabsOptions with side sheet options', () async {
+        when(mockedPlatform.login(any))
+            .thenAnswer((final _) async => TestPlatform.loginResult);
+        when(mockedCMPlatform.saveCredentials(any))
+            .thenAnswer((final _) async => true);
+
+        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
+            customTabsOptions: const CustomTabsOptions(
+                initialHeight: 700,
+                initialWidth: 500,
+                sideSheetBreakpoint: 840,
+            ));
+
+        final verificationResult = verify(mockedPlatform.login(captureAny))
+            .captured
+            .single as WebAuthRequest<WebAuthLoginOptions>;
+        expect(
+            verificationResult.options.customTabsOptions!.initialWidth, 500);
+        expect(
+            verificationResult.options.customTabsOptions!.sideSheetBreakpoint,
+            840);
+      });
+    });
+
+    group('logout', () {
+      test('passes customTabsOptions to the platform when specified', () async {
+        when(mockedPlatform.logout(any)).thenAnswer((final _) async => {});
+        when(mockedCMPlatform.clearCredentials(any))
+            .thenAnswer((final _) async => true);
+
+        await Auth0('test-domain', 'test-clientId').webAuthentication().logout(
+            customTabsOptions: const CustomTabsOptions(
+                initialHeight: 500,
+                toolbarCornerRadius: 12,
+            ));
+
+        final verificationResult = verify(mockedPlatform.logout(captureAny))
+            .captured
+            .single as WebAuthRequest<WebAuthLogoutOptions>;
+        expect(
+            verificationResult.options.customTabsOptions, isNotNull);
+        expect(
+            verificationResult.options.customTabsOptions!.initialHeight,
+            500);
+        expect(
+            verificationResult
+                .options.customTabsOptions!.toolbarCornerRadius,
+            12);
+      });
+
+      test('customTabsOptions defaults to null when not specified', () async {
+        when(mockedPlatform.logout(any)).thenAnswer((final _) async => {});
+        when(mockedCMPlatform.clearCredentials(any))
+            .thenAnswer((final _) async => true);
+
+        await Auth0('test-domain', 'test-clientId')
+            .webAuthentication()
+            .logout();
+
+        final verificationResult = verify(mockedPlatform.logout(captureAny))
+            .captured
+            .single as WebAuthRequest<WebAuthLogoutOptions>;
+        expect(verificationResult.options.customTabsOptions, isNull);
+      });
+    });
+  });
+
   group('DPoP Authentication', () {
     group('login with DPoP', () {
       test('passes useDPoP parameter to platform when enabled', () async {

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -45,6 +45,7 @@ export 'src/request/request_options.dart';
 export 'src/sso_credentials.dart';
 export 'src/user_agent.dart';
 export 'src/user_profile.dart';
+export 'src/web-auth/custom_tabs_options.dart';
 export 'src/web-auth/safari_view_controller.dart';
 export 'src/web-auth/web_auth_login_options.dart';
 export 'src/web-auth/web_auth_logout_options.dart';

--- a/auth0_flutter_platform_interface/lib/src/web-auth/custom_tabs_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/custom_tabs_options.dart
@@ -1,0 +1,64 @@
+/// Configuration for using Chrome Custom Tabs on Android.
+///
+/// Supports Partial Custom Tabs (bottom sheet / side sheet) on Chrome 107+.
+/// On older browsers, these options are ignored and the tab opens full-screen.
+class CustomTabsOptions {
+  /// The initial height of the bottom sheet in dp.
+  ///
+  /// Chrome enforces a minimum of 50% of the screen height.
+  final int? initialHeight;
+
+  /// Whether the user can drag to resize the bottom sheet.
+  ///
+  /// Defaults to `true` when not specified.
+  final bool? resizable;
+
+  /// The toolbar's top corner radius in dp.
+  ///
+  /// Only applies in bottom sheet mode. Values are clamped to [0, 16].
+  final int? toolbarCornerRadius;
+
+  /// The initial width of the side sheet in dp.
+  ///
+  /// Only applies on screens wider than [sideSheetBreakpoint].
+  final int? initialWidth;
+
+  /// The dp breakpoint to toggle between bottom sheet and side sheet.
+  ///
+  /// When the screen width exceeds this value, the tab renders as a side sheet.
+  /// If not set, the browser's default (typically 840dp) is used.
+  final int? sideSheetBreakpoint;
+
+  /// Whether the user can interact with the app behind the partial tab.
+  ///
+  /// Defaults to `false` when not specified.
+  final bool? backgroundInteractionEnabled;
+
+  /// An allowlist of browser packages to use for Custom Tabs.
+  ///
+  /// When the user's default browser is in the allowlist, it is used.
+  /// When the user's default browser is not in the allowlist but another
+  /// allowed browser is installed, that browser is used instead.
+  /// When no allowed browser is installed, an error is returned.
+  final List<String> allowedBrowsers;
+
+  const CustomTabsOptions({
+    this.initialHeight,
+    this.resizable,
+    this.toolbarCornerRadius,
+    this.initialWidth,
+    this.sideSheetBreakpoint,
+    this.backgroundInteractionEnabled,
+    this.allowedBrowsers = const [],
+  });
+
+  Map<String, dynamic> toMap() => {
+        'initialHeight': initialHeight,
+        'resizable': resizable,
+        'toolbarCornerRadius': toolbarCornerRadius,
+        'initialWidth': initialWidth,
+        'sideSheetBreakpoint': sideSheetBreakpoint,
+        'backgroundInteractionEnabled': backgroundInteractionEnabled,
+        'allowedBrowsers': allowedBrowsers,
+      };
+}

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -25,6 +25,7 @@ class WebAuthLoginOptions extends LoginOptions {
       this.scheme,
       this.safariViewController,
       this.customTabsOptions,
+      @Deprecated('Use CustomTabsOptions.allowedBrowsers instead')
       this.allowedBrowsers = const [],
       this.useDPoP = false});
 

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -1,4 +1,5 @@
 import '../login_options.dart';
+import 'custom_tabs_options.dart';
 import 'safari_view_controller.dart';
 
 class WebAuthLoginOptions extends LoginOptions {
@@ -6,6 +7,8 @@ class WebAuthLoginOptions extends LoginOptions {
   final bool useEphemeralSession;
   final String? scheme;
   final SafariViewController? safariViewController;
+  final CustomTabsOptions? customTabsOptions;
+  @Deprecated('Use CustomTabsOptions.allowedBrowsers instead')
   final List<String> allowedBrowsers;
   final bool useDPoP;
 
@@ -21,6 +24,7 @@ class WebAuthLoginOptions extends LoginOptions {
       this.useEphemeralSession = false,
       this.scheme,
       this.safariViewController,
+      this.customTabsOptions,
       this.allowedBrowsers = const [],
       this.useDPoP = false});
 
@@ -35,6 +39,9 @@ class WebAuthLoginOptions extends LoginOptions {
       'useDPoP': useDPoP,
       ...safariViewController != null
           ? {'safariViewController': safariViewController?.toMap()}
+          : <String, dynamic>{},
+      ...customTabsOptions != null
+          ? {'customTabsOptions': customTabsOptions?.toMap()}
           : <String, dynamic>{}
     };
 

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
@@ -16,6 +16,7 @@ class WebAuthLogoutOptions implements RequestOptions {
       this.scheme,
       this.federated = false,
       this.customTabsOptions,
+      @Deprecated('Use CustomTabsOptions.allowedBrowsers instead')
       this.allowedBrowsers = const []});
 
   @override

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
@@ -1,10 +1,13 @@
 import '../request/request_options.dart';
+import 'custom_tabs_options.dart';
 
 class WebAuthLogoutOptions implements RequestOptions {
   final bool useHTTPS;
   final String? returnTo;
   final String? scheme;
   final bool federated;
+  final CustomTabsOptions? customTabsOptions;
+  @Deprecated('Use CustomTabsOptions.allowedBrowsers instead')
   final List<String> allowedBrowsers;
 
   WebAuthLogoutOptions(
@@ -12,6 +15,7 @@ class WebAuthLogoutOptions implements RequestOptions {
       this.returnTo,
       this.scheme,
       this.federated = false,
+      this.customTabsOptions,
       this.allowedBrowsers = const []});
 
   @override
@@ -21,5 +25,8 @@ class WebAuthLogoutOptions implements RequestOptions {
         'scheme': scheme,
         'federated': federated,
         'allowedBrowsers': allowedBrowsers,
+        ...customTabsOptions != null
+            ? {'customTabsOptions': customTabsOptions?.toMap()}
+            : <String, dynamic>{}
       };
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Adds support for [Partial Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/guide-partial-custom-tabs) in auth0-flutter, allowing the authentication page to be displayed as a bottom sheet or side sheet on Android instead of a full-screen browser tab.

**New types:**

- CustomTabsOptions — Dart class mirroring the iOS SafariViewController pattern, with properties: initialHeight, resizable, toolbarCornerRadius, initialWidth, sideSheetBreakpoint, backgroundInteractionEnabled, allowedBrowsers

**Modified methods:**

- WebAuthentication.login() — added optional customTabsOptions parameter
- WebAuthentication.logout() — added optional customTabsOptions parameter

**Deprecated:**

- Top-level allowedBrowsers parameter on login() and logout() — replaced by CustomTabsOptions.allowedBrowsers

**Native (Kotlin):**

- LoginWebAuthRequestHandler and LogoutWebAuthRequestHandler parse the new customTabsOptions map and build CustomTabsOptions via the Auth0.Android SDK builder
- Bumped com.auth0.android:auth0 from 3.12.0 to 3.16.0

**Backward compatibility:** Fully non-breaking. The new parameter defaults to null. The deprecated allowedBrowsers continues to work as a fallback when customTabsOptions is absent.

**Usage:**

`await auth0.webAuthentication().login(
  customTabsOptions: const CustomTabsOptions(
    initialHeight: 700,
    toolbarCornerRadius: 16,
    backgroundInteractionEnabled: true,
  ),
);
`

### 📎 References

SDK-8720

### 🎯 Testing

**Unit tests added:**

- 5 Dart tests in web_authentication_test.dart — verifies customTabsOptions is serialized correctly for login/logout, defaults to null, and side sheet options pass through
- 5 Kotlin tests in LoginWebAuthRequestHandlerTest.kt — verifies partial tabs parsing with initialHeight, all options, absence, priority over top-level allowedBrowsers, and fallback behavior
- 5 Kotlin tests in LogoutWebAuthRequestHandlerTest.kt — same coverage as login handler

**Not tested:**

- No iOS changes; customTabsOptions is Android-only and ignored on other platforms