### PR TITLE
feat: add Flutter Multi-Resource Refresh Token (MRRT) support

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -726,21 +726,21 @@ final apiCredentials = await auth0.credentialsManager.getApiCredentials(
   scope: {'read:data', 'write:data'},
   minTtl: 60,
   parameters: {'key': 'value'},
-  headers: {'key': 'value'}, // iOS and macOS only
+  headers: {'key': 'value'},
 );
 ```
 
 To remove the cached API credentials for an audience – for example, on logout:
 
 ```dart
-await auth0.credentialsManager.clearApiCredentials(
+final removed = await auth0.credentialsManager.clearApiCredentials(
   audience: 'https://my-api.example.com',
 );
 ```
 
 > ⚠️ **Prerequisites:** Multi-Resource Refresh Tokens must be enabled on your tenant, and the `offline_access` scope must have been requested at login so that a refresh token is available for the exchange.
 >
-> 💡 On iOS and macOS, the stored API credentials are keyed by audience **and** scope, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them. On Android they are keyed by audience alone, and the `scope` argument is ignored.
+> 💡 On iOS and macOS, the stored API credentials are keyed by audience **and** scope, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them, and the returned `bool` reflects whether matching credentials were found and removed. On Android they are keyed by audience alone, the `scope` argument is ignored, and the call always returns `true`.
 
 ### Retrieve user profile
 

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -739,7 +739,7 @@ await auth0.credentialsManager.clearApiCredentials(
 ```
 
 > ⚠️ **Prerequisites:** Multi-Resource Refresh Tokens must be enabled on your tenant, and the `offline_access` scope must have been requested at login so that a refresh token is available for the exchange.
-
+>
 > 💡 On iOS and macOS, the stored API credentials are keyed by audience **and** scope, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them. On Android they are keyed by audience alone, and the `scope` argument is ignored.
 
 ### Retrieve user profile

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -733,14 +733,15 @@ final apiCredentials = await auth0.credentialsManager.getApiCredentials(
 To remove the cached API credentials for an audience – for example, on logout:
 
 ```dart
-final removed = await auth0.credentialsManager.clearApiCredentials(
+await auth0.credentialsManager.clearApiCredentials(
   audience: 'https://my-api.example.com',
+  scope: 'read:data write:data',
 );
 ```
 
 > ⚠️ **Prerequisites:** Multi-Resource Refresh Tokens must be enabled on your tenant, and the `offline_access` scope must have been requested at login so that a refresh token is available for the exchange.
 >
-> 💡 On iOS and macOS, the stored API credentials are keyed by audience **and** scope, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them, and the returned `bool` reflects whether matching credentials were found and removed. On Android they are keyed by audience alone, the `scope` argument is ignored, and the call always returns `true`.
+> 💡 Stored API credentials are keyed by **both** audience and scope on every platform, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them. The native APIs do not consistently report whether a matching entry existed, so this method returns `void` rather than a success flag.
 
 ### Retrieve user profile
 

--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -670,6 +670,7 @@ await auth0.windowsWebAuthentication().logout(
 
 - [Check for stored credentials](#check-for-stored-credentials)
 - [Retrieve stored credentials](#retrieve-stored-credentials)
+- [Retrieve API credentials for a specific audience (MRRT)](#retrieve-api-credentials-for-a-specific-audience-mrrt)
 - [Retrieve user profile](#retrieve-user-profile)
 - [Custom implementations](#custom-implementations)
 - [Local authentication](#local-authentication)
@@ -704,6 +705,42 @@ final credentials = await auth0.credentialsManager.credentials();
 ```
 
 > 💡 You do not need to call `credentialsManager.storeCredentials()` afterward. The Credentials Manager automatically persists the renewed credentials.
+
+### Retrieve API credentials for a specific audience (MRRT)
+
+If your app needs an access token for a **different API** than the one it logged in with, use `getApiCredentials()`. It exchanges the stored refresh token for an access token scoped to the requested `audience` using a [Multi-Resource Refresh Token (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token). If valid API credentials for that audience are already cached, they are returned without a network call; otherwise a new token is fetched and cached for next time.
+
+```dart
+final apiCredentials = await auth0.credentialsManager.getApiCredentials(
+  audience: 'https://my-api.example.com',
+);
+
+print('Access token: ${apiCredentials.accessToken}');
+```
+
+You can request specific scopes and pass additional options:
+
+```dart
+final apiCredentials = await auth0.credentialsManager.getApiCredentials(
+  audience: 'https://my-api.example.com',
+  scope: {'read:data', 'write:data'},
+  minTtl: 60,
+  parameters: {'key': 'value'},
+  headers: {'key': 'value'}, // iOS and macOS only
+);
+```
+
+To remove the cached API credentials for an audience – for example, on logout:
+
+```dart
+await auth0.credentialsManager.clearApiCredentials(
+  audience: 'https://my-api.example.com',
+);
+```
+
+> ⚠️ **Prerequisites:** Multi-Resource Refresh Tokens must be enabled on your tenant, and the `offline_access` scope must have been requested at login so that a refresh token is available for the exchange.
+
+> 💡 On iOS and macOS, the stored API credentials are keyed by audience **and** scope, so pass the same `scope` to `clearApiCredentials()` that you used when fetching them. On Android they are keyed by audience alone, and the `scope` argument is ignored.
 
 ### Retrieve user profile
 

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -631,6 +631,8 @@ void dispose() {
 - [storeCredentials](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/DefaultCredentialsManager/storeCredentials.html)
 - [clearCredentials](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/DefaultCredentialsManager/clearCredentials.html)
 - [ssoCredentials](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/DefaultCredentialsManager/ssoCredentials.html)
+- [getApiCredentials](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/DefaultCredentialsManager/getApiCredentials.html)
+- [clearApiCredentials](https://pub.dev/documentation/auth0_flutter/latest/auth0_flutter/DefaultCredentialsManager/clearApiCredentials.html)
 
 ### 🌐 Web
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -39,6 +39,8 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private val credentialsManagerCallHandler = CredentialsManagerMethodCallHandler(listOf(
     GetCredentialsRequestHandler(),
     GetSSOCredentialsRequestHandler(),
+    GetApiCredentialsRequestHandler(),
+    ClearApiCredentialsRequestHandler(),
     RenewCredentialsRequestHandler(),
     SaveCredentialsRequestHandler(),
     HasValidCredentialsRequestHandler(),

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
@@ -20,7 +20,7 @@ class ClearApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
             return
         }
 
-        val scope = request.data["scope"] as String?
+        val scope = request.data["scope"] as? String
 
         // Stored API credentials are keyed by audience and (optional) scope.
         credentialsManager.clearApiCredentials(audience, scope)

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
@@ -20,9 +20,10 @@ class ClearApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
             return
         }
 
-        // The stored API credentials on Android are keyed by audience alone;
-        // the optional `scope` argument (iOS/macOS only) is intentionally ignored.
-        credentialsManager.clearApiCredentials(audience)
+        val scope = request.data["scope"] as String?
+
+        // Stored API credentials are keyed by audience and (optional) scope.
+        credentialsManager.clearApiCredentials(audience, scope)
         result.success(true)
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
@@ -14,8 +14,8 @@ class ClearApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        val audience = request.data["audience"] as String?
-        if (audience == null) {
+        val audience = request.data["audience"] as? String
+        if (audience.isNullOrBlank()) {
             result.error("UNKNOWN ERROR", "audience is required to clear API credentials", null)
             return
         }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
@@ -23,7 +23,10 @@ class ClearApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
         val scope = request.data["scope"] as? String
 
         // Stored API credentials are keyed by audience and (optional) scope.
+        // The native API returns void and gives no indication of whether a
+        // matching entry existed, so we report no result rather than a
+        // misleading success value.
         credentialsManager.clearApiCredentials(audience, scope)
-        result.success(true)
+        result.success(null)
     }
 }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandler.kt
@@ -1,0 +1,28 @@
+package com.auth0.auth0_flutter.request_handlers.credentials_manager
+
+import android.content.Context
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import io.flutter.plugin.common.MethodChannel
+
+class ClearApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
+    override val method: String = "credentialsManager#clearApiCredentials"
+
+    override fun handle(
+        credentialsManager: SecureCredentialsManager,
+        context: Context,
+        request: MethodCallRequest,
+        result: MethodChannel.Result
+    ) {
+        val audience = request.data["audience"] as String?
+        if (audience == null) {
+            result.error("UNKNOWN ERROR", "audience is required to clear API credentials", null)
+            return
+        }
+
+        // The stored API credentials on Android are keyed by audience alone;
+        // the optional `scope` argument (iOS/macOS only) is intentionally ignored.
+        credentialsManager.clearApiCredentials(audience)
+        result.success(true)
+    }
+}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandler.kt
@@ -1,0 +1,59 @@
+package com.auth0.auth0_flutter.request_handlers.credentials_manager
+
+import android.content.Context
+import com.auth0.android.authentication.storage.CredentialsManagerException
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.android.callback.Callback
+import com.auth0.android.result.APICredentials
+import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import com.auth0.auth0_flutter.toMap
+import io.flutter.plugin.common.MethodChannel
+
+class GetApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
+    override val method: String = "credentialsManager#getApiCredentials"
+
+    override fun handle(
+        credentialsManager: SecureCredentialsManager,
+        context: Context,
+        request: MethodCallRequest,
+        result: MethodChannel.Result
+    ) {
+        val audience = request.data["audience"] as String?
+        if (audience == null) {
+            result.error("UNKNOWN ERROR", "audience is required to get API credentials", null)
+            return
+        }
+
+        var scope: String? = null
+        val scopes = (request.data["scopes"] ?: arrayListOf<String>()) as ArrayList<*>
+        if (scopes.isNotEmpty()) {
+            scope = scopes.joinToString(separator = " ")
+        }
+
+        val minTtl = request.data["minTtl"] as Int? ?: 0
+        val parameters = request.data["parameters"] as Map<String, String>? ?: mapOf()
+        val headers = request.data["headers"] as Map<String, String>? ?: mapOf()
+
+        credentialsManager.getApiCredentials(
+            audience, scope, minTtl, parameters, headers,
+            object : Callback<APICredentials, CredentialsManagerException> {
+                override fun onFailure(exception: CredentialsManagerException) {
+                    result.error(exception.message ?: "UNKNOWN ERROR", exception.message, exception.toMap())
+                }
+
+                override fun onSuccess(credentials: APICredentials) {
+                    val grantedScopes = credentials.scope.split(" ").filter { it.isNotEmpty() }
+                    val formattedDate = credentials.expiresAt.toInstant().toString()
+                    result.success(
+                        mapOf(
+                            "accessToken" to credentials.accessToken,
+                            "tokenType" to credentials.type,
+                            "expiresAt" to formattedDate,
+                            "scopes" to grantedScopes
+                        )
+                    )
+                }
+            }
+        )
+    }
+}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandler.kt
@@ -18,7 +18,7 @@ class GetApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
         request: MethodCallRequest,
         result: MethodChannel.Result
     ) {
-        val audience = request.data["audience"] as String?
+        val audience = request.data["audience"] as? String
         if (audience == null) {
             result.error("UNKNOWN ERROR", "audience is required to get API credentials", null)
             return
@@ -30,9 +30,9 @@ class GetApiCredentialsRequestHandler : CredentialsManagerRequestHandler {
             scope = scopes.joinToString(separator = " ")
         }
 
-        val minTtl = request.data["minTtl"] as Int? ?: 0
-        val parameters = request.data["parameters"] as Map<String, String>? ?: mapOf()
-        val headers = request.data["headers"] as Map<String, String>? ?: mapOf()
+        val minTtl = request.data["minTtl"] as? Int ?: 0
+        val parameters = request.data["parameters"] as? Map<String, String> ?: mapOf()
+        val headers = request.data["headers"] as? Map<String, String> ?: mapOf()
 
         credentialsManager.getApiCredentials(
             audience, scope, minTtl, parameters, headers,

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -3,6 +3,8 @@ package com.auth0.auth0_flutter
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
+import com.auth0.android.provider.BrowserPicker
+import com.auth0.android.provider.CustomTabsOptions
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
@@ -1,0 +1,58 @@
+package com.auth0.auth0_flutter.request_handlers.credentials_manager
+
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import io.flutter.plugin.common.MethodChannel.Result
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.*
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClearApiCredentialsRequestHandlerTest {
+
+    @Test
+    fun `should call clearApiCredentials with the provided audience`() {
+        val handler = ClearApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>("audience" to "test-audience")
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockCredentialsManager).clearApiCredentials(eq("test-audience"))
+    }
+
+    @Test
+    fun `should call result success on success`() {
+        val handler = ClearApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>("audience" to "test-audience")
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockResult).success(eq(true))
+    }
+
+    @Test
+    fun `should error when audience is missing`() {
+        val handler = ClearApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>()
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockResult).error(eq("UNKNOWN ERROR"), any(), anyOrNull())
+        verify(mockCredentialsManager, never()).clearApiCredentials(anyString())
+    }
+}

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
@@ -45,7 +45,7 @@ class ClearApiCredentialsRequestHandlerTest {
     }
 
     @Test
-    fun `should call result success on success`() {
+    fun `should call result success with null because the native API returns void`() {
         val handler = ClearApiCredentialsRequestHandler()
         val options = hashMapOf<String, Any>("audience" to "test-audience")
         val mockResult = mock<Result>()
@@ -55,7 +55,7 @@ class ClearApiCredentialsRequestHandlerTest {
 
         handler.handle(mockCredentialsManager, mock(), request, mockResult)
 
-        verify(mockResult).success(eq(true))
+        verify(mockResult).success(isNull())
     }
 
     @Test

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/ClearApiCredentialsRequestHandlerTest.kt
@@ -14,7 +14,24 @@ import org.robolectric.RobolectricTestRunner
 class ClearApiCredentialsRequestHandlerTest {
 
     @Test
-    fun `should call clearApiCredentials with the provided audience`() {
+    fun `should call clearApiCredentials with the provided audience and scope`() {
+        val handler = ClearApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>(
+            "audience" to "test-audience",
+            "scope" to "test-scope"
+        )
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockCredentialsManager).clearApiCredentials(eq("test-audience"), eq("test-scope"))
+    }
+
+    @Test
+    fun `should call clearApiCredentials with a null scope when not provided`() {
         val handler = ClearApiCredentialsRequestHandler()
         val options = hashMapOf<String, Any>("audience" to "test-audience")
         val mockResult = mock<Result>()
@@ -24,7 +41,7 @@ class ClearApiCredentialsRequestHandlerTest {
 
         handler.handle(mockCredentialsManager, mock(), request, mockResult)
 
-        verify(mockCredentialsManager).clearApiCredentials(eq("test-audience"))
+        verify(mockCredentialsManager).clearApiCredentials(eq("test-audience"), isNull())
     }
 
     @Test
@@ -53,6 +70,6 @@ class ClearApiCredentialsRequestHandlerTest {
         handler.handle(mockCredentialsManager, mock(), request, mockResult)
 
         verify(mockResult).error(eq("UNKNOWN ERROR"), any(), anyOrNull())
-        verify(mockCredentialsManager, never()).clearApiCredentials(anyString())
+        verify(mockCredentialsManager, never()).clearApiCredentials(anyString(), anyOrNull())
     }
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetApiCredentialsRequestHandlerTest.kt
@@ -1,0 +1,163 @@
+package com.auth0.auth0_flutter.request_handlers.credentials_manager
+
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.storage.CredentialsManagerException
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.android.callback.Callback
+import com.auth0.android.result.APICredentials
+import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import io.flutter.plugin.common.MethodChannel.Result
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.*
+import org.robolectric.RobolectricTestRunner
+import java.util.Date
+
+@RunWith(RobolectricTestRunner::class)
+class GetApiCredentialsRequestHandlerTest {
+
+    @Test
+    fun `should call getApiCredentials with the provided audience and options`() {
+        val handler = GetApiCredentialsRequestHandler()
+        val options = hashMapOf(
+            "audience" to "test-audience",
+            "scopes" to arrayListOf("a", "b"),
+            "minTtl" to 30,
+            "parameters" to mapOf("p" to "1"),
+            "headers" to mapOf("h" to "2")
+        )
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockCredentialsManager).getApiCredentials(
+            eq("test-audience"),
+            eq("a b"),
+            eq(30),
+            eq(mapOf("p" to "1")),
+            eq(mapOf("h" to "2")),
+            any()
+        )
+    }
+
+    @Test
+    fun `should use defaults when optional arguments are omitted`() {
+        val handler = GetApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>("audience" to "test-audience")
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockCredentialsManager).getApiCredentials(
+            eq("test-audience"),
+            isNull(),
+            eq(0),
+            eq(mapOf()),
+            eq(mapOf()),
+            any()
+        )
+    }
+
+    @Test
+    fun `should error when audience is missing`() {
+        val handler = GetApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>()
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockResult).error(eq("UNKNOWN ERROR"), any(), anyOrNull())
+        verify(mockCredentialsManager, never()).getApiCredentials(
+            anyString(), anyOrNull(), anyInt(), anyMap(), anyMap(), any()
+        )
+    }
+
+    @Test
+    fun `should call result error on failure`() {
+        val handler = GetApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>("audience" to "test-audience")
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        val exception = mock<CredentialsManagerException>()
+        `when`(exception.message).thenReturn("test-message")
+
+        doAnswer {
+            val cb = it.getArgument<Callback<APICredentials, CredentialsManagerException>>(5)
+            cb.onFailure(exception)
+        }.`when`(mockCredentialsManager).getApiCredentials(
+            anyString(), anyOrNull(), anyInt(), anyMap(), anyMap(), any()
+        )
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        verify(mockResult).error(eq("test-message"), eq("test-message"), any())
+    }
+
+    @Test
+    fun `should call result success on success`() {
+        val handler = GetApiCredentialsRequestHandler()
+        val options = hashMapOf<String, Any>("audience" to "test-audience")
+        val mockResult = mock<Result>()
+        val mockAccount = mock<Auth0>()
+        val mockCredentialsManager = mock<SecureCredentialsManager>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        val apiCredentials = APICredentials(
+            accessToken = "api-access-token",
+            type = "Bearer",
+            expiresAt = Date(0),
+            scope = "a b"
+        )
+
+        whenever(
+            mockCredentialsManager.getApiCredentials(
+                anyString(), anyOrNull(), anyInt(), anyMap(), anyMap(), any()
+            )
+        ).thenAnswer {
+            val callback =
+                it.getArgument<Callback<APICredentials, CredentialsManagerException>>(5)
+            callback.onSuccess(apiCredentials)
+        }
+
+        handler.handle(mockCredentialsManager, mock(), request, mockResult)
+
+        val captor = argumentCaptor<Map<String, *>>()
+        verify(mockResult).success(captor.capture())
+
+        val resultMap = captor.firstValue
+        MatcherAssert.assertThat(
+            resultMap["accessToken"],
+            CoreMatchers.equalTo("api-access-token")
+        )
+        MatcherAssert.assertThat(
+            resultMap["tokenType"],
+            CoreMatchers.equalTo("Bearer")
+        )
+        MatcherAssert.assertThat(
+            resultMap["scopes"],
+            CoreMatchers.equalTo(listOf("a", "b"))
+        )
+        MatcherAssert.assertThat(
+            resultMap["expiresAt"],
+            CoreMatchers.equalTo(Date(0).toInstant().toString())
+        )
+    }
+}

--- a/auth0_flutter/darwin/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/darwin/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
@@ -1,0 +1,50 @@
+import Auth0
+
+#if os(iOS)
+import Flutter
+#else
+import FlutterMacOS
+#endif
+
+struct ApiCredentialsMethodHandler: MethodHandler {
+
+    enum Argument: String {
+        case audience
+        case scopes
+        case minTtl
+        case parameters
+        case headers
+    }
+
+    let credentialsManager: CredentialsManager
+
+    func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
+        guard let audience = arguments[Argument.audience] as? String else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.audience.rawValue)))
+        }
+        guard let scopes = arguments[Argument.scopes] as? [String] else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.scopes.rawValue)))
+        }
+        guard let minTTL = arguments[Argument.minTtl] as? Int else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.minTtl.rawValue)))
+        }
+        guard let parameters = arguments[Argument.parameters] as? [String: Any] else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.parameters.rawValue)))
+        }
+        guard let headers = arguments[Argument.headers] as? [String: String] else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.headers.rawValue)))
+        }
+
+        self.credentialsManager.apiCredentials(forAudience: audience,
+                                               scope: scopes.isEmpty ? nil : scopes.asSpaceSeparatedString,
+                                               minTTL: minTTL,
+                                               parameters: parameters,
+                                               headers: headers) {
+            switch $0 {
+            case let .success(apiCredentials): callback(apiCredentials.asDictionary())
+            case let .failure(error): callback(FlutterError(from: error))
+            }
+        }
+    }
+
+}

--- a/auth0_flutter/darwin/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/darwin/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
@@ -1,0 +1,27 @@
+import Auth0
+
+#if os(iOS)
+import Flutter
+#else
+import FlutterMacOS
+#endif
+
+struct ClearApiCredentialsMethodHandler: MethodHandler {
+
+    enum Argument: String {
+        case audience
+        case scope
+    }
+
+    let credentialsManager: CredentialsManager
+
+    func handle(with arguments: [String: Any], callback: @escaping FlutterResult) {
+        guard let audience = arguments[Argument.audience] as? String else {
+            return callback(FlutterError(from: .requiredArgumentMissing(Argument.audience.rawValue)))
+        }
+        let scope = arguments[Argument.scope] as? String
+
+        callback(self.credentialsManager.clear(forAudience: audience, scope: scope))
+    }
+
+}

--- a/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
+++ b/auth0_flutter/darwin/Classes/CredentialsManager/CredentialsManagerHandler.swift
@@ -25,6 +25,8 @@ public class CredentialsManagerHandler: NSObject, FlutterPlugin {
         case clear = "credentialsManager#clearCredentials"
         case userInfo = "credentialsManager#user"
         case sso = "credentialsManager#getSSOCredentials"
+        case apiCredentials = "credentialsManager#getApiCredentials"
+        case clearApiCredentials = "credentialsManager#clearApiCredentials"
     }
 
     private struct ManagerCacheKey: Equatable {
@@ -135,6 +137,8 @@ public class CredentialsManagerHandler: NSObject, FlutterPlugin {
         case .userInfo: return CredentialsManagerUserInfoMethodHandler(credentialsManager: credentialsManager)
         case .renew: return CredentialsManagerRenewMethodHandler(credentialsManager: credentialsManager)
         case .sso: return SSOCredentialsMethodHandler(credentialsManager: credentialsManager)
+        case .apiCredentials: return ApiCredentialsMethodHandler(credentialsManager: credentialsManager)
+        case .clearApiCredentials: return ClearApiCredentialsMethodHandler(credentialsManager: credentialsManager)
         }
     }
 

--- a/auth0_flutter/darwin/Classes/Extensions.swift
+++ b/auth0_flutter/darwin/Classes/Extensions.swift
@@ -100,7 +100,7 @@ extension APICredentials {
         return [
             "accessToken": accessToken,
             "tokenType": tokenType,
-            "expiresAt": expiresAt.asISO8601String,
+            "expiresAt": expiresIn.asISO8601String,
             "scopes": scope.split(separator: " ").map(String.init)
         ]
     }

--- a/auth0_flutter/darwin/Classes/Extensions.swift
+++ b/auth0_flutter/darwin/Classes/Extensions.swift
@@ -95,6 +95,17 @@ extension Credentials {
     }
 }
 
+extension APICredentials {
+    func asDictionary() -> [String: Any] {
+        return [
+            "accessToken": accessToken,
+            "tokenType": tokenType,
+            "expiresAt": expiresAt.asISO8601String,
+            "scopes": scope.split(separator: " ").map(String.init)
+        ]
+    }
+}
+
 extension UserInfo {
     func asDictionary() -> [String: Any] {
         let claimsToFilter = ["aud",

--- a/auth0_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/auth0_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		5C4E65C7286D24A900141449 /* CredentialsManagerSaveMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4E65C6286D24A900141449 /* CredentialsManagerSaveMethodHandlerTests.swift */; };
 		5C4E65C9286D26D800141449 /* CredentialsManagerGetMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4E65C8286D26D800141449 /* CredentialsManagerGetMethodHandlerTests.swift */; };
 		A09B2E3F1D4C7891BA000002 /* CredentialsManagerSSOCredentialsMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09B2E3F1D4C7891BA000001 /* CredentialsManagerSSOCredentialsMethodHandlerTests.swift */; };
+		A0AC1D0F2E0000000000AC02 /* CredentialsManagerApiCredentialsMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AC1D0F2E0000000000AC01 /* CredentialsManagerApiCredentialsMethodHandlerTests.swift */; };
+		A0AC1D0F2E0000000000AC04 /* CredentialsManagerClearApiCredentialsMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AC1D0F2E0000000000AC03 /* CredentialsManagerClearApiCredentialsMethodHandlerTests.swift */; };
 		5C59DA6527FFCF0600365CDB /* AuthAPIHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C59DA6427FFCF0600365CDB /* AuthAPIHandlerTests.swift */; };
 		5C59DA6727FFE75600365CDB /* AuthAPILoginUsernameOrEmailMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C59DA6627FFE75600365CDB /* AuthAPILoginUsernameOrEmailMethodHandlerTests.swift */; };
 		5C59DA6928011D4F00365CDB /* AuthAPISignupMethodHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C59DA6828011D4F00365CDB /* AuthAPISignupMethodHandlerTests.swift */; };
@@ -104,6 +106,8 @@
 		5C4E65C6286D24A900141449 /* CredentialsManagerSaveMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerSaveMethodHandlerTests.swift; sourceTree = "<group>"; };
 		5C4E65C8286D26D800141449 /* CredentialsManagerGetMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerGetMethodHandlerTests.swift; sourceTree = "<group>"; };
 		A09B2E3F1D4C7891BA000001 /* CredentialsManagerSSOCredentialsMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerSSOCredentialsMethodHandlerTests.swift; sourceTree = "<group>"; };
+		A0AC1D0F2E0000000000AC01 /* CredentialsManagerApiCredentialsMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerApiCredentialsMethodHandlerTests.swift; sourceTree = "<group>"; };
+		A0AC1D0F2E0000000000AC03 /* CredentialsManagerClearApiCredentialsMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerClearApiCredentialsMethodHandlerTests.swift; sourceTree = "<group>"; };
 		5C59DA6427FFCF0600365CDB /* AuthAPIHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIHandlerTests.swift; sourceTree = "<group>"; };
 		5C59DA6627FFE75600365CDB /* AuthAPILoginUsernameOrEmailMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPILoginUsernameOrEmailMethodHandlerTests.swift; sourceTree = "<group>"; };
 		5C59DA6828011D4F00365CDB /* AuthAPISignupMethodHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPISignupMethodHandlerTests.swift; sourceTree = "<group>"; };
@@ -230,6 +234,8 @@
 				5C4E65BD286D151400141449 /* CredentialsManagerClearMethodHandlerTests.swift */,
 				5C08DBC7288A7646000D2F37 /* CredentialsManagerExtensionsTests.swift */,
 				A09B2E3F1D4C7891BA000001 /* CredentialsManagerSSOCredentialsMethodHandlerTests.swift */,
+				A0AC1D0F2E0000000000AC01 /* CredentialsManagerApiCredentialsMethodHandlerTests.swift */,
+				A0AC1D0F2E0000000000AC03 /* CredentialsManagerClearApiCredentialsMethodHandlerTests.swift */,
 			);
 			path = CredentialsManager;
 			sourceTree = "<group>";
@@ -607,6 +613,8 @@
 				5C335E3D27FBBC2300EDDE3A /* WebAuthLogoutMethodHandlerTests.swift in Sources */,
 				5C08DBC8288A7646000D2F37 /* CredentialsManagerExtensionsTests.swift in Sources */,
 				A09B2E3F1D4C7891BA000002 /* CredentialsManagerSSOCredentialsMethodHandlerTests.swift in Sources */,
+				A0AC1D0F2E0000000000AC02 /* CredentialsManagerApiCredentialsMethodHandlerTests.swift in Sources */,
+				A0AC1D0F2E0000000000AC04 /* CredentialsManagerClearApiCredentialsMethodHandlerTests.swift in Sources */,
 				5C335E4127FBD2FE00EDDE3A /* ExtensionsTests.swift in Sources */,
 				5C59DA732807B1A300365CDB /* AuthAPIResetPasswordMethodHandlerTests.swift in Sources */,
 				5C59DA832809214200365CDB /* AuthAPIUserInfoMethodHandlerTests.swift in Sources */,

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerApiCredentialsMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerApiCredentialsMethodHandlerTests.swift
@@ -46,6 +46,7 @@ extension ApiCredentialsMethodHandlerTests {
                                       scope: "scope")
         let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
         let expectation = self.expectation(description: "API credentials exchange was called")
+        spyAuthentication.credentialsResult = .success(credentials)
         spyStorage.getEntryReturnValue = data
         sut.handle(with: arguments()) { _ in
             XCTAssertEqual(self.spyAuthentication.arguments["refreshToken"] as? String, "refreshToken")
@@ -65,6 +66,7 @@ extension ApiCredentialsMethodHandlerTests {
                                       scope: "a b")
         let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
         let expectation = self.expectation(description: "Produced API credentials")
+        spyAuthentication.credentialsResult = .success(credentials)
         spyStorage.getEntryReturnValue = data
         sut.handle(with: arguments()) { result in
             guard let dictionary = result as? [String: Any] else {

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerApiCredentialsMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerApiCredentialsMethodHandlerTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import Auth0
+
+@testable import auth0_flutter
+
+fileprivate typealias Argument = ApiCredentialsMethodHandler.Argument
+
+final class ApiCredentialsMethodHandlerTests: XCTestCase {
+    var spyAuthentication: SpyAuthentication!
+    var spyStorage: SpyCredentialsStorage!
+    var sut: ApiCredentialsMethodHandler!
+
+    override func setUpWithError() throws {
+        spyAuthentication = SpyAuthentication()
+        spyStorage = SpyCredentialsStorage()
+        let credentialsManager = CredentialsManager(authentication: spyAuthentication, storage: spyStorage)
+        sut = ApiCredentialsMethodHandler(credentialsManager: credentialsManager)
+    }
+}
+
+// MARK: - Required Arguments Error
+
+extension ApiCredentialsMethodHandlerTests {
+    func testProducesErrorWhenRequiredArgumentsAreMissing() {
+        let keys: [Argument] = [.audience, .scopes, .minTtl, .parameters, .headers]
+        let expectations = keys.map { expectation(description: "\($0.rawValue) is missing") }
+        for (argument, currentExpectation) in zip(keys, expectations) {
+            sut.handle(with: arguments(without: argument)) { result in
+                assert(result: result, isError: .requiredArgumentMissing(argument.rawValue))
+                currentExpectation.fulfill()
+            }
+        }
+        wait(for: expectations)
+    }
+}
+
+// MARK: - API Credentials Exchange
+
+extension ApiCredentialsMethodHandlerTests {
+    func testExchangeIsCalledWithAudienceAndScope() {
+        let credentials = Credentials(accessToken: "accessToken",
+                                      tokenType: "tokenType",
+                                      idToken: testIdToken,
+                                      refreshToken: "refreshToken",
+                                      expiresIn: Date(timeIntervalSinceNow: 3600),
+                                      scope: "scope")
+        let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
+        let expectation = self.expectation(description: "API credentials exchange was called")
+        spyStorage.getEntryReturnValue = data
+        sut.handle(with: arguments()) { _ in
+            XCTAssertEqual(self.spyAuthentication.arguments["refreshToken"] as? String, "refreshToken")
+            XCTAssertEqual(self.spyAuthentication.arguments["audience"] as? String, "test-audience")
+            XCTAssertEqual(self.spyAuthentication.arguments["scope"] as? String, "a b")
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testProducesApiCredentials() {
+        let credentials = Credentials(accessToken: "accessToken",
+                                      tokenType: "tokenType",
+                                      idToken: testIdToken,
+                                      refreshToken: "refreshToken",
+                                      expiresIn: Date(timeIntervalSinceNow: 3600),
+                                      scope: "a b")
+        let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
+        let expectation = self.expectation(description: "Produced API credentials")
+        spyStorage.getEntryReturnValue = data
+        sut.handle(with: arguments()) { result in
+            guard let dictionary = result as? [String: Any] else {
+                return XCTFail("The handler did not produce a dictionary")
+            }
+            XCTAssertEqual(dictionary.keys.sorted(),
+                           ["accessToken", "expiresAt", "scopes", "tokenType"])
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}
+
+// MARK: - Error
+
+extension ApiCredentialsMethodHandlerTests {
+    func testProducesCredentialsManagerError() {
+        let error = CredentialsManagerError.noCredentials
+        let expectation = self.expectation(description: "Produced the CredentialsManagerError \(error)")
+        spyStorage.getEntryReturnValue = nil
+        sut.handle(with: arguments()) { result in
+            assert(result: result, isError: error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}
+
+// MARK: - Helpers
+
+extension ApiCredentialsMethodHandlerTests {
+    override func arguments() -> [String: Any] {
+        return [
+            Argument.audience.rawValue: "test-audience",
+            Argument.scopes.rawValue: ["a", "b"],
+            Argument.minTtl.rawValue: 0,
+            Argument.parameters.rawValue: [String: Any](),
+            Argument.headers.rawValue: [String: String]()
+        ]
+    }
+}

--- a/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerClearApiCredentialsMethodHandlerTests.swift
+++ b/auth0_flutter/example/ios/Tests/CredentialsManager/CredentialsManagerClearApiCredentialsMethodHandlerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import Auth0
+
+@testable import auth0_flutter
+
+fileprivate typealias Argument = ClearApiCredentialsMethodHandler.Argument
+
+class ClearApiCredentialsMethodHandlerTests: XCTestCase {
+    var spy: SpyCredentialsStorage!
+    var sut: ClearApiCredentialsMethodHandler!
+
+    override func setUpWithError() throws {
+        spy = SpyCredentialsStorage()
+        let credentialsManager = CredentialsManager(authentication: SpyAuthentication(), storage: spy)
+        sut = ClearApiCredentialsMethodHandler(credentialsManager: credentialsManager)
+    }
+}
+
+// MARK: - Required Arguments Error
+
+extension ClearApiCredentialsMethodHandlerTests {
+    func testProducesErrorWhenAudienceIsMissing() {
+        let expectation = self.expectation(description: "audience is missing")
+        sut.handle(with: arguments(without: Argument.audience)) { result in
+            assert(result: result, isError: .requiredArgumentMissing(Argument.audience.rawValue))
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}
+
+// MARK: - Clear Result
+
+extension ClearApiCredentialsMethodHandlerTests {
+    func testCallsSDKClearMethod() {
+        sut.handle(with: arguments()) { _ in }
+        XCTAssertTrue(spy.calledDeleteEntry)
+    }
+
+    func testProducesTrueOnSuccess() {
+        let expectation = self.expectation(description: "Produced true")
+        spy.deleteEntryReturnValue = true
+        sut.handle(with: arguments()) { result in
+            XCTAssertEqual(result as? Bool, true)
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testProducesFalseOnFailure() {
+        let expectation = self.expectation(description: "Produced false")
+        spy.deleteEntryReturnValue = false
+        sut.handle(with: arguments()) { result in
+            XCTAssertEqual(result as? Bool, false)
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}
+
+// MARK: - Helpers
+
+extension ClearApiCredentialsMethodHandlerTests {
+    override func arguments() -> [String: Any] {
+        return [
+            Argument.audience.rawValue: "test-audience",
+            Argument.scope.rawValue: "test-scope"
+        ]
+    }
+}

--- a/auth0_flutter/ios/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift

--- a/auth0_flutter/ios/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/ios/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -16,6 +16,7 @@ export 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interfac
         CustomTabsOptions,
         Credentials,
         SSOCredentials,
+        ApiCredentials,
         UserProfile,
         DatabaseUser,
         ChallengeType,

--- a/auth0_flutter/lib/src/mobile/credentials_manager.dart
+++ b/auth0_flutter/lib/src/mobile/credentials_manager.dart
@@ -73,15 +73,14 @@ abstract class CredentialsManager {
     final Map<String, String> headers = const {},
   });
 
-  /// Removes the API credentials for the given [audience] from the storage if
-  /// present.
+  /// Removes the stored API credentials for the given [audience] and [scope].
   ///
-  /// On iOS and macOS, pass the [scope] the credentials were stored with. On
-  /// Android the stored credentials are keyed by audience alone, so [scope] is
-  /// ignored there.
-  ///
-  /// Returns `true` if credentials for the [audience] were found and removed.
-  Future<bool> clearApiCredentials({
+  /// API credentials are keyed by **both** audience and scope on all
+  /// platforms, so pass the same [scope] you used when fetching them via
+  /// [getApiCredentials]. Omitting [scope] only matches credentials that were
+  /// stored without a scope; it does **not** remove every entry for the
+  /// [audience].
+  Future<void> clearApiCredentials({
     required final String audience,
     final String? scope,
   });
@@ -211,12 +210,11 @@ class DefaultCredentialsManager extends CredentialsManager {
         headers: headers,
       )));
 
-  /// Removes the API credentials for the given [audience] from the storage if
-  /// present.
+  /// Removes the stored API credentials for the given audience and scope.
   ///
   /// See [CredentialsManager.clearApiCredentials] for full documentation.
   @override
-  Future<bool> clearApiCredentials({
+  Future<void> clearApiCredentials({
     required final String audience,
     final String? scope,
   }) =>

--- a/auth0_flutter/lib/src/mobile/credentials_manager.dart
+++ b/auth0_flutter/lib/src/mobile/credentials_manager.dart
@@ -79,7 +79,9 @@ abstract class CredentialsManager {
   /// On iOS and macOS, pass the [scope] the credentials were stored with. On
   /// Android the stored credentials are keyed by audience alone, so [scope] is
   /// ignored there.
-  Future<void> clearApiCredentials({
+  ///
+  /// Returns `true` if credentials for the [audience] were found and removed.
+  Future<bool> clearApiCredentials({
     required final String audience,
     final String? scope,
   });
@@ -214,7 +216,7 @@ class DefaultCredentialsManager extends CredentialsManager {
   ///
   /// See [CredentialsManager.clearApiCredentials] for full documentation.
   @override
-  Future<void> clearApiCredentials({
+  Future<bool> clearApiCredentials({
     required final String audience,
     final String? scope,
   }) =>

--- a/auth0_flutter/lib/src/mobile/credentials_manager.dart
+++ b/auth0_flutter/lib/src/mobile/credentials_manager.dart
@@ -48,6 +48,41 @@ abstract class CredentialsManager {
     final Map<String, String> parameters = const {},
     final Map<String, String> headers = const {},
   });
+
+  /// Exchanges the stored refresh token for [ApiCredentials] scoped to a
+  /// specific API (audience), using a Multi-Resource Refresh Token (MRRT).
+  ///
+  /// If valid API credentials for the [audience] are already cached, they are
+  /// returned. Otherwise the stored refresh token is exchanged for a new
+  /// access token for that API and the result is cached for subsequent calls.
+  ///
+  /// Use [scope] to set the scopes to request for the access token; if empty,
+  /// the default scopes configured for the API are used. Set [minTtl] to the
+  /// minimum time in seconds the access token should last before expiration.
+  /// Pass optional [parameters] to include in the token exchange request. On
+  /// iOS and macOS, [headers] can also be forwarded to the Auth0 endpoint.
+  ///
+  /// **Prerequisites:**
+  /// - Multi-Resource Refresh Tokens must be enabled on the tenant.
+  /// - `offline_access` scope must be present in the stored credentials.
+  Future<ApiCredentials> getApiCredentials({
+    required final String audience,
+    final Set<String> scope = const {},
+    final int minTtl = 0,
+    final Map<String, String> parameters = const {},
+    final Map<String, String> headers = const {},
+  });
+
+  /// Removes the API credentials for the given [audience] from the storage if
+  /// present.
+  ///
+  /// On iOS and macOS, pass the [scope] the credentials were stored with. On
+  /// Android the stored credentials are keyed by audience alone, so [scope] is
+  /// ignored there.
+  Future<void> clearApiCredentials({
+    required final String audience,
+    final String? scope,
+  });
 }
 
 /// Default [CredentialsManager] implementation that passes calls to
@@ -152,6 +187,39 @@ class DefaultCredentialsManager extends CredentialsManager {
         parameters: parameters,
         headers: headers,
       )));
+
+  /// Exchanges the stored refresh token for [ApiCredentials] scoped to a
+  /// specific API (audience), using a Multi-Resource Refresh Token (MRRT).
+  ///
+  /// See [CredentialsManager.getApiCredentials] for full documentation.
+  @override
+  Future<ApiCredentials> getApiCredentials({
+    required final String audience,
+    final Set<String> scope = const {},
+    final int minTtl = 0,
+    final Map<String, String> parameters = const {},
+    final Map<String, String> headers = const {},
+  }) =>
+      CredentialsManagerPlatform.instance
+          .getApiCredentials(_createApiRequest(GetApiCredentialsOptions(
+        audience: audience,
+        scopes: scope,
+        minTtl: minTtl,
+        parameters: parameters,
+        headers: headers,
+      )));
+
+  /// Removes the API credentials for the given [audience] from the storage if
+  /// present.
+  ///
+  /// See [CredentialsManager.clearApiCredentials] for full documentation.
+  @override
+  Future<void> clearApiCredentials({
+    required final String audience,
+    final String? scope,
+  }) =>
+      CredentialsManagerPlatform.instance.clearApiCredentials(_createApiRequest(
+          ClearApiCredentialsOptions(audience: audience, scope: scope)));
 
   CredentialsManagerRequest<TOptions>
       _createApiRequest<TOptions extends RequestOptions>(

--- a/auth0_flutter/macos/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/CredentialsManager/ApiCredentialsMethodHandler.swift

--- a/auth0_flutter/macos/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
+++ b/auth0_flutter/macos/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/CredentialsManager/ClearApiCredentialsMethodHandler.swift

--- a/auth0_flutter/test/mobile/credentials_manager_test.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.dart
@@ -409,9 +409,10 @@ void main() {
   group('clearApiCredentials', () {
     test('passes through properties to the platform', () async {
       when(mockedPlatform.clearApiCredentials(any))
-          .thenAnswer((final _) async {});
+          .thenAnswer((final _) async => true);
 
-      await DefaultCredentialsManager(account, userAgent).clearApiCredentials(
+      final result = await DefaultCredentialsManager(account, userAgent)
+          .clearApiCredentials(
         audience: 'test-audience',
         scope: 'test-scope',
       );
@@ -423,11 +424,12 @@ void main() {
       expect(verificationResult.account.clientId, 'test-clientId');
       expect(verificationResult.options?.audience, 'test-audience');
       expect(verificationResult.options?.scope, 'test-scope');
+      expect(result, true);
     });
 
     test('leaves the scope null when omitted', () async {
       when(mockedPlatform.clearApiCredentials(any))
-          .thenAnswer((final _) async {});
+          .thenAnswer((final _) async => true);
 
       await DefaultCredentialsManager(account, userAgent)
           .clearApiCredentials(audience: 'test-audience');

--- a/auth0_flutter/test/mobile/credentials_manager_test.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.dart
@@ -409,10 +409,9 @@ void main() {
   group('clearApiCredentials', () {
     test('passes through properties to the platform', () async {
       when(mockedPlatform.clearApiCredentials(any))
-          .thenAnswer((final _) async => true);
+          .thenAnswer((final _) async {});
 
-      final result = await DefaultCredentialsManager(account, userAgent)
-          .clearApiCredentials(
+      await DefaultCredentialsManager(account, userAgent).clearApiCredentials(
         audience: 'test-audience',
         scope: 'test-scope',
       );
@@ -424,12 +423,11 @@ void main() {
       expect(verificationResult.account.clientId, 'test-clientId');
       expect(verificationResult.options?.audience, 'test-audience');
       expect(verificationResult.options?.scope, 'test-scope');
-      expect(result, true);
     });
 
     test('leaves the scope null when omitted', () async {
       when(mockedPlatform.clearApiCredentials(any))
-          .thenAnswer((final _) async => true);
+          .thenAnswer((final _) async {});
 
       await DefaultCredentialsManager(account, userAgent)
           .clearApiCredentials(audience: 'test-audience');

--- a/auth0_flutter/test/mobile/credentials_manager_test.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.dart
@@ -40,6 +40,13 @@ class TestPlatform extends Mock
     idToken: 'idToken',
     refreshToken: 'refreshToken',
   );
+
+  static ApiCredentials apiResult = ApiCredentials.fromMap({
+    'accessToken': 'apiAccessToken',
+    'tokenType': 'Bearer',
+    'expiresAt': DateTime.now().toIso8601String(),
+    'scopes': ['a', 'b'],
+  });
 }
 
 @GenerateMocks([TestPlatform])
@@ -337,6 +344,99 @@ void main() {
       expect(result.expiresIn, TestPlatform.ssoResult.expiresIn);
       expect(result.idToken, TestPlatform.ssoResult.idToken);
       expect(result.refreshToken, TestPlatform.ssoResult.refreshToken);
+    });
+  });
+
+  group('getApiCredentials', () {
+    test('passes through properties to the platform', () async {
+      when(mockedPlatform.getApiCredentials(any))
+          .thenAnswer((final _) async => TestPlatform.apiResult);
+
+      await DefaultCredentialsManager(account, userAgent).getApiCredentials(
+        audience: 'test-audience',
+        scope: {'a', 'b'},
+        minTtl: 30,
+        parameters: {'param': 'value'},
+        headers: {'header': 'header-value'},
+      );
+
+      final verificationResult =
+          verify(mockedPlatform.getApiCredentials(captureAny)).captured.single
+              as CredentialsManagerRequest<GetApiCredentialsOptions>;
+      expect(verificationResult.account.domain, 'test-domain');
+      expect(verificationResult.account.clientId, 'test-clientId');
+      expect(verificationResult.options?.audience, 'test-audience');
+      expect(verificationResult.options?.scopes, {'a', 'b'});
+      expect(verificationResult.options?.minTtl, 30);
+      expect(verificationResult.options?.parameters, {'param': 'value'});
+      expect(verificationResult.options?.headers, {'header': 'header-value'});
+    });
+
+    test('uses default values for optional properties when omitted', () async {
+      when(mockedPlatform.getApiCredentials(any))
+          .thenAnswer((final _) async => TestPlatform.apiResult);
+
+      await DefaultCredentialsManager(account, userAgent)
+          .getApiCredentials(audience: 'test-audience');
+
+      final verificationResult =
+          verify(mockedPlatform.getApiCredentials(captureAny)).captured.single
+              as CredentialsManagerRequest<GetApiCredentialsOptions>;
+      expect(verificationResult.options?.audience, 'test-audience');
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options?.scopes, isEmpty);
+      expect(verificationResult.options?.minTtl, 0);
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options?.parameters, isEmpty);
+      // ignore: inference_failure_on_collection_literal
+      expect(verificationResult.options?.headers, isEmpty);
+    });
+
+    test('returns the ApiCredentials from the platform', () async {
+      when(mockedPlatform.getApiCredentials(any))
+          .thenAnswer((final _) async => TestPlatform.apiResult);
+
+      final result = await DefaultCredentialsManager(account, userAgent)
+          .getApiCredentials(audience: 'test-audience');
+
+      expect(result.accessToken, TestPlatform.apiResult.accessToken);
+      expect(result.tokenType, TestPlatform.apiResult.tokenType);
+      expect(result.expiresAt, TestPlatform.apiResult.expiresAt);
+      expect(result.scopes, TestPlatform.apiResult.scopes);
+    });
+  });
+
+  group('clearApiCredentials', () {
+    test('passes through properties to the platform', () async {
+      when(mockedPlatform.clearApiCredentials(any))
+          .thenAnswer((final _) async {});
+
+      await DefaultCredentialsManager(account, userAgent).clearApiCredentials(
+        audience: 'test-audience',
+        scope: 'test-scope',
+      );
+
+      final verificationResult =
+          verify(mockedPlatform.clearApiCredentials(captureAny)).captured.single
+              as CredentialsManagerRequest<ClearApiCredentialsOptions>;
+      expect(verificationResult.account.domain, 'test-domain');
+      expect(verificationResult.account.clientId, 'test-clientId');
+      expect(verificationResult.options?.audience, 'test-audience');
+      expect(verificationResult.options?.scope, 'test-scope');
+    });
+
+    test('leaves the scope null when omitted', () async {
+      when(mockedPlatform.clearApiCredentials(any))
+          .thenAnswer((final _) async {});
+
+      await DefaultCredentialsManager(account, userAgent)
+          .clearApiCredentials(audience: 'test-audience');
+
+      final verificationResult =
+          verify(mockedPlatform.clearApiCredentials(captureAny)).captured.single
+              as CredentialsManagerRequest<ClearApiCredentialsOptions>;
+      expect(verificationResult.options?.audience, 'test-audience');
+      expect(verificationResult.options?.scope, isNull);
     });
   });
 }

--- a/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
@@ -184,7 +184,7 @@ class MockTestPlatform extends _i1.Mock implements _i4.TestPlatform {
       ) as _i5.Future<_i3.ApiCredentials>);
 
   @override
-  _i5.Future<void> clearApiCredentials(
+  _i5.Future<bool> clearApiCredentials(
           _i3.CredentialsManagerRequest<_i3.ClearApiCredentialsOptions>?
               request) =>
       (super.noSuchMethod(
@@ -192,7 +192,7 @@ class MockTestPlatform extends _i1.Mock implements _i4.TestPlatform {
           #clearApiCredentials,
           [request],
         ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 }

--- a/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
@@ -184,7 +184,7 @@ class MockTestPlatform extends _i1.Mock implements _i4.TestPlatform {
       ) as _i5.Future<_i3.ApiCredentials>);
 
   @override
-  _i5.Future<bool> clearApiCredentials(
+  _i5.Future<void> clearApiCredentials(
           _i3.CredentialsManagerRequest<_i3.ClearApiCredentialsOptions>?
               request) =>
       (super.noSuchMethod(
@@ -192,7 +192,7 @@ class MockTestPlatform extends _i1.Mock implements _i4.TestPlatform {
           #clearApiCredentials,
           [request],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
+++ b/auth0_flutter/test/mobile/credentials_manager_test.mocks.dart
@@ -48,6 +48,17 @@ class _FakeSSOCredentials_1 extends _i1.SmartFake
         );
 }
 
+class _FakeApiCredentials_2 extends _i1.SmartFake
+    implements _i3.ApiCredentials {
+  _FakeApiCredentials_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [TestPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -153,4 +164,35 @@ class MockTestPlatform extends _i1.Mock implements _i4.TestPlatform {
           ),
         )),
       ) as _i5.Future<_i3.SSOCredentials>);
+
+  @override
+  _i5.Future<_i3.ApiCredentials> getApiCredentials(
+          _i3.CredentialsManagerRequest<_i3.GetApiCredentialsOptions>?
+              request) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getApiCredentials,
+          [request],
+        ),
+        returnValue: _i5.Future<_i3.ApiCredentials>.value(_FakeApiCredentials_2(
+          this,
+          Invocation.method(
+            #getApiCredentials,
+            [request],
+          ),
+        )),
+      ) as _i5.Future<_i3.ApiCredentials>);
+
+  @override
+  _i5.Future<void> clearApiCredentials(
+          _i3.CredentialsManagerRequest<_i3.ClearApiCredentialsOptions>?
+              request) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #clearApiCredentials,
+          [request],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
+++ b/auth0_flutter_platform_interface/lib/auth0_flutter_platform_interface.dart
@@ -1,4 +1,5 @@
 export 'src/account.dart';
+export 'src/api_credentials.dart';
 export 'src/auth/api_exception.dart';
 export 'src/auth/auth_custom_token_exchange_options.dart';
 export 'src/auth/auth_dpop_headers_options.dart';
@@ -26,6 +27,8 @@ export 'src/credentials-manager/credentials_manager_configuration.dart';
 export 'src/credentials-manager/credentials_manager_exception.dart';
 export 'src/credentials-manager/credentials_manager_platform.dart';
 export 'src/credentials-manager/method_channel_credentials_manager.dart';
+export 'src/credentials-manager/options/clear_api_credentials_options.dart';
+export 'src/credentials-manager/options/get_api_credentials_options.dart';
 export 'src/credentials-manager/options/get_credentials_options.dart';
 export 'src/credentials-manager/options/get_sso_credentials_options.dart';
 export 'src/credentials-manager/options/has_valid_credentials_options.dart';

--- a/auth0_flutter_platform_interface/lib/src/api_credentials.dart
+++ b/auth0_flutter_platform_interface/lib/src/api_credentials.dart
@@ -1,0 +1,52 @@
+/// User's credentials obtained from Auth0 for a specific API (audience) as the
+/// result of exchanging the stored refresh token using a Multi-Resource Refresh
+/// Token (MRRT).
+///
+/// Obtain an [ApiCredentials] instance via
+/// `CredentialsManager.getApiCredentials()`.
+///
+/// **Prerequisites:**
+/// - Multi-Resource Refresh Tokens must be enabled on the tenant.
+/// - The `offline_access` scope must be present in the stored credentials so
+///   that a refresh token is available for the exchange.
+class ApiCredentials {
+  /// Token that can be used to make authenticated requests to the API
+  /// identified by the requested **audience**.
+  ///
+  /// [Read more about access tokens](https://auth0.com/docs/secure/tokens/access-tokens).
+  final String accessToken;
+
+  /// Indicates how the [accessToken] should be used. For example, as a bearer
+  /// token.
+  final String tokenType;
+
+  /// The absolute date and time of when the [accessToken] expires.
+  final DateTime expiresAt;
+
+  /// The scopes that have been granted by Auth0 for this API.
+  ///
+  /// [Read more about scopes](https://auth0.com/docs/get-started/apis/scopes).
+  final Set<String> scopes;
+
+  const ApiCredentials({
+    required this.accessToken,
+    required this.tokenType,
+    required this.expiresAt,
+    this.scopes = const {},
+  });
+
+  factory ApiCredentials.fromMap(final Map<dynamic, dynamic> result) =>
+      ApiCredentials(
+        accessToken: result['accessToken'] as String,
+        tokenType: result['tokenType'] as String,
+        expiresAt: DateTime.parse(result['expiresAt'] as String).toUtc(),
+        scopes: Set<String>.from(result['scopes'] as List<Object?>),
+      );
+
+  Map<String, dynamic> toMap() => {
+        'accessToken': accessToken,
+        'tokenType': tokenType,
+        'expiresAt': expiresAt.toUtc().toIso8601String(),
+        'scopes': scopes.toList(),
+      };
+}

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
@@ -75,4 +75,24 @@ abstract class CredentialsManagerPlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('getSSOCredentials() has not been implemented');
   }
+
+  /// Exchanges the stored refresh token for [ApiCredentials] scoped to a
+  /// specific API (audience), using a Multi-Resource Refresh Token (MRRT).
+  ///
+  /// See `CredentialsManager.getApiCredentials` for full documentation.
+  Future<ApiCredentials> getApiCredentials(
+    final CredentialsManagerRequest<GetApiCredentialsOptions> request,
+  ) {
+    throw UnimplementedError('getApiCredentials() has not been implemented');
+  }
+
+  /// Removes the API credentials for the given audience from the native
+  /// storage if present.
+  ///
+  /// See `CredentialsManager.clearApiCredentials` for full documentation.
+  Future<void> clearApiCredentials(
+    final CredentialsManagerRequest<ClearApiCredentialsOptions> request,
+  ) {
+    throw UnimplementedError('clearApiCredentials() has not been implemented');
+  }
 }

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
@@ -90,7 +90,7 @@ abstract class CredentialsManagerPlatform extends PlatformInterface {
   /// storage if present.
   ///
   /// See `CredentialsManager.clearApiCredentials` for full documentation.
-  Future<void> clearApiCredentials(
+  Future<bool> clearApiCredentials(
     final CredentialsManagerRequest<ClearApiCredentialsOptions> request,
   ) {
     throw UnimplementedError('clearApiCredentials() has not been implemented');

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/credentials_manager_platform.dart
@@ -86,11 +86,11 @@ abstract class CredentialsManagerPlatform extends PlatformInterface {
     throw UnimplementedError('getApiCredentials() has not been implemented');
   }
 
-  /// Removes the API credentials for the given audience from the native
-  /// storage if present.
+  /// Removes the API credentials for the given audience and scope from the
+  /// native storage if present.
   ///
   /// See `CredentialsManager.clearApiCredentials` for full documentation.
-  Future<bool> clearApiCredentials(
+  Future<void> clearApiCredentials(
     final CredentialsManagerRequest<ClearApiCredentialsOptions> request,
   ) {
     throw UnimplementedError('clearApiCredentials() has not been implemented');

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
@@ -139,13 +139,14 @@ class MethodChannelCredentialsManager extends CredentialsManagerPlatform {
   /// Uses the [MethodChannel] to communicate with the native platforms.
   /// See `CredentialsManager.clearApiCredentials` for full documentation.
   @override
-  Future<void> clearApiCredentials(
+  Future<bool> clearApiCredentials(
       final CredentialsManagerRequest<ClearApiCredentialsOptions>
           request) async {
-    await _invokeRequest<void, ClearApiCredentialsOptions>(
+    final bool? result = await _invokeRequest<bool, ClearApiCredentialsOptions>(
         method: credentialsManagerClearApiCredentialsMethod,
         request: request,
         throwOnNull: false);
+    return result ?? true;
   }
 
   Future<TResult?> _invokeRequest<TResult, TOptions extends RequestOptions?>({

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
@@ -133,20 +133,19 @@ class MethodChannelCredentialsManager extends CredentialsManagerPlatform {
     return ApiCredentials.fromMap(result);
   }
 
-  /// Removes the API credentials for the given audience from the native
-  /// storage if present.
+  /// Removes the API credentials for the given audience and scope from the
+  /// native storage if present.
   ///
   /// Uses the [MethodChannel] to communicate with the native platforms.
   /// See `CredentialsManager.clearApiCredentials` for full documentation.
   @override
-  Future<bool> clearApiCredentials(
+  Future<void> clearApiCredentials(
       final CredentialsManagerRequest<ClearApiCredentialsOptions>
           request) async {
-    final bool? result = await _invokeRequest<bool, ClearApiCredentialsOptions>(
+    await _invokeRequest<void, ClearApiCredentialsOptions>(
         method: credentialsManagerClearApiCredentialsMethod,
         request: request,
         throwOnNull: false);
-    return result ?? true;
   }
 
   Future<TResult?> _invokeRequest<TResult, TOptions extends RequestOptions?>({

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/method_channel_credentials_manager.dart
@@ -18,6 +18,10 @@ const String credentialsManagerRenewCredentialsMethod =
     'credentialsManager#renewCredentials';
 const String credentialsManagerGetSSOCredentialsMethod =
     'credentialsManager#getSSOCredentials';
+const String credentialsManagerGetApiCredentialsMethod =
+    'credentialsManager#getApiCredentials';
+const String credentialsManagerClearApiCredentialsMethod =
+    'credentialsManager#clearApiCredentials';
 
 /// Method Channel implementation to communicate with the Native
 /// CredentialsManager
@@ -112,6 +116,36 @@ class MethodChannelCredentialsManager extends CredentialsManagerPlatform {
         method: credentialsManagerGetSSOCredentialsMethod, request: request);
 
     return SSOCredentials.fromMap(result);
+  }
+
+  /// Exchanges the stored refresh token for [ApiCredentials] scoped to a
+  /// specific API (audience), using a Multi-Resource Refresh Token (MRRT).
+  ///
+  /// Uses the [MethodChannel] to communicate with the native platforms.
+  /// See `CredentialsManager.getApiCredentials` for full documentation.
+  @override
+  Future<ApiCredentials> getApiCredentials(
+      final CredentialsManagerRequest<GetApiCredentialsOptions>
+          request) async {
+    final Map<String, dynamic> result = await _invokeMapRequest(
+        method: credentialsManagerGetApiCredentialsMethod, request: request);
+
+    return ApiCredentials.fromMap(result);
+  }
+
+  /// Removes the API credentials for the given audience from the native
+  /// storage if present.
+  ///
+  /// Uses the [MethodChannel] to communicate with the native platforms.
+  /// See `CredentialsManager.clearApiCredentials` for full documentation.
+  @override
+  Future<void> clearApiCredentials(
+      final CredentialsManagerRequest<ClearApiCredentialsOptions>
+          request) async {
+    await _invokeRequest<void, ClearApiCredentialsOptions>(
+        method: credentialsManagerClearApiCredentialsMethod,
+        request: request,
+        throwOnNull: false);
   }
 
   Future<TResult?> _invokeRequest<TResult, TOptions extends RequestOptions?>({

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/options/clear_api_credentials_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/options/clear_api_credentials_options.dart
@@ -9,8 +9,8 @@ class ClearApiCredentialsOptions implements RequestOptions {
 
   /// The scope the API credentials were stored with, if any.
   ///
-  /// **iOS/macOS only.** On Android the stored credentials are keyed by
-  /// audience alone, so this value is ignored there.
+  /// Stored API credentials are keyed by both audience and scope on every
+  /// platform, so this must match the scope used to fetch them.
   final String? scope;
 
   ClearApiCredentialsOptions({

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/options/clear_api_credentials_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/options/clear_api_credentials_options.dart
@@ -1,0 +1,26 @@
+import '../../../auth0_flutter_platform_interface.dart';
+
+/// Options used to remove the stored API credentials for a given audience via
+/// `CredentialsManagerPlatform.clearApiCredentials()`.
+class ClearApiCredentialsOptions implements RequestOptions {
+  /// The identifier of the API (the **audience**) whose stored credentials
+  /// should be removed.
+  final String audience;
+
+  /// The scope the API credentials were stored with, if any.
+  ///
+  /// **iOS/macOS only.** On Android the stored credentials are keyed by
+  /// audience alone, so this value is ignored there.
+  final String? scope;
+
+  ClearApiCredentialsOptions({
+    required this.audience,
+    this.scope,
+  });
+
+  @override
+  Map<String, dynamic> toMap() => {
+        'audience': audience,
+        if (scope != null) 'scope': scope,
+      };
+}

--- a/auth0_flutter_platform_interface/lib/src/credentials-manager/options/get_api_credentials_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/credentials-manager/options/get_api_credentials_options.dart
@@ -1,0 +1,41 @@
+import '../../../auth0_flutter_platform_interface.dart';
+
+// ignore: comment_references
+/// Options used to retrieve [ApiCredentials] via
+/// `CredentialsManagerPlatform.getApiCredentials()`.
+class GetApiCredentialsOptions implements RequestOptions {
+  /// The identifier of the API for which to obtain credentials (the
+  /// **audience**), e.g. `https://api.example.com`.
+  final String audience;
+
+  /// The scopes to request for the new access token. If empty, the default
+  /// scopes configured for the API will be used.
+  final Set<String> scopes;
+
+  /// The minimum time-to-live, in seconds, required for the access token. If
+  /// the cached token expires sooner, a refresh will be attempted.
+  final int minTtl;
+
+  /// Additional parameters to send during the token exchange request.
+  final Map<String, String> parameters;
+
+  /// Additional headers to include in the token exchange request.
+  final Map<String, String> headers;
+
+  GetApiCredentialsOptions({
+    required this.audience,
+    this.scopes = const {},
+    this.minTtl = 0,
+    this.parameters = const {},
+    this.headers = const {},
+  });
+
+  @override
+  Map<String, dynamic> toMap() => {
+        'audience': audience,
+        'scopes': scopes.toList(),
+        'minTtl': minTtl,
+        'parameters': parameters,
+        'headers': headers,
+      };
+}

--- a/auth0_flutter_platform_interface/test/api_credentials_test.dart
+++ b/auth0_flutter_platform_interface/test/api_credentials_test.dart
@@ -1,0 +1,97 @@
+import 'package:auth0_flutter_platform_interface/auth0_flutter_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ApiCredentials.fromMap', () {
+    test('maps all properties', () async {
+      final apiCredentials = ApiCredentials.fromMap({
+        'accessToken': 'accessToken',
+        'tokenType': 'Bearer',
+        'expiresAt': '2023-11-01T22:16:35.760Z',
+        'scopes': ['a', 'b'],
+      });
+
+      expect(apiCredentials.accessToken, 'accessToken');
+      expect(apiCredentials.tokenType, 'Bearer');
+      expect(apiCredentials.scopes, {'a', 'b'});
+      expect(apiCredentials.expiresAt,
+          DateTime.parse('2023-11-01T22:16:35.760Z'));
+    });
+
+    test('expiresAt is a UTC DateTime', () async {
+      final apiCredentials = ApiCredentials.fromMap({
+        'accessToken': 'accessToken',
+        'tokenType': 'Bearer',
+        'expiresAt': '2023-11-01T22:16:35.760Z',
+        'scopes': <String>[],
+      });
+
+      expect(apiCredentials.expiresAt.isUtc, true);
+      expect(apiCredentials.scopes, isEmpty);
+    });
+  });
+
+  group('ApiCredentials.toMap', () {
+    test('expiresAt is an ISO 8601 date with UTC time zone', () async {
+      final apiCredentials = ApiCredentials(
+        accessToken: 'accessToken',
+        tokenType: 'Bearer',
+        expiresAt: DateTime.utc(2023, 11, 1, 22, 16, 35, 760),
+        scopes: {'a', 'b'},
+      );
+
+      final map = apiCredentials.toMap();
+      expect(map['accessToken'], 'accessToken');
+      expect(map['tokenType'], 'Bearer');
+      expect(map['expiresAt'], '2023-11-01T22:16:35.760Z');
+      expect(map['scopes'], ['a', 'b']);
+    });
+  });
+
+  group('GetApiCredentialsOptions.toMap', () {
+    test('maps all properties', () async {
+      final map = GetApiCredentialsOptions(
+        audience: 'test-audience',
+        scopes: {'a', 'b'},
+        minTtl: 30,
+        parameters: {'p': '1'},
+        headers: {'h': '2'},
+      ).toMap();
+
+      expect(map['audience'], 'test-audience');
+      expect(map['scopes'], ['a', 'b']);
+      expect(map['minTtl'], 30);
+      expect(map['parameters'], {'p': '1'});
+      expect(map['headers'], {'h': '2'});
+    });
+
+    test('applies defaults to non-required properties', () async {
+      final map = GetApiCredentialsOptions(audience: 'test-audience').toMap();
+
+      expect(map['audience'], 'test-audience');
+      expect(map['scopes'], isEmpty);
+      expect(map['minTtl'], 0);
+      expect(map['parameters'], isEmpty);
+      expect(map['headers'], isEmpty);
+    });
+  });
+
+  group('ClearApiCredentialsOptions.toMap', () {
+    test('includes the scope when provided', () async {
+      final map = ClearApiCredentialsOptions(
+        audience: 'test-audience',
+        scope: 'test-scope',
+      ).toMap();
+
+      expect(map['audience'], 'test-audience');
+      expect(map['scope'], 'test-scope');
+    });
+
+    test('omits the scope when not provided', () async {
+      final map = ClearApiCredentialsOptions(audience: 'test-audience').toMap();
+
+      expect(map['audience'], 'test-audience');
+      expect(map.containsKey('scope'), false);
+    });
+  });
+}

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -1172,7 +1172,7 @@ void main() {
     test('calls the correct MethodChannel method', () async {
       when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
 
-      await MethodChannelCredentialsManager().clearApiCredentials(
+      final result = await MethodChannelCredentialsManager().clearApiCredentials(
           CredentialsManagerRequest<ClearApiCredentialsOptions>(
               account: const Account('test-domain', 'test-clientId'),
               userAgent: UserAgent(name: 'test-name', version: 'test-version'),
@@ -1181,6 +1181,19 @@ void main() {
       expect(
           verify(mocked.methodCallHandler(captureAny)).captured.single.method,
           'credentialsManager#clearApiCredentials');
+      expect(result, true);
+    });
+
+    test('returns false when the audience was not found', () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => false);
+
+      final result = await MethodChannelCredentialsManager().clearApiCredentials(
+          CredentialsManagerRequest<ClearApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: ClearApiCredentialsOptions(audience: 'test-audience')));
+
+      expect(result, false);
     });
 
     test('correctly maps all properties', () async {
@@ -1217,18 +1230,16 @@ void main() {
       expect(verificationResult.arguments.containsKey('scope'), false);
     });
 
-    test('does not throw when the method channel returns null', () async {
+    test('defaults to true when the method channel returns null', () async {
       when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
 
-      await expectLater(
-          MethodChannelCredentialsManager().clearApiCredentials(
-              CredentialsManagerRequest<ClearApiCredentialsOptions>(
-                  account: const Account('', ''),
-                  userAgent:
-                      UserAgent(name: 'test-name', version: 'test-version'),
-                  options:
-                      ClearApiCredentialsOptions(audience: 'test-audience'))),
-          completes);
+      final result = await MethodChannelCredentialsManager().clearApiCredentials(
+          CredentialsManagerRequest<ClearApiCredentialsOptions>(
+              account: const Account('', ''),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: ClearApiCredentialsOptions(audience: 'test-audience')));
+
+      expect(result, true);
     });
 
     test(

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -26,6 +26,13 @@ class MethodCallHandler {
     'refreshToken': 'refreshToken',
   };
 
+  static const Map<dynamic, dynamic> apiCredentials = {
+    'accessToken': 'apiAccessToken',
+    'tokenType': 'Bearer',
+    'expiresAt': '2023-11-01T22:16:35.760Z',
+    'scopes': ['a', 'b'],
+  };
+
   Future<dynamic>? methodCallHandler(final MethodCall? methodCall) async {}
 }
 
@@ -1013,6 +1020,228 @@ void main() {
 
         return result;
       }
+
+      await expectLater(actual, throwsA(isA<CredentialsManagerException>()));
+    });
+  });
+
+  group('getApiCredentials', () {
+    test('calls the correct MethodChannel method', () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.apiCredentials);
+
+      await MethodChannelCredentialsManager().getApiCredentials(
+          CredentialsManagerRequest<GetApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: GetApiCredentialsOptions(audience: 'test-audience')));
+
+      expect(
+          verify(mocked.methodCallHandler(captureAny)).captured.single.method,
+          'credentialsManager#getApiCredentials');
+    });
+
+    test('correctly maps all properties', () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.apiCredentials);
+
+      await MethodChannelCredentialsManager().getApiCredentials(
+          CredentialsManagerRequest<GetApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: GetApiCredentialsOptions(
+                audience: 'test-audience',
+                scopes: {'test-scope1', 'test-scope2'},
+                minTtl: 30,
+                parameters: {'test-param': 'test-value'},
+                headers: {'test-header': 'test-header-value'},
+              )));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['_userAgent']['name'], 'test-name');
+      expect(verificationResult.arguments['_userAgent']['version'],
+          'test-version');
+      expect(verificationResult.arguments['audience'], 'test-audience');
+      expect(verificationResult.arguments['scopes'],
+          ['test-scope1', 'test-scope2']);
+      expect(verificationResult.arguments['minTtl'], 30);
+      expect(verificationResult.arguments['parameters']['test-param'],
+          'test-value');
+      expect(verificationResult.arguments['headers']['test-header'],
+          'test-header-value');
+    });
+
+    test(
+        'correctly assigns default values to all non-required properties when missing',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.apiCredentials);
+
+      await MethodChannelCredentialsManager().getApiCredentials(
+          CredentialsManagerRequest<GetApiCredentialsOptions>(
+              account: const Account('', ''),
+              userAgent: UserAgent(name: '', version: ''),
+              options: GetApiCredentialsOptions(audience: 'test-audience')));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['scopes'], isEmpty);
+      expect(verificationResult.arguments['minTtl'], 0);
+      expect(verificationResult.arguments['parameters'], isEmpty);
+      expect(verificationResult.arguments['headers'], isEmpty);
+    });
+
+    test('correctly returns the response from the Method Channel', () async {
+      when(mocked.methodCallHandler(any))
+          .thenAnswer((final _) async => MethodCallHandler.apiCredentials);
+
+      final result = await MethodChannelCredentialsManager().getApiCredentials(
+          CredentialsManagerRequest<GetApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: GetApiCredentialsOptions(audience: 'test-audience')));
+
+      verify(mocked.methodCallHandler(captureAny));
+
+      expect(result.accessToken,
+          MethodCallHandler.apiCredentials['accessToken']);
+      expect(result.tokenType, MethodCallHandler.apiCredentials['tokenType']);
+      expect(result.scopes, MethodCallHandler.apiCredentials['scopes']);
+      expect(
+          result.expiresAt,
+          DateTime.parse(
+              MethodCallHandler.apiCredentials['expiresAt'] as String));
+    });
+
+    test(
+        'throws a CredentialsManagerException when method channel returns null',
+        () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
+
+      Future<ApiCredentials> actual() async {
+        final result = await MethodChannelCredentialsManager()
+            .getApiCredentials(
+                CredentialsManagerRequest<GetApiCredentialsOptions>(
+                    account: const Account('', ''),
+                    userAgent:
+                        UserAgent(name: 'test-name', version: 'test-version'),
+                    options:
+                        GetApiCredentialsOptions(audience: 'test-audience')));
+
+        return result;
+      }
+
+      expectLater(
+          actual,
+          throwsA(predicate((final e) =>
+              e is CredentialsManagerException &&
+              e.message == 'Channel returned null.')));
+    });
+
+    test(
+        'throws a CredentialsManagerException when method channel throws a PlatformException',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenThrow(PlatformException(code: '123'));
+
+      Future<ApiCredentials> actual() async {
+        final result = await MethodChannelCredentialsManager()
+            .getApiCredentials(
+                CredentialsManagerRequest<GetApiCredentialsOptions>(
+                    account: const Account('', ''),
+                    userAgent:
+                        UserAgent(name: 'test-name', version: 'test-version'),
+                    options:
+                        GetApiCredentialsOptions(audience: 'test-audience')));
+
+        return result;
+      }
+
+      await expectLater(actual, throwsA(isA<CredentialsManagerException>()));
+    });
+  });
+
+  group('clearApiCredentials', () {
+    test('calls the correct MethodChannel method', () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+
+      await MethodChannelCredentialsManager().clearApiCredentials(
+          CredentialsManagerRequest<ClearApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: ClearApiCredentialsOptions(audience: 'test-audience')));
+
+      expect(
+          verify(mocked.methodCallHandler(captureAny)).captured.single.method,
+          'credentialsManager#clearApiCredentials');
+    });
+
+    test('correctly maps all properties', () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+
+      await MethodChannelCredentialsManager().clearApiCredentials(
+          CredentialsManagerRequest<ClearApiCredentialsOptions>(
+              account: const Account('test-domain', 'test-clientId'),
+              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
+              options: ClearApiCredentialsOptions(
+                  audience: 'test-audience', scope: 'test-scope')));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['_account']['domain'], 'test-domain');
+      expect(verificationResult.arguments['_account']['clientId'],
+          'test-clientId');
+      expect(verificationResult.arguments['audience'], 'test-audience');
+      expect(verificationResult.arguments['scope'], 'test-scope');
+    });
+
+    test('omits the scope when not provided', () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+
+      await MethodChannelCredentialsManager().clearApiCredentials(
+          CredentialsManagerRequest<ClearApiCredentialsOptions>(
+              account: const Account('', ''),
+              userAgent: UserAgent(name: '', version: ''),
+              options: ClearApiCredentialsOptions(audience: 'test-audience')));
+
+      final verificationResult =
+          verify(mocked.methodCallHandler(captureAny)).captured.single;
+      expect(verificationResult.arguments['audience'], 'test-audience');
+      expect(verificationResult.arguments.containsKey('scope'), false);
+    });
+
+    test('does not throw when the method channel returns null', () async {
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
+
+      await expectLater(
+          MethodChannelCredentialsManager().clearApiCredentials(
+              CredentialsManagerRequest<ClearApiCredentialsOptions>(
+                  account: const Account('', ''),
+                  userAgent:
+                      UserAgent(name: 'test-name', version: 'test-version'),
+                  options:
+                      ClearApiCredentialsOptions(audience: 'test-audience'))),
+          completes);
+    });
+
+    test(
+        'throws a CredentialsManagerException when method channel throws a PlatformException',
+        () async {
+      when(mocked.methodCallHandler(any))
+          .thenThrow(PlatformException(code: '123'));
+
+      Future<void> actual() async =>
+          MethodChannelCredentialsManager().clearApiCredentials(
+              CredentialsManagerRequest<ClearApiCredentialsOptions>(
+                  account: const Account('', ''),
+                  userAgent:
+                      UserAgent(name: 'test-name', version: 'test-version'),
+                  options:
+                      ClearApiCredentialsOptions(audience: 'test-audience')));
 
       await expectLater(actual, throwsA(isA<CredentialsManagerException>()));
     });

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -1170,9 +1170,9 @@ void main() {
 
   group('clearApiCredentials', () {
     test('calls the correct MethodChannel method', () async {
-      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
 
-      final result = await MethodChannelCredentialsManager().clearApiCredentials(
+      await MethodChannelCredentialsManager().clearApiCredentials(
           CredentialsManagerRequest<ClearApiCredentialsOptions>(
               account: const Account('test-domain', 'test-clientId'),
               userAgent: UserAgent(name: 'test-name', version: 'test-version'),
@@ -1181,23 +1181,10 @@ void main() {
       expect(
           verify(mocked.methodCallHandler(captureAny)).captured.single.method,
           'credentialsManager#clearApiCredentials');
-      expect(result, true);
-    });
-
-    test('returns false when the audience was not found', () async {
-      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => false);
-
-      final result = await MethodChannelCredentialsManager().clearApiCredentials(
-          CredentialsManagerRequest<ClearApiCredentialsOptions>(
-              account: const Account('test-domain', 'test-clientId'),
-              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
-              options: ClearApiCredentialsOptions(audience: 'test-audience')));
-
-      expect(result, false);
     });
 
     test('correctly maps all properties', () async {
-      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
 
       await MethodChannelCredentialsManager().clearApiCredentials(
           CredentialsManagerRequest<ClearApiCredentialsOptions>(
@@ -1216,7 +1203,7 @@ void main() {
     });
 
     test('omits the scope when not provided', () async {
-      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => true);
+      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
 
       await MethodChannelCredentialsManager().clearApiCredentials(
           CredentialsManagerRequest<ClearApiCredentialsOptions>(
@@ -1228,18 +1215,6 @@ void main() {
           verify(mocked.methodCallHandler(captureAny)).captured.single;
       expect(verificationResult.arguments['audience'], 'test-audience');
       expect(verificationResult.arguments.containsKey('scope'), false);
-    });
-
-    test('defaults to true when the method channel returns null', () async {
-      when(mocked.methodCallHandler(any)).thenAnswer((final _) async => null);
-
-      final result = await MethodChannelCredentialsManager().clearApiCredentials(
-          CredentialsManagerRequest<ClearApiCredentialsOptions>(
-              account: const Account('', ''),
-              userAgent: UserAgent(name: 'test-name', version: 'test-version'),
-              options: ClearApiCredentialsOptions(audience: 'test-audience')));
-
-      expect(result, true);
     });
 
     test(

--- a/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_credentials_manager_test.dart
@@ -1110,7 +1110,10 @@ void main() {
       expect(result.accessToken,
           MethodCallHandler.apiCredentials['accessToken']);
       expect(result.tokenType, MethodCallHandler.apiCredentials['tokenType']);
-      expect(result.scopes, MethodCallHandler.apiCredentials['scopes']);
+      expect(
+          result.scopes,
+          Set<String>.from(
+              MethodCallHandler.apiCredentials['scopes'] as List<dynamic>));
       expect(
           result.expiresAt,
           DateTime.parse(


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds Multi-Resource Refresh Token (MRRT) support to the credentials manager, bringing the Flutter plugin to parity with react-native-auth0, Auth0.Android, and Auth0.swift, which already expose this capability.

**Why:** Previously the Flutter plugin had no way to obtain an access token for an API (audience) other than the one the user logged in with. Apps had to either log in again interactively against the second audience or misuse credentials(parameters: {'audience': ...}), which does not perform a real MRRT exchange (it returns the cached app-audience token when still valid). This adds the dedicated, correct API.

**New public API on CredentialsManager:**

```
Future<ApiCredentials> getApiCredentials({
  required String audience,
  Set<String> scope = const {},
  int minTtl = 0,
  Map<String, String> parameters = const {},
  Map<String, String> headers = const {}, // iOS/macOS only
});

Future<void> clearApiCredentials({
  required String audience,
  String? scope,
});
```

- getApiCredentials exchanges the stored refresh token for an access token scoped to the requested audience (MRRT). If valid API credentials for that audience are already cached, they are returned without a network call; otherwise a new token is fetched and cached per audience.
- clearApiCredentials removes the cached API credentials for an audience (e.g. on logout).

**Layers touched:** platform interface (ApiCredentials model, two options classes, abstract methods, method channel, barrel exports) → Dart public API → Android request handlers → iOS/macOS method handlers → docs (EXAMPLES.md, README.md).

**No breaking changes:** everything is additive (new methods/types; new platform-interface methods follow the existing throw UnimplementedError() default-body pattern). No native dependency bump required — MRRT is available in the already-pinned Auth0.Android 3.16.0 (added in 3.7.0) and Auth0.swift 2.18.0 (added in 2.12.0).

**Prerequisites for use:** Multi-Resource Refresh Tokens must be enabled on the tenant, and the offline_access scope must be requested at login.

### 📎 References

SDK-9521

### 🎯 Testing

**Automated (added in this PR):**

- Dart – platform interface (api_credentials_test.dart, method_channel_credentials_manager_test.dart): ApiCredentials.fromMap/toMap, options toMap (with/without optional args, scope omission), and method-channel routing/result-parsing/error paths for both getApiCredentials and clearApiCredentials.
- Dart – auth0_flutter (credentials_manager_test.dart): both methods pass arguments through to the platform, apply defaults, and return the platform result.
- Android (GetApiCredentialsRequestHandlerTest.kt, ClearApiCredentialsRequestHandlerTest.kt): native call invoked with correct audience/scope/options, success field mapping, failure path, missing-audience error.
- iOS/macOS (CredentialsManagerApiCredentialsMethodHandlerTests.swift, CredentialsManagerClearApiCredentialsMethodHandlerTests.swift): required-argument errors, exchange called with audience/scope, produced dictionary shape, and CredentialsManagerError propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getApiCredentials() and clearApiCredentials() and an ApiCredentials model for per-audience API credential management (MRRT), with options for scopes, TTL, parameters, and headers.

* **Documentation**
  * Updated docs and examples with Credentials Manager MRRT usage, API examples, prerequisites, and platform cache-keying behavior.

* **Tests**
  * Added unit and platform tests covering fetch/clear flows, defaults, error handling, and credentials serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->