### PR TITLE
afpi: suppress deprecated allowedBrowsers analyze warnings in ship cli

### DIFF
--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_login_options.dart
@@ -33,6 +33,7 @@ class WebAuthLoginOptions extends LoginOptions {
   Map<String, dynamic> toMap() {
     final map = {
       ...super.toMap(),
+      // ignore: deprecated_member_use_from_same_package
       'allowedBrowsers': allowedBrowsers,
       'useHTTPS': useHTTPS,
       'useEphemeralSession': useEphemeralSession,

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_auth_logout_options.dart
@@ -25,6 +25,7 @@ class WebAuthLogoutOptions implements RequestOptions {
         'returnTo': returnTo,
         'scheme': scheme,
         'federated': federated,
+        // ignore: deprecated_member_use_from_same_package
         'allowedBrowsers': allowedBrowsers,
         ...customTabsOptions != null
             ? {'customTabsOptions': customTabsOptions?.toMap()}

--- a/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
+++ b/auth0_flutter_platform_interface/test/method_channel_auth0_flutter_web_auth_test.dart
@@ -283,6 +283,7 @@ void main() {
                   useHTTPS: true,
                   returnTo: 'http://localhost:1234',
                   scheme: 'test-scheme',
+                  // ignore: deprecated_member_use_from_same_package
                   allowedBrowsers: ['com.android.chrome', 'org.mozilla.firefox'])));
 
       final verificationResult =
@@ -308,6 +309,7 @@ void main() {
               account: const Account('test-domain', 'test-clientId'),
               userAgent: UserAgent(name: 'test-name', version: 'test-version'),
               options: WebAuthLogoutOptions(
+                  // ignore: deprecated_member_use_from_same_package
                   allowedBrowsers: ['com.android.chrome'])));
 
       final verificationResult =

--- a/auth0_flutter_platform_interface/test/web_auth_login_options_test.dart
+++ b/auth0_flutter_platform_interface/test/web_auth_login_options_test.dart
@@ -20,6 +20,7 @@ void main() {
         useEphemeralSession: true,
         scheme: 'demo',
         safariViewController: safariViewController,
+        // ignore: deprecated_member_use_from_same_package
         allowedBrowsers: ['chrome', 'firefox'],
       );
 


### PR DESCRIPTION
The allowedBrowsers field is retained for backward compatibility but its internal toMap() serialization and tests still reference it, producing deprecated_member_use_from_same_package info warnings that block the Ship CLI release. Suppress at the legitimate internal-use sites.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Here's content for the PR template sections:

📋 Changes

### 📋 Changes

The `allowedBrowsers` field on `WebAuthLoginOptions` and `WebAuthLogoutOptions` was deprecated (in favor of `CustomTabsOptions.allowedBrowsers`) by the Partial Custom Tabs work (#846). The field is intentionally retained for backward compatibility, but it is still referenced internally by each class's `toMap()` serialization and by the existing unit tests. These internal references produce `deprecated_member_use_from_same_package` info-level warnings.

The Ship CLI release pipeline runs `flutter analyze` as a pre-release gate and treats any output (including info-level lints) as a failure, which blocks cutting a release for `auth0_flutter_platform_interface`.

This change suppresses the warning at the 5 legitimate internal-use sites with `// ignore: deprecated_member_use_from_same_package`:

- `lib/src/web-auth/web_auth_login_options.dart` — `toMap()` serialization
- `lib/src/web-auth/web_auth_logout_options.dart` — `toMap()` serialization
- `test/method_channel_auth0_flutter_web_auth_test.dart` (2 sites)
- `test/web_auth_login_options_test.dart`

No public API changes. The deprecated field remains available and serialized exactly as before; this only silences the same-package self-reference lint.

### 🎯 Testing

- `flutter analyze` now reports **No issues found!** in `auth0_flutter_platform_interface` (previously 5 issues, which blocked the Ship CLI release).
- Existing unit tests are unchanged in behavior — only `// ignore:` comments were added; `flutter test` continues to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added analyzer suppressions to address deprecated member usage warnings in the Auth0 Flutter platform interface library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->