### PR TITLE
chore(example): bump Android Gradle plugin and Kotlin toolchain

### DIFF
--- a/auth0_flutter/example/android/app/src/main/kotlin/com/auth0/auth0_flutter_example/MainActivity.kt
+++ b/auth0_flutter/example/android/app/src/main/kotlin/com/auth0/auth0_flutter_example/MainActivity.kt
@@ -1,6 +1,11 @@
 package com.auth0.auth0_flutter_example
 
 import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterFragmentActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+    }
 }

--- a/auth0_flutter/example/android/gradle.properties
+++ b/auth0_flutter/example/android/gradle.properties
@@ -7,3 +7,7 @@ org.gradle.jvmargs=-Xmx1536M \
 android.useAndroidX=true
 android.enableJetifier=true
 android.jetifier.ignorelist=bcprov-jdk15on
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/auth0_flutter/example/android/settings.gradle
+++ b/auth0_flutter/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
 include ':app'


### PR DESCRIPTION
## Summary

Extracts unrelated Android toolchain maintenance from the passkeys PR (#858).

- Bump example app AGP `8.3.0` → `8.6.0` and Kotlin `1.9.10` → `1.9.22` (`settings.gradle`)
- Add Flutter-migrator flags `android.builtInKotlin=false` / `android.newDsl=false` (`gradle.properties`)
- Add generated `MainActivity.configureFlutterEngine` override

## Context

These changes were bundled into #858 (passkeys) but are independent build-system maintenance. Splitting them out isolates the build-system risk for focused review.

## Test plan

- [ ] CI Android build passes
- [ ] Example app builds and runs on Android