### PR TITLE
docs: fix README drift — broken DPoP link, stale What's New banner, stale migration notice

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -58,29 +58,6 @@
 
 ## 📱 Web Authentication
 
-  - [Log out](#log-out)
-  - [Sign up](#sign-up)
-  - [Adding an audience](#adding-an-audience)
-  - [Adding scopes](#adding-scopes)
-  - [Adding custom parameters](#adding-custom-parameters)
-  - [ID token validation](#id-token-validation)
-  - [Using `SFSafariViewController` (iOS only)](#using-sfsafariviewcontroller-ios-only)
-    - [1. Configure a custom URL scheme](#1-configure-a-custom-url-scheme)
-    - [2. Capture the callback URL](#2-capture-the-callback-url)
-  - [Using Partial Custom Tabs (Android only)](#using-partial-custom-tabs-android-only)
-  - [Errors](#errors)
-  - [Android: Custom schemes](#android-custom-schemes)
-- [🪟 Windows Web Authentication](#-windows-web-authentication)
-  - [Prerequisites](#prerequisites)
-    - [1. Install vcpkg and native dependencies](#1-install-vcpkg-and-native-dependencies)
-    - [2. Configure your app's CMakeLists.txt](#2-configure-your-apps-cmakeliststxt)
-    - [3. Register the custom URL scheme (protocol handler)](#3-register-the-custom-url-scheme-protocol-handler)
-    - [4. Update the runner (main.cpp)](#4-update-the-runner-maincpp)
-  - [Login](#login)
-  - [Logout](#logout)
-
----
-
 ### Log out
 
 Logging the user out involves clearing the Universal Login session cookie and then deleting the user's credentials from your app.
@@ -767,7 +744,7 @@ if (userProfile != null) {
 
 ### Custom implementations
 
-flutter_auth0 exposes a built-in, default Credentials Manager implementation through the `credentialsManager` property. You can pass your own implementation to the `Auth0` constructor. If you're using Web Auth, this implementation will be used to store the user's credentials after login and delete them after logout.
+auth0_flutter exposes a built-in, default Credentials Manager implementation through the `credentialsManager` property. You can pass your own implementation to the `Auth0` constructor. If you're using Web Auth, this implementation will be used to store the user's credentials after login and delete them after logout.
 
 ```dart
 final customCredentialsManager = CustomCredentialsManager();
@@ -1472,7 +1449,7 @@ try {
 
 The My Account API lets authenticated users manage their own multi-factor authentication (MFA) methods — enrolling, confirming, listing, updating, and deleting factors such as phone, email, TOTP, push notifications, and recovery codes. It is available on **mobile (Android/iOS) only**.
 
-> 💡 The My Account API must be enabled for your tenant. If it is not yet available on your account, reach out to Auth0 support to get it enabled.
+> 💡 The My Account API requires [Multi-Resource Refresh Tokens (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token) to be enabled for your tenant. Contact Auth0 support if MRRT is not yet available on your account.
 
 ### Obtaining an access token for the My Account API
 

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -9,9 +9,9 @@
 📚 <a href="#documentation">Documentation</a> • 🚀 <a href="#getting-started">Getting started</a> • 🌐 <a href="#api-reference">API reference</a> • 💬 <a href="#feedback">Feedback</a>
 </div>
 
-## What's New: v2.1.0
+## What's New: v2.3.0
 
-**auth0_flutter v2.1.0** adds **Windows Desktop** support. You can now use `windowsWebAuthentication()` to authenticate users on Windows using the same PKCE-based flow available on mobile. See the [Windows configuration section](#windows-configure-protocol-handler) below for setup instructions.
+**auth0_flutter v2.3.0** adds **Passkeys** support. You can now authenticate users with passkeys via the `webAuthentication()` flow on Android, iOS, and Web. See the [Auth0 passkeys documentation](https://auth0.com/docs/authenticate/database-connections/passkeys) for setup instructions.
 
 ## Important Migration Notice: v2.0.0
 

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -13,10 +13,6 @@
 
 **auth0_flutter v2.3.0** adds **Passkeys** support. You can now authenticate users with passkeys via the `webAuthentication()` flow on Android, iOS, and Web. See the [Auth0 passkeys documentation](https://auth0.com/docs/authenticate/database-connections/passkeys) for setup instructions.
 
-## Important Migration Notice: v2.0.0
-
-**auth0_flutter v2.0.0** includes updates to the underlying native Auth0 SDKs to support **DPoP (Demonstrating Proof of Possession)** and other improvements. See the [Migration Guide](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/MIGRATION_GUIDE.md) for compatibility requirements and upgrade instructions.
-
 ## Documentation
 
 - Quickstarts: [Native](https://auth0.com/docs/quickstart/native/flutter/interactive) / [Web](https://auth0.com/docs/quickstart/spa/flutter/interactive) / [Windows](https://auth0.com/docs/quickstart/native/flutter-windows) - our interactive guide for quickly adding login, logout and user information to your app using Auth0

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -534,7 +534,7 @@ final auth0Web = Auth0Web(
 
 > **Note:** In most cases, DPoP is managed automatically when `useDPoP: true` is enabled. Manual DPoP APIs are available for advanced use cases where you need direct control over DPoP proof generation.
 
-📖 **For complete DPoP documentation, examples, and troubleshooting, see [DPOP.md](DPOP.md)**
+📖 **For complete DPoP documentation, examples, and troubleshooting, see [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md)**
 
 ### iOS SSO Alert Box
 


### PR DESCRIPTION
## Summary

Documentation drift fixes for `auth0-flutter` v2.3.0 — audited against the live API surface.

### README.md (3 fixes)
- **What's New banner** updated from v2.1.0 → v2.3.0 with passkeys callout (P2 — stale hero section)
- **Stale v2.0.0 migration notice** removed — 3 versions old, no longer relevant to new developers (P2)
- **Broken DPoP.md link** corrected to point to `MIGRATION_GUIDE.md` (P2)

### EXAMPLES.md (3 fixes)
- **Package name typo** corrected: `flutter_auth0` → `auth0_flutter` in Credentials Manager section (P3)
- **Duplicate partial TOC block** removed — lines that re-listed Web Auth section headings already present in the full TOC above (P3)
- **Stale My Account API gating note** updated: the note said "the API must be enabled — contact support"; in reality only MRRT must be enabled, not the feature itself (P2)

## Test plan

- [ ] Verify all markdown links resolve in the GitHub preview
- [ ] Confirm `## What's New: v2.3.0` banner accurately describes passkeys and links to the passkeys docs
- [ ] Confirm no duplicate headings remain in EXAMPLES.md TOC
- [ ] Confirm `auth0_flutter` package name is used consistently throughout EXAMPLES.md

🤖 Generated with [syncing-sdk-docs](https://github.com/atko-cic/claude-marketplace) skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the “What’s New” section to highlight version 2.3.0 and new Passkeys support for web authentication on Android, iOS, and Web.

* **Documentation**
  * Refined example docs for clearer web authentication and credentials manager guidance.
  * Clarified the My Account API note about Multi-Resource Refresh Tokens requirements.
  * Updated a documentation link for DPoP guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->