### PR TITLE
chore: Added Auth0.Android dependency to dependabot update checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,19 @@ updates:
       - ignore title check
       - dependencies
 
+  - package-ecosystem: gradle
+    directory: auth0_flutter/android
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: 'com.auth0.android:auth0'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+    labels:
+      - ignore title check
+      - dependencies
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION


### 📋 Changes

This PR adds a check for `Auth0.Android`  minor / patch version updates in the dependabot regular checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new automated dependency update rule for the Android Gradle project.
  * Updates now run daily, focus on the Auth0 Android package, and keep major version changes for other dependencies out of automatic updates.
  * Existing labels are still applied to these update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->