### PR TITLE
fix: Prevent named-pipe squatting in Windows example app via FILE_FLAG_FIRST_PIPE_INSTANCE

### DIFF
--- a/auth0_flutter/example/windows/runner/main.cpp
+++ b/auth0_flutter/example/windows/runner/main.cpp
@@ -120,9 +120,13 @@ void StartPipeServer() {
       sa.lpSecurityDescriptor = pSD;
       sa.bInheritHandle       = FALSE;
 
+      // FILE_FLAG_FIRST_PIPE_INSTANCE causes this call to fail if a pipe with
+      // this name already exists, preventing an attacker from squatting the
+      // name before the app starts and having later client connections
+      // round-robin onto their instance instead of ours.
       HANDLE hPipe = CreateNamedPipeW(
           kRedirectPipeName,
-          PIPE_ACCESS_INBOUND,
+          PIPE_ACCESS_INBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE,
           PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
           1, 0, 0, 0, &sa);
 
@@ -130,6 +134,11 @@ void StartPipeServer() {
       LocalFree(pSD);
 
       if (hPipe == INVALID_HANDLE_VALUE) {
+        // ERROR_ACCESS_DENIED here means a pipe instance with this name
+        // already existed (e.g. squatted before this app started, or a
+        // stale instance from another process) — refuse to run the
+        // redirect-forwarding thread rather than risk operating alongside
+        // an attacker-controlled instance.
         return;
       }
 


### PR DESCRIPTION
## Summary

- `CreateNamedPipeW` in the Windows example app's redirect-forwarding pipe server now passes `FILE_FLAG_FIRST_PIPE_INSTANCE`, so pipe creation fails if a pipe with the same name already exists.
- This closes a squatting window where an attacker (running as the same user) could pre-create the pipe before the app starts, causing later client connections to round-robin onto their instance instead of ours.
- This is additional defense-in-depth on top of the SID-restricted pipe ACL and callback-prefix validation already in `main`.

## Test plan

- [x] Build the Windows example app and confirm normal single-instance / protocol-redirect login flow still works
- [x] Verify a second app launch (simulating the OS protocol-activation path) still forwards the callback URI to the first instance correctly
- [x] Confirm `CreateNamedPipeW` failure (e.g. simulated pre-existing pipe) is handled gracefully — pipe server thread exits rather than crashing
