### PR TITLE
chore : Added dependabot update for Auth0.Swift version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,19 @@ updates:
       - ignore title check
       - dependencies
 
+  - package-ecosystem: swift
+    directory: auth0_flutter/darwin/auth0_flutter
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: 'https://github.com/auth0/Auth0.swift'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+    labels:
+      - ignore title check
+      - dependencies
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/check-darwin-deps.yml
+++ b/.github/workflows/check-darwin-deps.yml
@@ -1,0 +1,37 @@
+## This workflow can be removed once we removed podspec from flutter for Auth0.Seift dependency
+
+name: Darwin dependencies
+
+on:
+    pull_request:
+      types:
+        - opened
+        - synchronize
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check-darwin-deps:
+    name: Check iOS/macOS podspec dependency versions
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+        - name: Run check
+          run: |
+            scripts/sync-darwin-deps.sh
+
+            if git diff HEAD --quiet --diff-filter=ACDMRT; then
+                echo $'\nPodspec dependency versions are in sync with Package.swift.'
+                echo 'All good.'
+            else
+                echo $'\nThe podspec dependency versions are out of sync with Package.swift.'
+                echo "Please run 'scripts/sync-darwin-deps.sh' from the repository root and commit the changes."
+                exit 1
+            fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,23 @@ The `.githooks` folder contains git hooks specific to this repository. To make s
 git config core.hooksPath .githooks
 ```
 
+## iOS/macOS dependency versions
+
+The native Auth0 dependencies (`Auth0.swift`, `JWTDecode.swift`, `SimpleKeychain`) are declared in two places for the iOS/macOS SDK:
+
+- **`auth0_flutter/darwin/auth0_flutter/Package.swift`** — the Swift Package Manager manifest. This is the **single source of truth**, and the only file [Dependabot](.github/dependabot.yml) updates (via the `swift` ecosystem). CocoaPods has no Dependabot support, so bumps land here.
+- **The three CocoaPods podspecs** (`auth0_flutter/ios`, `auth0_flutter/macos`, `auth0_flutter/darwin`) — consumed by apps that use CocoaPods rather than SPM. These must be kept in sync with `Package.swift` manually.
+
+To propagate a version change from `Package.swift` into the podspecs, run **from the repository root**:
+
+```sh
+scripts/sync-darwin-deps.sh
+```
+
+The [`Darwin dependencies` workflow](.github/workflows/check-darwin-deps.yml) enforces this on every PR: it runs the script and fails if the podspecs are out of sync, so a Dependabot bump of `Auth0.swift` will show a red check until someone runs the script and commits the result.
+
+> This whole mechanism only exists because the podspecs duplicate the SPM version pin. Once the CocoaPods podspecs are no longer needed, the script and the workflow can both be removed.
+
 ## Running package tests
 
 Run the unit tests for both packages using `flutter test` in **/auth0_flutter** and **/auth0_flutter_platform_interface** respectively.

--- a/scripts/sync-darwin-deps.sh
+++ b/scripts/sync-darwin-deps.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Syncs the Auth0 native dependency versions declared in the CocoaPods podspecs
+# (ios/, macos/, darwin/) with the canonical versions pinned in the Swift Package
+# Manager manifest under darwin/auth0_flutter/Package.swift.
+#
+# Package.swift is the single source of truth: Dependabot (swift ecosystem) bumps
+# it, and this script propagates the new version into the podspecs, which
+# CocoaPods consumers rely on.
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+repo_path=$(git rev-parse --show-toplevel)
+
+if [ "$repo_path" != "$PWD" ]; then
+    echo 'This script must be run from the repository root'
+    exit 1
+fi
+
+package_swift='auth0_flutter/darwin/auth0_flutter/Package.swift'
+
+podspecs=(
+    'auth0_flutter/ios/auth0_flutter.podspec'
+    'auth0_flutter/macos/auth0_flutter.podspec'
+    'auth0_flutter/darwin/auth0_flutter.podspec'
+)
+
+# Maps the CocoaPods pod name (as it appears in `s.dependency '<pod>', '<ver>'`)
+# to the trailing path of its Swift package URL in Package.swift
+# (`.package(url: "https://github.com/auth0/<url>", exact: "<ver>")`).
+pods=('Auth0' 'JWTDecode' 'SimpleKeychain')
+urls=('Auth0.swift' 'JWTDecode.swift' 'SimpleKeychain')
+
+for i in "${!pods[@]}"; do
+    pod="${pods[$i]}"
+    url="${urls[$i]}"
+
+    # Extract the version pinned for this package in Package.swift. Match the
+    # exact URL (including the closing quote) so e.g. Auth0.swift does not also
+    # match a longer URL, then pull out the semantic version.
+    line=$(grep -F "github.com/auth0/${url}\"" "$package_swift" || true)
+    version=$(printf '%s\n' "$line" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+
+    if [ -z "$version" ]; then
+        echo "::error::Could not find a version for '$url' in $package_swift"
+        exit 1
+    fi
+
+    for spec in "${podspecs[@]}"; do
+        # Portable in-place edit: perl is available on both macOS and the CI
+        # runners, and \x27 lets us match the literal single quotes in the
+        # podspec without shell-quoting gymnastics.
+        POD="$pod" VER="$version" perl -i -pe \
+            's/(s\.dependency\s+\x27\Q$ENV{POD}\E\x27\s*,\s*\x27)\d+\.\d+\.\d+(\x27)/$1$ENV{VER}$2/' \
+            "$spec"
+    done
+done
+
+for spec in "${podspecs[@]}"; do
+    git add "$spec"
+done
+
+echo 'Podspec dependency versions synced with Package.swift.'


### PR DESCRIPTION

### 📋 Changes

This PR adds dependabot check for the lates `Auth0.Swift` versions in the SPM. Added a new workflow check to ensure the SPM version updates are in sync with the podspec ones.  A new `bash` script is added to automatically update the podspec versions when run 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of iOS and macOS dependency versions across supported package definitions.
  * Added validation to detect and report version mismatches during pull requests.
  * Enabled daily checks for Swift dependency updates.

* **Documentation**
  * Added guidance for managing and synchronizing native dependency versions.
  * Documented the automated validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->