### PR TITLE
Release afpi-v2.6.0

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [afpi-v2.6.0](https://github.com/auth0/auth0-flutter/tree/afpi-v2.6.0) (2026-07-30)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.5.0...afpi-v2.6.0)
+
+**Added**
+- feat: surface IPSIE session_expiry claim across Android, iOS and web [\#904](https://github.com/auth0/auth0-flutter/pull/904) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
+**Fixed**
+- fix: Prevent named-pipe squatting in Windows example app via FILE_FLAG_FIRST_PIPE_INSTANCE [\#905](https://github.com/auth0/auth0-flutter/pull/905) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [afpi-v2.5.0](https://github.com/auth0/auth0-flutter/tree/afpi-v2.5.0) (2026-07-17)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.4.0...afpi-v2.5.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 2.5.0
+version: 2.6.0
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Added**
- feat: surface IPSIE session_expiry claim across Android, iOS and web [\#904](https://github.com/auth0/auth0-flutter/pull/904) ([utkrishtsahu](https://github.com/utkrishtsahu))

**Fixed**
- fix: Prevent named-pipe squatting in Windows example app via FILE_FLAG_FIRST_PIPE_INSTANCE [\#905](https://github.com/auth0/auth0-flutter/pull/905) ([NandanPrabhu](https://github.com/NandanPrabhu))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released `auth0_flutter_platform_interface` version 2.6.0.
  * Updated the changelog with release details and links to the full change history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->