### PR TITLE
Release af-v2.6.0

### DIFF
--- a/auth0_flutter/CHANGELOG.md
+++ b/auth0_flutter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [af-v2.6.0](https://github.com/auth0/auth0-flutter/tree/af-v2.6.0) (2026-07-31)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v2.5.0...af-v2.6.0)
+
+**Added**
+- feat: add passkeys support for web [\#907](https://github.com/auth0/auth0-flutter/pull/907) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- feat: surface IPSIE session_expiry claim across Android, iOS and web [\#904](https://github.com/auth0/auth0-flutter/pull/904) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
+**Fixed**
+- fix: Prevent named-pipe squatting in Windows example app via FILE_FLAG_FIRST_PIPE_INSTANCE [\#905](https://github.com/auth0/auth0-flutter/pull/905) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [af-v2.5.0](https://github.com/auth0/auth0-flutter/tree/af-v2.5.0) (2026-07-17)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/af-v2.4.0...af-v2.5.0)
 

--- a/auth0_flutter/darwin/auth0_flutter.podspec
+++ b/auth0_flutter/darwin/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.5.0'
+  s.version      = '2.6.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/ios/auth0_flutter.podspec
+++ b/auth0_flutter/ios/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.5.0'
+  s.version      = '2.6.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/lib/src/version.dart
+++ b/auth0_flutter/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String version = '2.5.0';
+const String version = '2.6.0';

--- a/auth0_flutter/macos/auth0_flutter.podspec
+++ b/auth0_flutter/macos/auth0_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name         = 'auth0_flutter'
-  s.version      = '2.5.0'
+  s.version      = '2.6.0'
   s.summary      = 'Auth0 SDK for Flutter'
   s.description  = 'Auth0 SDK for Flutter Android, iOS, macOS, Windows, and web apps.'
   s.homepage     = 'https://auth0.com'

--- a/auth0_flutter/pubspec.yaml
+++ b/auth0_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter
 description: Auth0 SDK for Flutter. Easily integrate Auth0 into Android, iOS, macOS, Windows, and web Flutter apps.
-version: 2.5.0
+version: 2.6.0
 homepage: https://github.com/auth0/auth0-flutter
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.24.0"
 
 dependencies:
-  auth0_flutter_platform_interface: ^2.5.0
+  auth0_flutter_platform_interface: ^2.6.0
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION

**Added**
- feat: add passkeys support for web [\#907](https://github.com/auth0/auth0-flutter/pull/907) ([NandanPrabhu](https://github.com/NandanPrabhu))
- feat: surface IPSIE session_expiry claim across Android, iOS and web [\#904](https://github.com/auth0/auth0-flutter/pull/904) ([utkrishtsahu](https://github.com/utkrishtsahu))

**Fixed**
- fix: Prevent named-pipe squatting in Windows example app via FILE_FLAG_FIRST_PIPE_INSTANCE [\#905](https://github.com/auth0/auth0-flutter/pull/905) ([NandanPrabhu](https://github.com/NandanPrabhu))
