### PR TITLE
feat: Upgrade Auth0.Android to v4.0.0.

### DIFF
--- a/auth0_flutter/V3_MIGRATION_GUIDE.md
+++ b/auth0_flutter/V3_MIGRATION_GUIDE.md
@@ -1,0 +1,113 @@
+# Migration Guide from auth0_flutter v2 to v3
+
+`auth0_flutter` v3 upgrades the wrapped native SDKs to their next major versions
+— **Auth0.Android v4** on Android and **Auth0.swift v3** on iOS/macOS. Those
+upgrades raise the minimum platform requirements and change some native
+behavior that surfaces through the Dart API.
+
+> **Note**
+> This is a living document. It currently covers the **Android** track changes.
+> The remaining cross-platform Dart API renames (for example
+> `expiresIn` → `expiresAt`, `clearSession` → `logout`, `UserInfo` →
+> `UserProfile`) land in later v3 PRs and will be documented here as they merge.
+
+## Table of Contents
+
+- [Requirements Changes](#requirements-changes)
+- [Behavior Changes](#behavior-changes)
+  - [`credentialsManager.clearCredentials` now clears all stored data (Android)](#credentialsmanagerclearcredentials-now-clears-all-stored-data-android)
+  - [`api.multifactorChallenge` requires `authenticatorId` (Android)](#apimultifactorchallenge-requires-authenticatorid-android)
+- [Getting Help](#getting-help)
+
+## Requirements Changes
+
+Because the underlying native SDKs raised their floors, `auth0_flutter` v3
+raises the Android minimums:
+
+| Requirement | v2 | v3 |
+| --- | --- | --- |
+| Android `minSdkVersion` | 21 | **26** (Android 8.0) |
+| Android compile/target SDK | 34 | **36** |
+| JDK (to build the Android module) | 8 | **17** |
+| Kotlin | 1.9.x | **2.0.21** |
+| Android Gradle Plugin | 8.4.x | **8.10.1** |
+| Gradle | 8.7 | **8.11.1** |
+
+**Migration:** if your app targets an Android `minSdkVersion` below 26, raise it
+to at least 26 in your app's `android/app/build.gradle`. Ensure your build
+environment uses JDK 17 (for example, set it in Android Studio under
+*Settings → Build, Execution, Deployment → Build Tools → Gradle → Gradle JDK*,
+or via `org.gradle.java.home`).
+
+There are **no source changes required** to your Dart code for these
+requirement bumps.
+
+## Behavior Changes
+
+### `credentialsManager.clearCredentials` now clears all stored data (Android)
+
+**Change:** In Auth0.Android v4, `clearCredentials()` performs a full wipe of
+the underlying storage (`Storage.removeAll()`) rather than removing only the
+individual credential entries it wrote.
+
+**Impact:** If your app stored unrelated values in the same
+`SharedPreferences` instance that the credentials manager uses (for example, by
+supplying a custom `sharedPreferencesName` via
+`CredentialsManagerConfiguration` and reusing it elsewhere), calling
+`clearCredentials` now removes those values too.
+
+**Migration:** Do not share the credentials manager's storage with other data.
+Keep any app data you need to persist independently of Auth0 credentials in a
+separate store. The Dart API is unchanged:
+
+```dart
+// Same call as v2 — behavior on Android is now a full wipe of the store.
+await credentialsManager.clearCredentials();
+```
+
+This affects Android only. iOS/macOS behavior is unchanged.
+
+### `api.multifactorChallenge` requires `authenticatorId` (Android)
+
+**Change:** Auth0.Android v4 removed the inline MFA methods from the
+authentication client and routes MFA through a dedicated MFA client whose
+`challenge` operation accepts only an `authenticatorId` — there is no
+challenge-type filtering.
+
+**Impact:** On Android, a `multifactorChallenge` call must now include
+`authenticatorId`. A call that supplies only `types` and omits
+`authenticatorId` — which was accepted in v2 — now fails on Android. Any `types`
+value passed is ignored on Android.
+
+> **Note**
+> The Dart signature of `multifactorChallenge` is unchanged in this release
+> (`types` and `authenticatorId` remain optional parameters), so this is a
+> runtime behavior change on Android rather than a compile-time break. iOS
+> already requires `authenticatorId`. A later v3 PR realigns the shared Dart
+> API to make `authenticatorId` required and remove `types` across platforms.
+
+**Migration:** Always pass `authenticatorId` when calling
+`multifactorChallenge`, and stop relying on `types`:
+
+```dart
+// ❌ v2 — worked on Android, relied on challenge-type filtering
+final challenge = await auth0.api.multifactorChallenge(
+  mfaToken: mfaToken,
+  types: [ChallengeType.otp, ChallengeType.oob],
+);
+
+// ✅ v3 — pass the authenticator to challenge
+final challenge = await auth0.api.multifactorChallenge(
+  mfaToken: mfaToken,
+  authenticatorId: authenticatorId,
+);
+```
+
+If you support one-time passwords and don't need to select a specific factor,
+you can skip the challenge request and call `api.loginWithOtp` directly.
+
+## Getting Help
+
+If you encounter issues migrating, please open an issue on the
+[auth0-flutter repository](https://github.com/auth0/auth0-flutter/issues) with
+details of the API you're migrating and the platform affected.

--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:8.4.0"
+        classpath "com.android.tools.build:gradle:8.10.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -31,18 +31,18 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdk 34
+    compileSdk 36
 
     if (project.android.hasProperty("namespace")) {
         namespace libApplicationId
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -52,7 +52,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders = [auth0Domain: "test-domain", auth0Scheme: "test"]
     }
@@ -73,8 +73,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.auth0.android:auth0:3.21.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.auth0.android:auth0:4.0.0'
+    implementation 'com.google.code.gson:gson:2.11.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:java-hamcrest:2.0.0.0'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"

--- a/auth0_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/auth0_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/CredentialsManagerMethodCallHandler.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import androidx.annotation.NonNull
 import androidx.fragment.app.FragmentActivity
-import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
 import com.auth0.android.authentication.storage.AuthenticationLevel
 import com.auth0.android.authentication.storage.LocalAuthenticationOptions
@@ -114,11 +113,11 @@ class CredentialsManagerMethodCallHandler(private val requestHandlers: List<Cred
 
                 val newManager = if (options != null) {
                     SecureCredentialsManager(
-                        apiClient, context, request.account, storage, activity as FragmentActivity, options
+                        apiClient, context, storage, activity as FragmentActivity, options
                     )
                 } else {
                     SecureCredentialsManager(
-                        apiClient, context, request.account, storage
+                        apiClient, context, storage
                     )
                 }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -1,11 +1,13 @@
 package com.auth0.auth0_flutter.request_handlers.api
 
 import com.auth0.android.authentication.AuthenticationAPIClient
-import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.mfa.MfaException.MfaVerifyException
+import com.auth0.android.authentication.mfa.MfaVerificationType
 import com.auth0.android.callback.Callback
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
+import com.auth0.auth0_flutter.toMfaMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
@@ -24,18 +26,18 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
 
         assertHasProperties(listOf("mfaToken", "otp"), args)
 
+        // v4 removed AuthenticationAPIClient.loginWithOTP; the inline MFA OTP
+        // flow now goes through the dedicated MfaApiClient.
         val loginBuilder = api
-            .loginWithOTP(
-                args["mfaToken"] as String,
-                args["otp"] as String,
-            )
+            .mfaClient(args["mfaToken"] as String)
+            .verify(MfaVerificationType.Otp(args["otp"] as String))
 
-        loginBuilder.start(object : Callback<Credentials, AuthenticationException> {
-            override fun onFailure(exception: AuthenticationException) {
+        loginBuilder.start(object : Callback<Credentials, MfaVerifyException> {
+            override fun onFailure(exception: MfaVerifyException) {
                 result.error(
                     exception.getCode(),
                     exception.getDescription(),
-                    exception.toMap()
+                    exception.toMfaMap()
                 )
             }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandler.kt
@@ -26,8 +26,6 @@ class LoginWithOtpApiRequestHandler: ApiRequestHandler {
 
         assertHasProperties(listOf("mfaToken", "otp"), args)
 
-        // v4 removed AuthenticationAPIClient.loginWithOTP; the inline MFA OTP
-        // flow now goes through the dedicated MfaApiClient.
         val loginBuilder = api
             .mfaClient(args["mfaToken"] as String)
             .verify(MfaVerificationType.Otp(args["otp"] as String))

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandler.kt
@@ -1,11 +1,11 @@
 package com.auth0.auth0_flutter.request_handlers.api
 
 import com.auth0.android.authentication.AuthenticationAPIClient
-import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.mfa.MfaException.MfaChallengeException
 import com.auth0.android.callback.Callback
 import com.auth0.android.result.Challenge
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
-import com.auth0.auth0_flutter.toMap
+import com.auth0.auth0_flutter.toMfaMap
 import com.auth0.auth0_flutter.utils.assertHasProperties
 import io.flutter.plugin.common.MethodChannel
 
@@ -19,22 +19,23 @@ class MultifactorChallengeApiRequestHandler : ApiRequestHandler {
             request: MethodCallRequest,
             result: MethodChannel.Result
     ) {
-        assertHasProperties(listOf("mfaToken"), request.data)
+        // v4 removed AuthenticationAPIClient.multifactorChallenge; the challenge
+        // now goes through MfaApiClient, whose challenge() takes only an
+        // authenticatorId (no challenge-type filtering). `authenticatorId` is
+        // therefore now required and any `types` value is ignored; the shared
+        // Dart surface is realigned separately in the integration PR (S-A).
+        assertHasProperties(listOf("mfaToken", "authenticatorId"), request.data)
 
-        val challengeTypes = request.data["types"] as ArrayList<*>?
+        val builder = api
+                .mfaClient(request.data["mfaToken"] as String)
+                .challenge(request.data["authenticatorId"] as String)
 
-        val builder = api.multifactorChallenge(
-                mfaToken = request.data["mfaToken"] as String,
-                challengeType = challengeTypes?.joinToString(separator = " "),
-                authenticatorId = request.data["authenticatorId"] as String?
-        )
-
-        builder.start(object : Callback<Challenge, AuthenticationException> {
-            override fun onFailure(exception: AuthenticationException) {
+        builder.start(object : Callback<Challenge, MfaChallengeException> {
+            override fun onFailure(exception: MfaChallengeException) {
                 result.error(
                         exception.getCode(),
                         exception.getDescription(),
-                        exception.toMap()
+                        exception.toMfaMap()
                 )
             }
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandler.kt
@@ -19,11 +19,6 @@ class MultifactorChallengeApiRequestHandler : ApiRequestHandler {
             request: MethodCallRequest,
             result: MethodChannel.Result
     ) {
-        // v4 removed AuthenticationAPIClient.multifactorChallenge; the challenge
-        // now goes through MfaApiClient, whose challenge() takes only an
-        // authenticatorId (no challenge-type filtering). `authenticatorId` is
-        // therefore now required and any `types` value is ignored; the shared
-        // Dart surface is realigned separately in the integration PR (S-A).
         assertHasProperties(listOf("mfaToken", "authenticatorId"), request.data)
 
         val builder = api

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandler.kt
@@ -43,10 +43,6 @@ class SSOExchangeApiRequestHandler : ApiRequestHandler {
             }
 
             override fun onSuccess(credentials: SSOCredentials) {
-                // v4 renamed SSOCredentials.expiresIn (seconds) to expiresAt
-                // (absolute Date). The shared Dart model still expects seconds
-                // under "expiresIn" until the S-A rename, so convert back to
-                // seconds-until-expiry here (mirrors the iOS handler).
                 val expiresIn =
                     (credentials.expiresAt.time - System.currentTimeMillis()) / 1000
                 val map = mutableMapOf<String, Any?>(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandler.kt
@@ -43,10 +43,16 @@ class SSOExchangeApiRequestHandler : ApiRequestHandler {
             }
 
             override fun onSuccess(credentials: SSOCredentials) {
+                // v4 renamed SSOCredentials.expiresIn (seconds) to expiresAt
+                // (absolute Date). The shared Dart model still expects seconds
+                // under "expiresIn" until the S-A rename, so convert back to
+                // seconds-until-expiry here (mirrors the iOS handler).
+                val expiresIn =
+                    (credentials.expiresAt.time - System.currentTimeMillis()) / 1000
                 val map = mutableMapOf<String, Any?>(
                     "sessionTransferToken" to credentials.sessionTransferToken,
                     "tokenType" to credentials.issuedTokenType,
-                    "expiresIn" to credentials.expiresIn,
+                    "expiresIn" to expiresIn,
                     "idToken" to credentials.idToken
                 )
                 credentials.refreshToken?.let { map["refreshToken"] = it }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandler.kt
@@ -27,10 +27,6 @@ class GetSSOCredentialsRequestHandler : CredentialsManagerRequestHandler {
             }
 
             override fun onSuccess(credentials: SSOCredentials) {
-                // v4 renamed SSOCredentials.expiresIn (seconds) to expiresAt
-                // (absolute Date). The shared Dart model still expects seconds
-                // under "expiresIn" until the S-A rename, so convert back to
-                // seconds-until-expiry here (mirrors the iOS handler).
                 val expiresIn =
                     (credentials.expiresAt.time - System.currentTimeMillis()) / 1000
                 val map = mutableMapOf<String, Any?>(

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandler.kt
@@ -27,10 +27,16 @@ class GetSSOCredentialsRequestHandler : CredentialsManagerRequestHandler {
             }
 
             override fun onSuccess(credentials: SSOCredentials) {
+                // v4 renamed SSOCredentials.expiresIn (seconds) to expiresAt
+                // (absolute Date). The shared Dart model still expects seconds
+                // under "expiresIn" until the S-A rename, so convert back to
+                // seconds-until-expiry here (mirrors the iOS handler).
+                val expiresIn =
+                    (credentials.expiresAt.time - System.currentTimeMillis()) / 1000
                 val map = mutableMapOf<String, Any?>(
                     "sessionTransferToken" to credentials.sessionTransferToken,
                     "tokenType" to credentials.issuedTokenType,
-                    "expiresIn" to credentials.expiresIn,
+                    "expiresIn" to expiresIn,
                     "idToken" to credentials.idToken
                 )
                 credentials.refreshToken?.let { map["refreshToken"] = it }

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -66,7 +66,7 @@ class LoginWebAuthRequestHandler(
         }
 
         if (args["useDPoP"] == true) {
-            WebAuthProvider.useDPoP(context)
+            builder.useDPoP(context)
         }
 
         builder.start(context, object : Callback<Credentials, AuthenticationException> {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/LoginWithOtpApiRequestHandlerTest.kt
@@ -2,10 +2,13 @@ package com.auth0.auth0_flutter.request_handlers.api
 
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
-import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.mfa.MfaApiClient
+import com.auth0.android.authentication.mfa.MfaException.MfaVerifyException
+import com.auth0.android.authentication.mfa.MfaVerificationType
 import com.auth0.android.callback.Callback
-import com.auth0.android.request.AuthenticationRequest
+import com.auth0.android.request.Request
 import com.auth0.android.result.Credentials
+
 import com.auth0.auth0_flutter.JwtTestUtils
 
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
@@ -69,19 +72,21 @@ class LoginWithOtpApiRequestHandlerTest {
     }
 
     @Test
-    fun `should call loginWithOTp with the correct parameters`() {
+    fun `should call mfaClient verify with the correct parameters`() {
         val options = hashMapOf(
             "otp" to "test-otp",
             "mfaToken" to "test-mfaToken"
         )
         val handler = LoginWithOtpApiRequestHandler()
-        val mockLoginBuilder = mock<AuthenticationRequest>()
+        val mockLoginBuilder = mock<Request<Credentials, MfaVerifyException>>()
+        val mockMfaClient = mock<MfaApiClient>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
         val request = MethodCallRequest(account = mockAccount, options)
 
-        doReturn(mockLoginBuilder).`when`(mockApi).loginWithOTP(any(), any())
+        doReturn(mockMfaClient).`when`(mockApi).mfaClient(any())
+        doReturn(mockLoginBuilder).`when`(mockMfaClient).verify(any())
 
         handler.handle(
             mockApi,
@@ -89,7 +94,8 @@ class LoginWithOtpApiRequestHandlerTest {
             mockResult
         )
 
-        verify(mockApi).loginWithOTP("test-mfaToken", "test-otp")
+        verify(mockApi).mfaClient("test-mfaToken")
+        verify(mockMfaClient).verify(eq(MfaVerificationType.Otp("test-otp")))
         verify(mockLoginBuilder).start(any())
     }
 
@@ -100,17 +106,20 @@ class LoginWithOtpApiRequestHandlerTest {
             "mfaToken" to "test-mfaToken"
         )
         val handler = LoginWithOtpApiRequestHandler()
-        val mockLoginBuilder = mock<AuthenticationRequest>()
+        val mockLoginBuilder = mock<Request<Credentials, MfaVerifyException>>()
+        val mockMfaClient = mock<MfaApiClient>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
         val request = MethodCallRequest(account = mockAccount, options)
-        val exception =
-            AuthenticationException(code = "test-code", description = "test-description")
+        val exception = mock<MfaVerifyException>()
+        whenever(exception.getCode()).thenReturn("test-code")
+        whenever(exception.getDescription()).thenReturn("test-description")
 
-        doReturn(mockLoginBuilder).`when`(mockApi).loginWithOTP(any(), any())
+        doReturn(mockMfaClient).`when`(mockApi).mfaClient(any())
+        doReturn(mockLoginBuilder).`when`(mockMfaClient).verify(any())
         doAnswer {
-            val ob = it.getArgument<Callback<Credentials, AuthenticationException>>(0)
+            val ob = it.getArgument<Callback<Credentials, MfaVerifyException>>(0)
             ob.onFailure(exception)
         }.`when`(mockLoginBuilder).start(any())
 
@@ -130,7 +139,8 @@ class LoginWithOtpApiRequestHandlerTest {
             "mfaToken" to "test-mfaToken"
         )
         val handler = LoginWithOtpApiRequestHandler()
-        val mockLoginBuilder = mock<AuthenticationRequest>()
+        val mockLoginBuilder = mock<Request<Credentials, MfaVerifyException>>()
+        val mockMfaClient = mock<MfaApiClient>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
@@ -138,9 +148,10 @@ class LoginWithOtpApiRequestHandlerTest {
         val idToken = JwtTestUtils.createJwt(claims = mapOf("name" to "John Doe"))
         val credentials = Credentials(idToken, "test", "", null, Date(), "scope1 scope2")
 
-        whenever(mockApi.loginWithOTP(any(), any())).thenReturn(mockLoginBuilder)
+        whenever(mockApi.mfaClient(any())).thenReturn(mockMfaClient)
+        whenever(mockMfaClient.verify(any())).thenReturn(mockLoginBuilder)
         whenever(mockLoginBuilder.start(any())).thenAnswer {
-            val callback = it.getArgument<Callback<Credentials, AuthenticationException>>(0)
+            val callback = it.getArgument<Callback<Credentials, MfaVerifyException>>(0)
             callback.onSuccess(credentials)
         }
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/MultifactorChallengeApiRequestHandlerTest.kt
@@ -2,7 +2,8 @@ package com.auth0.auth0_flutter.request_handlers.api
 
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationAPIClient
-import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.mfa.MfaApiClient
+import com.auth0.android.authentication.mfa.MfaException.MfaChallengeException
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.Request
 import com.auth0.android.result.Challenge
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner
 class MultifactorChallengeApiRequestHandlerTest {
     @Test
     fun `should throw when missing mfaToken`() {
-        val options = hashMapOf<String, Any>()
+        val options = hashMapOf<String, Any>("authenticatorId" to "test-authenticatorId")
         val handler = MultifactorChallengeApiRequestHandler()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
@@ -39,42 +40,69 @@ class MultifactorChallengeApiRequestHandlerTest {
     }
 
     @Test
-    fun `should call multifactorChallenge with the correct parameters`() {
-        val options = hashMapOf(
-                "mfaToken" to "test-mfaToken",
-                "types" to arrayListOf("type-1", "type-2"),
-                "authenticatorId" to "test-authenticatorId"
-        )
+    fun `should throw when missing authenticatorId`() {
+        val options = hashMapOf<String, Any>("mfaToken" to "test-mfaToken")
         val handler = MultifactorChallengeApiRequestHandler()
-        val mockBuilder = mock<Request<Challenge, AuthenticationException>>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
         val request = MethodCallRequest(account = mockAccount, options)
 
-        doReturn(mockBuilder).`when`(mockApi).multifactorChallenge(any(), any(), any())
+        val exception = Assert.assertThrows(IllegalArgumentException::class.java) {
+            handler.handle(mockApi, request, mockResult)
+        }
+
+        assertThat(
+                exception.message,
+                equalTo("Required property 'authenticatorId' is not provided.")
+        )
+    }
+
+    @Test
+    fun `should call mfaClient challenge with the correct parameters`() {
+        val options = hashMapOf(
+                "mfaToken" to "test-mfaToken",
+                "authenticatorId" to "test-authenticatorId"
+        )
+        val handler = MultifactorChallengeApiRequestHandler()
+        val mockBuilder = mock<Request<Challenge, MfaChallengeException>>()
+        val mockMfaClient = mock<MfaApiClient>()
+        val mockApi = mock<AuthenticationAPIClient>()
+        val mockAccount = mock<Auth0>()
+        val mockResult = mock<Result>()
+        val request = MethodCallRequest(account = mockAccount, options)
+
+        doReturn(mockMfaClient).`when`(mockApi).mfaClient(any())
+        doReturn(mockBuilder).`when`(mockMfaClient).challenge(any())
 
         handler.handle(mockApi, request, mockResult)
 
-        verify(mockApi).multifactorChallenge("test-mfaToken", "type-1 type-2", "test-authenticatorId")
+        verify(mockApi).mfaClient("test-mfaToken")
+        verify(mockMfaClient).challenge("test-authenticatorId")
         verify(mockBuilder).start(any())
     }
 
     @Test
     fun `should call result error on failure`() {
-        val options = hashMapOf("mfaToken" to "test-mfaToken")
+        val options = hashMapOf(
+                "mfaToken" to "test-mfaToken",
+                "authenticatorId" to "test-authenticatorId"
+        )
         val handler = MultifactorChallengeApiRequestHandler()
-        val mockBuilder = mock<Request<Challenge, AuthenticationException>>()
+        val mockBuilder = mock<Request<Challenge, MfaChallengeException>>()
+        val mockMfaClient = mock<MfaApiClient>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
         val request = MethodCallRequest(account = mockAccount, options)
-        val exception =
-                AuthenticationException(code = "test-code", description = "test-description")
+        val exception = mock<MfaChallengeException>()
+        whenever(exception.getCode()).thenReturn("test-code")
+        whenever(exception.getDescription()).thenReturn("test-description")
 
-        doReturn(mockBuilder).`when`(mockApi).multifactorChallenge(any(), anyOrNull(), anyOrNull())
+        doReturn(mockMfaClient).`when`(mockApi).mfaClient(any())
+        doReturn(mockBuilder).`when`(mockMfaClient).challenge(any())
         doAnswer {
-            val ob = it.getArgument<Callback<Challenge, AuthenticationException>>(0)
+            val ob = it.getArgument<Callback<Challenge, MfaChallengeException>>(0)
             ob.onFailure(exception)
         }.`when`(mockBuilder).start(any())
 
@@ -85,18 +113,23 @@ class MultifactorChallengeApiRequestHandlerTest {
 
     @Test
     fun `should call result success on success`() {
-        val options = hashMapOf("mfaToken" to "test-mfaToken")
+        val options = hashMapOf(
+                "mfaToken" to "test-mfaToken",
+                "authenticatorId" to "test-authenticatorId"
+        )
         val handler = MultifactorChallengeApiRequestHandler()
-        val mockBuilder = mock<Request<Challenge, AuthenticationException>>()
+        val mockBuilder = mock<Request<Challenge, MfaChallengeException>>()
+        val mockMfaClient = mock<MfaApiClient>()
         val mockApi = mock<AuthenticationAPIClient>()
         val mockAccount = mock<Auth0>()
         val mockResult = mock<Result>()
         val request = MethodCallRequest(account = mockAccount, options)
         val challenge = Challenge("challengeType", "oobCode", "bindingMethod")
 
-        doReturn(mockBuilder).`when`(mockApi).multifactorChallenge(any(), anyOrNull(), anyOrNull())
+        doReturn(mockMfaClient).`when`(mockApi).mfaClient(any())
+        doReturn(mockBuilder).`when`(mockMfaClient).challenge(any())
         doAnswer {
-            val ob = it.getArgument<Callback<Challenge, AuthenticationException>>(0)
+            val ob = it.getArgument<Callback<Challenge, MfaChallengeException>>(0)
             ob.onSuccess(challenge)
         }.`when`(mockBuilder).start(any())
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandlerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
+import java.util.Date
 
 @RunWith(RobolectricTestRunner::class)
 class SSOExchangeApiRequestHandlerTest {
@@ -181,7 +182,9 @@ class SSOExchangeApiRequestHandlerTest {
         val mockSSOCredentials = mock<SSOCredentials>()
         whenever(mockSSOCredentials.sessionTransferToken).thenReturn("sso-token")
         whenever(mockSSOCredentials.issuedTokenType).thenReturn("session_transfer")
-        whenever(mockSSOCredentials.expiresIn).thenReturn(60)
+        // v4 exposes expiresAt (absolute Date); the handler converts it back to
+        // seconds-until-expiry for the "expiresIn" key the Dart model expects.
+        whenever(mockSSOCredentials.expiresAt).thenReturn(Date(System.currentTimeMillis() + 60_000))
         whenever(mockSSOCredentials.idToken).thenReturn("id-token")
         whenever(mockSSOCredentials.refreshToken).thenReturn("new-refresh-token")
 
@@ -199,7 +202,8 @@ class SSOExchangeApiRequestHandlerTest {
         val resultMap = captor.firstValue
         assertThat(resultMap["sessionTransferToken"], equalTo("sso-token"))
         assertThat(resultMap["tokenType"], equalTo("session_transfer"))
-        assertThat(resultMap["expiresIn"], equalTo(60))
+        // Converted from an absolute Date, so allow a small execution-time delta.
+        assertThat((resultMap["expiresIn"] as Long) in 58L..60L, equalTo(true))
         assertThat(resultMap["idToken"], equalTo("id-token"))
         assertThat(resultMap["refreshToken"], equalTo("new-refresh-token"))
     }
@@ -219,7 +223,7 @@ class SSOExchangeApiRequestHandlerTest {
         val mockSSOCredentials = mock<SSOCredentials>()
         whenever(mockSSOCredentials.sessionTransferToken).thenReturn("sso-token")
         whenever(mockSSOCredentials.issuedTokenType).thenReturn("session_transfer")
-        whenever(mockSSOCredentials.expiresIn).thenReturn(60)
+        whenever(mockSSOCredentials.expiresAt).thenReturn(Date(System.currentTimeMillis() + 60_000))
         whenever(mockSSOCredentials.idToken).thenReturn("id-token")
         whenever(mockSSOCredentials.refreshToken).thenReturn(null)
 

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/api/SSOExchangeApiRequestHandlerTest.kt
@@ -182,8 +182,6 @@ class SSOExchangeApiRequestHandlerTest {
         val mockSSOCredentials = mock<SSOCredentials>()
         whenever(mockSSOCredentials.sessionTransferToken).thenReturn("sso-token")
         whenever(mockSSOCredentials.issuedTokenType).thenReturn("session_transfer")
-        // v4 exposes expiresAt (absolute Date); the handler converts it back to
-        // seconds-until-expiry for the "expiresIn" key the Dart model expects.
         whenever(mockSSOCredentials.expiresAt).thenReturn(Date(System.currentTimeMillis() + 60_000))
         whenever(mockSSOCredentials.idToken).thenReturn("id-token")
         whenever(mockSSOCredentials.refreshToken).thenReturn("new-refresh-token")
@@ -202,7 +200,6 @@ class SSOExchangeApiRequestHandlerTest {
         val resultMap = captor.firstValue
         assertThat(resultMap["sessionTransferToken"], equalTo("sso-token"))
         assertThat(resultMap["tokenType"], equalTo("session_transfer"))
-        // Converted from an absolute Date, so allow a small execution-time delta.
         assertThat((resultMap["expiresIn"] as Long) in 58L..60L, equalTo(true))
         assertThat(resultMap["idToken"], equalTo("id-token"))
         assertThat(resultMap["refreshToken"], equalTo("new-refresh-token"))

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandlerTest.kt
@@ -109,8 +109,6 @@ class GetSSOCredentialsRequestHandlerTest {
         val mockSSOCredentials = mock<SSOCredentials>()
         `when`(mockSSOCredentials.sessionTransferToken).thenReturn("sso-token")
         `when`(mockSSOCredentials.issuedTokenType).thenReturn("session_transfer")
-        // v4 exposes expiresAt (absolute Date); the handler converts it back to
-        // seconds-until-expiry for the "expiresIn" key the Dart model expects.
         `when`(mockSSOCredentials.expiresAt).thenReturn(Date(System.currentTimeMillis() + 3_600_000))
         `when`(mockSSOCredentials.idToken).thenReturn("id-token")
         `when`(mockSSOCredentials.refreshToken).thenReturn(null)
@@ -135,7 +133,6 @@ class GetSSOCredentialsRequestHandlerTest {
             resultMap["tokenType"],
             CoreMatchers.equalTo("session_transfer")
         )
-        // Converted from an absolute Date, so allow a small execution-time delta.
         MatcherAssert.assertThat(
             (resultMap["expiresIn"] as Long) in 3598L..3600L,
             CoreMatchers.equalTo(true)

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/credentials_manager/GetSSOCredentialsRequestHandlerTest.kt
@@ -15,6 +15,7 @@ import org.mockito.ArgumentMatchers.anyMap
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
+import java.util.Date
 
 @RunWith(RobolectricTestRunner::class)
 class GetSSOCredentialsRequestHandlerTest {
@@ -108,7 +109,9 @@ class GetSSOCredentialsRequestHandlerTest {
         val mockSSOCredentials = mock<SSOCredentials>()
         `when`(mockSSOCredentials.sessionTransferToken).thenReturn("sso-token")
         `when`(mockSSOCredentials.issuedTokenType).thenReturn("session_transfer")
-        `when`(mockSSOCredentials.expiresIn).thenReturn(3600)
+        // v4 exposes expiresAt (absolute Date); the handler converts it back to
+        // seconds-until-expiry for the "expiresIn" key the Dart model expects.
+        `when`(mockSSOCredentials.expiresAt).thenReturn(Date(System.currentTimeMillis() + 3_600_000))
         `when`(mockSSOCredentials.idToken).thenReturn("id-token")
         `when`(mockSSOCredentials.refreshToken).thenReturn(null)
 
@@ -132,9 +135,10 @@ class GetSSOCredentialsRequestHandlerTest {
             resultMap["tokenType"],
             CoreMatchers.equalTo("session_transfer")
         )
+        // Converted from an absolute Date, so allow a small execution-time delta.
         MatcherAssert.assertThat(
-            resultMap["expiresIn"],
-            CoreMatchers.equalTo(3600)
+            (resultMap["expiresIn"] as Long) in 3598L..3600L,
+            CoreMatchers.equalTo(true)
         )
         MatcherAssert.assertThat(
             resultMap["idToken"],

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/mfa/EnrollTotpRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/mfa/EnrollTotpRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import com.auth0.android.authentication.mfa.MfaException.MfaEnrollmentException
 import com.auth0.android.callback.Callback
 import com.auth0.android.request.Request
 import com.auth0.android.result.EnrollmentChallenge
+import com.auth0.android.result.TotpEnrollmentChallenge
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.junit.Test
@@ -52,7 +53,15 @@ class EnrollTotpRequestHandlerTest {
         doAnswer {
             val callback =
                 it.getArgument<Callback<EnrollmentChallenge, MfaEnrollmentException>>(0)
-            callback.onSuccess(mock<EnrollmentChallenge>())
+            // EnrollmentChallenge is a sealed class in Auth0.Android v4 and
+            // cannot be mocked; use a concrete subclass instead.
+            callback.onSuccess(
+                TotpEnrollmentChallenge(
+                    id = "totp|test123",
+                    authSession = "session123",
+                    barcodeUri = "otpauth://totp/test"
+                )
+            )
         }.whenever(mockRequest).start(any())
 
         handler.handle(mockClient, request, mockResult)

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/mfa/EnrollTotpRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/mfa/EnrollTotpRequestHandlerTest.kt
@@ -53,8 +53,6 @@ class EnrollTotpRequestHandlerTest {
         doAnswer {
             val callback =
                 it.getArgument<Callback<EnrollmentChallenge, MfaEnrollmentException>>(0)
-            // EnrollmentChallenge is a sealed class in Auth0.Android v4 and
-            // cannot be mocked; use a concrete subclass instead.
             callback.onSuccess(
                 TotpEnrollmentChallenge(
                     id = "totp|test123",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/ConfirmEnrollmentRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/ConfirmEnrollmentRequestHandlerTest.kt
@@ -52,8 +52,6 @@ class ConfirmEnrollmentRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockMethod = PushNotificationAuthenticationMethod(
             id = "push|test123",
             type = "push",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/ConfirmEnrollmentRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/ConfirmEnrollmentRequestHandlerTest.kt
@@ -6,6 +6,7 @@ import com.auth0.android.myaccount.MyAccountAPIClient
 import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.request.Request
 import com.auth0.android.result.AuthenticationMethod
+import com.auth0.android.result.PushNotificationAuthenticationMethod
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.hamcrest.CoreMatchers.equalTo
@@ -51,10 +52,16 @@ class ConfirmEnrollmentRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockMethod = mock<AuthenticationMethod>()
-        whenever(mockMethod.id).thenReturn("push|test123")
-        whenever(mockMethod.type).thenReturn("push")
-        whenever(mockMethod.createdAt).thenReturn("2026-01-01")
+        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockMethod = PushNotificationAuthenticationMethod(
+            id = "push|test123",
+            type = "push",
+            createdAt = "2026-01-01",
+            usage = emptyList(),
+            confirmed = true,
+            name = null
+        )
 
         whenever(mockClient.verify(any(), any())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollEmailRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollEmailRequestHandlerTest.kt
@@ -6,6 +6,7 @@ import com.auth0.android.myaccount.MyAccountAPIClient
 import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.request.Request
 import com.auth0.android.result.EnrollmentChallenge
+import com.auth0.android.result.MfaEnrollmentChallenge
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.junit.Test
@@ -43,9 +44,12 @@ class EnrollEmailRequestHandlerTest {
         val options = hashMapOf<String, Any>("email" to "test@example.com")
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockChallenge = mock<EnrollmentChallenge>()
-        whenever(mockChallenge.id).thenReturn("email|test123")
-        whenever(mockChallenge.authSession).thenReturn("session123")
+        // EnrollmentChallenge is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockChallenge = MfaEnrollmentChallenge(
+            id = "email|test123",
+            authSession = "session123"
+        )
 
         whenever(mockClient.enrollEmail(any())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollEmailRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollEmailRequestHandlerTest.kt
@@ -44,8 +44,6 @@ class EnrollEmailRequestHandlerTest {
         val options = hashMapOf<String, Any>("email" to "test@example.com")
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // EnrollmentChallenge is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockChallenge = MfaEnrollmentChallenge(
             id = "email|test123",
             authSession = "session123"

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollPhoneRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollPhoneRequestHandlerTest.kt
@@ -71,8 +71,6 @@ class EnrollPhoneRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // EnrollmentChallenge is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockChallenge = MfaEnrollmentChallenge(
             id = "phone|test123",
             authSession = "session123"

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollPhoneRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/EnrollPhoneRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.myaccount.PhoneAuthenticationMethodType
 import com.auth0.android.request.Request
 import com.auth0.android.result.EnrollmentChallenge
+import com.auth0.android.result.MfaEnrollmentChallenge
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.junit.Test
@@ -70,9 +71,12 @@ class EnrollPhoneRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockChallenge = mock<EnrollmentChallenge>()
-        whenever(mockChallenge.id).thenReturn("phone|test123")
-        whenever(mockChallenge.authSession).thenReturn("session123")
+        // EnrollmentChallenge is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockChallenge = MfaEnrollmentChallenge(
+            id = "phone|test123",
+            authSession = "session123"
+        )
 
         whenever(mockClient.enrollPhone(any(), any())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodRequestHandlerTest.kt
@@ -6,6 +6,7 @@ import com.auth0.android.myaccount.MyAccountAPIClient
 import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.request.Request
 import com.auth0.android.result.AuthenticationMethod
+import com.auth0.android.result.PhoneAuthenticationMethod
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.junit.Test
@@ -43,10 +44,18 @@ class GetAuthenticationMethodRequestHandlerTest {
         val options = hashMapOf<String, Any>("id" to "phone|test123")
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockMethod = mock<AuthenticationMethod>()
-        whenever(mockMethod.id).thenReturn("phone|test123")
-        whenever(mockMethod.type).thenReturn("phone")
-        whenever(mockMethod.createdAt).thenReturn("2026-01-01T00:00:00.000Z")
+        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockMethod = PhoneAuthenticationMethod(
+            id = "phone|test123",
+            type = "phone",
+            createdAt = "2026-01-01T00:00:00.000Z",
+            usage = emptyList(),
+            confirmed = true,
+            name = null,
+            phoneNumber = null,
+            preferredAuthenticationMethod = null
+        )
 
         whenever(mockClient.getAuthenticationMethodById(any())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodRequestHandlerTest.kt
@@ -44,8 +44,6 @@ class GetAuthenticationMethodRequestHandlerTest {
         val options = hashMapOf<String, Any>("id" to "phone|test123")
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockMethod = PhoneAuthenticationMethod(
             id = "phone|test123",
             type = "phone",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodsRequestHandlerTest.kt
@@ -62,8 +62,6 @@ class GetAuthenticationMethodsRequestHandlerTest {
         val mockRequest = mock<Request<List<AuthenticationMethod>, MyAccountException>>()
         val request = MethodCallRequest(account = mockAccount, hashMapOf<String, Any>())
 
-        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockMethod = PhoneAuthenticationMethod(
             id = "test-id",
             type = "phone",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodsRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/GetAuthenticationMethodsRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import com.auth0.android.myaccount.MyAccountAPIClient
 import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.request.Request
 import com.auth0.android.result.AuthenticationMethod
+import com.auth0.android.result.PhoneAuthenticationMethod
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.junit.Test
@@ -61,10 +62,18 @@ class GetAuthenticationMethodsRequestHandlerTest {
         val mockRequest = mock<Request<List<AuthenticationMethod>, MyAccountException>>()
         val request = MethodCallRequest(account = mockAccount, hashMapOf<String, Any>())
 
-        val mockMethod = mock<AuthenticationMethod>()
-        whenever(mockMethod.id).thenReturn("test-id")
-        whenever(mockMethod.type).thenReturn("phone")
-        whenever(mockMethod.createdAt).thenReturn("2026-01-01T00:00:00.000Z")
+        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockMethod = PhoneAuthenticationMethod(
+            id = "test-id",
+            type = "phone",
+            createdAt = "2026-01-01T00:00:00.000Z",
+            usage = emptyList(),
+            confirmed = true,
+            name = null,
+            phoneNumber = null,
+            preferredAuthenticationMethod = null
+        )
 
         whenever(mockClient.getAuthenticationMethods(anyOrNull())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/UpdateAuthenticationMethodRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/UpdateAuthenticationMethodRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.myaccount.PhoneAuthenticationMethodType
 import com.auth0.android.request.Request
 import com.auth0.android.result.AuthenticationMethod
+import com.auth0.android.result.PhoneAuthenticationMethod
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.hamcrest.CoreMatchers.equalTo
@@ -78,10 +79,18 @@ class UpdateAuthenticationMethodRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockMethod = mock<AuthenticationMethod>()
-        whenever(mockMethod.id).thenReturn("phone|test123")
-        whenever(mockMethod.type).thenReturn("phone")
-        whenever(mockMethod.createdAt).thenReturn("2026-01-01")
+        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockMethod = PhoneAuthenticationMethod(
+            id = "phone|test123",
+            type = "phone",
+            createdAt = "2026-01-01",
+            usage = emptyList(),
+            confirmed = true,
+            name = null,
+            phoneNumber = null,
+            preferredAuthenticationMethod = null
+        )
 
         whenever(mockClient.updateAuthenticationMethodById(any(), anyOrNull(), anyOrNull()))
             .thenReturn(mockRequest)

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/UpdateAuthenticationMethodRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/UpdateAuthenticationMethodRequestHandlerTest.kt
@@ -79,8 +79,6 @@ class UpdateAuthenticationMethodRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockMethod = PhoneAuthenticationMethod(
             id = "phone|test123",
             type = "phone",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/VerifyOtpRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/VerifyOtpRequestHandlerTest.kt
@@ -54,8 +54,6 @@ class VerifyOtpRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
-        // be mocked; use a concrete subclass instead.
         val mockMethod = PhoneAuthenticationMethod(
             id = "phone|test123",
             type = "phone",

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/VerifyOtpRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/request_handlers/my_account/VerifyOtpRequestHandlerTest.kt
@@ -6,6 +6,7 @@ import com.auth0.android.myaccount.MyAccountAPIClient
 import com.auth0.android.myaccount.MyAccountException
 import com.auth0.android.request.Request
 import com.auth0.android.result.AuthenticationMethod
+import com.auth0.android.result.PhoneAuthenticationMethod
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import io.flutter.plugin.common.MethodChannel.Result
 import org.hamcrest.CoreMatchers.equalTo
@@ -53,10 +54,18 @@ class VerifyOtpRequestHandlerTest {
         )
         val request = MethodCallRequest(account = mockAccount, options)
 
-        val mockMethod = mock<AuthenticationMethod>()
-        whenever(mockMethod.id).thenReturn("phone|test123")
-        whenever(mockMethod.type).thenReturn("phone")
-        whenever(mockMethod.createdAt).thenReturn("2026-01-01")
+        // AuthenticationMethod is a sealed class in Auth0.Android v4 and cannot
+        // be mocked; use a concrete subclass instead.
+        val mockMethod = PhoneAuthenticationMethod(
+            id = "phone|test123",
+            type = "phone",
+            createdAt = "2026-01-01",
+            usage = emptyList(),
+            confirmed = true,
+            name = null,
+            phoneNumber = null,
+            preferredAuthenticationMethod = null
+        )
 
         whenever(mockClient.verifyOtp(any(), any(), any())).thenReturn(mockRequest)
         doAnswer {

--- a/auth0_flutter/example/android/app/build.gradle
+++ b/auth0_flutter/example/android/app/build.gradle
@@ -25,18 +25,18 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 34
+    compileSdk 36
 
     if (project.android.hasProperty("namespace")) {
         namespace exampleAppApplicationId
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -47,8 +47,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId exampleAppApplicationId
-        minSdkVersion 24
-        targetSdk 35
+        minSdkVersion 26
+        targetSdk 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/auth0_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/auth0_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/auth0_flutter/example/android/settings.gradle
+++ b/auth0_flutter/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+    id "com.android.application" version "8.10.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 
 include ':app'


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Upgrades the Android side of the SDK to **Auth0.Android v4** and gets the native bridge compiling and passing against the new major. This covers tickets **A-1**, **A-2**, and **A-3** on the v3 Android track, plus the compile-blocking pieces of **A-4** and **A-5** (targets `develop/v3.0`).

**A-1 — Dependency bump & build floor** (`android/build.gradle`, `example/android/*`)
- `com.auth0.android:auth0` `3.21.0` → `4.0.0`; Gson `2.10.1` → `2.11.0`
- `minSdkVersion` `21` → `26`, `compileSdk`/`targetSdk` `34` → `36`
- AGP `8.4.0` → `8.10.1`, Kotlin `1.9.0` → `2.0.21`, Java/`jvmTarget` `8` → `17`, Gradle wrapper `8.7` → `8.11.1`
- Example app raised to the same floor (minSdk 26, compile/target 36, JDK 17, AGP/Kotlin pins)

**A-2 — `SecureCredentialsManager` construction**
- v4 removed the constructors that took an `Auth0` instance; the manager is now built from `AuthenticationAPIClient` (`CredentialsManagerMethodCallHandler.kt`). No Dart API change.

**A-3 — Inline MFA routed through `MfaApiClient`**
- v4 removed `AuthenticationAPIClient.loginWithOTP` / `multifactorChallenge`. `LoginWithOtpApiRequestHandler` now calls `mfaClient(mfaToken).verify(Otp(otp))`; `MultifactorChallengeApiRequestHandler` now calls `mfaClient(mfaToken).challenge(authenticatorId)`. On Android `authenticatorId` is now required and `types` is ignored (matching iOS from #909). **No Dart signature change** — the shared Dart surface is realigned later in S-A.

**A-4 — `SSOCredentials.expiresIn` → `expiresAt` (compile-blocker pulled forward)**
- v4 renamed `SSOCredentials.expiresIn` (`Int`, seconds) to `expiresAt` (`Date`). `SSOExchangeApiRequestHandler` and `GetSSOCredentialsRequestHandler` now convert the absolute `Date` back to seconds-until-expiry and keep sending it under the `expiresIn` key, mirroring the iOS handler from #909. **No Dart model change** — the `expiresAt` rename on the shared Dart model lands in S-A.

**A-5 — `useDPoP` moved to the login builder (compile-blocker pulled forward)**
- v4 moved `useDPoP` off the global `WebAuthProvider` onto the login builder: `WebAuthProvider.useDPoP(context)` → `builder.useDPoP(context)` (`LoginWebAuthRequestHandler.kt`). Required for the module to compile; full per-request DPoP work remains A-5.

**Docs**
- Adds `auth0_flutter/V3_MIGRATION_GUIDE.md` (living doc) covering the Android requirement bumps, the `clearCredentials` full-wipe behavior change, and the `multifactorChallenge` `authenticatorId` requirement.

**Public API:** unchanged in this PR. Management API, passkey providers, and dedicated MFA handlers required no changes — no removed-API references remained for them.


### 🎯 Testing

- **Unit tests updated:** `LoginWithOtpApiRequestHandlerTest` and `MultifactorChallengeApiRequestHandlerTest` were reworked to mock the `mfaClient().verify()` / `mfaClient().challenge()` chain and the new `MfaVerifyException` / `MfaChallengeException` callbacks. Added a `missing authenticatorId` test for the challenge handler. Existing success/error/response-shape assertions are preserved.
- **SSO tests updated:** `SSOExchangeApiRequestHandlerTest` and `GetSSOCredentialsRequestHandlerTest` now mock `expiresAt` (a `Date`) and assert the converted seconds value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the latest Auth0 Android SDK and updated Android build requirements, including Android 8.0+, Java 17, and compile SDK 36.
  - Updated OTP login and multifactor challenge flows to use the latest authentication behavior.
  - Improved SSO credential expiration handling for more accurate remaining-session times.
  - Updated DPoP configuration for web authentication.

- **Documentation**
  - Added a v2-to-v3 migration guide covering platform requirements, behavior changes, migration examples, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->