### PR TITLE
feat: honor useEphemeralSession on Android web auth

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -1751,7 +1751,7 @@ try {
   if (e.isVerificationRequired) {
     final credentials = await auth0.webAuthentication().login(
         scopes: scopes,
-        useEphemeralSession: true, // Otherwise a session cookie will remain (iOS/macOS only)
+        useEphemeralSession: true, // Otherwise a session cookie will remain (see note below)
         parameters: {
           'connection': connection,
           'login_hint': email // So the user doesn't have to type it again
@@ -1760,6 +1760,8 @@ try {
   }
 }
 ```
+
+> 💡 `useEphemeralSession` starts a private browser session so no session cookie is persisted. It is honored on iOS/macOS and, as of v3, on Android. On Android it depends on the device browser supporting ephemeral (private) Custom Tabs sessions — if the browser doesn't support it, the login falls back to a normal Custom Tabs session and is **not** ephemeral.
 
 ---
 

--- a/auth0_flutter/V3_MIGRATION_GUIDE.md
+++ b/auth0_flutter/V3_MIGRATION_GUIDE.md
@@ -127,6 +127,11 @@ user is not silently signed in from an existing browser session.
 await auth0.webAuthentication().login(useEphemeralSession: true);
 ```
 
+> **Note**
+> Ephemeral sessions depend on the device browser supporting them. If the
+> browser that handles the login does not support ephemeral browsing, Android
+> falls back to a normal Custom Tabs login and the session is not ephemeral.
+
 ## Getting Help
 
 If you encounter issues migrating, please open an issue on the

--- a/auth0_flutter/V3_MIGRATION_GUIDE.md
+++ b/auth0_flutter/V3_MIGRATION_GUIDE.md
@@ -17,6 +17,7 @@ behavior that surfaces through the Dart API.
 - [Behavior Changes](#behavior-changes)
   - [`credentialsManager.clearCredentials` now clears all stored data (Android)](#credentialsmanagerclearcredentials-now-clears-all-stored-data-android)
   - [`api.multifactorChallenge` requires `authenticatorId` (Android)](#apimultifactorchallenge-requires-authenticatorid-android)
+  - [Web Auth `useEphemeralSession` is now honored on Android](#web-auth-useephemeralsession-is-now-honored-on-android)
 - [Getting Help](#getting-help)
 
 ## Requirements Changes
@@ -105,6 +106,26 @@ final challenge = await auth0.api.multifactorChallenge(
 
 If you support one-time passwords and don't need to select a specific factor,
 you can skip the challenge request and call `api.loginWithOtp` directly.
+
+### Web Auth `useEphemeralSession` is now honored on Android
+
+**Change:** In v2 the Web Auth `useEphemeralSession` login option had no effect
+on Android (it was accepted but ignored, and documented as iOS/macOS only). In
+v3, Android honors it via Auth0.Android v4's ephemeral browsing, matching
+iOS/macOS.
+
+**Impact:** If your Android app already passed `useEphemeralSession: true`
+expecting it to be ignored, the login now runs in a private/ephemeral browser
+session: no session is shared with or persisted in the system browser, so the
+user is not silently signed in from an existing browser session.
+
+**Migration:** No code change is required. Review your use of
+`useEphemeralSession` on Android if you relied on the previous no-op behavior:
+
+```dart
+// v3: on Android this now starts an ephemeral browser session (as on iOS/macOS).
+await auth0.webAuthentication().login(useEphemeralSession: true);
+```
 
 ## Getting Help
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -65,6 +65,10 @@ class LoginWebAuthRequestHandler(
             builder.withParameters(args["parameters"] as Map<String, *>)
         }
 
+        if (args["useEphemeralSession"] == true) {
+            builder.withEphemeralBrowsing()
+        }
+
         if (args["useDPoP"] == true) {
             builder.useDPoP(context)
         }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -318,6 +318,28 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
+    fun `handler should enable ephemeral browsing when useEphemeralSession is true`() {
+        val args = hashMapOf<String, Any?>(
+            "useEphemeralSession" to true
+        )
+
+        runRequestHandler(args) { _, builder ->
+            verify(builder).withEphemeralBrowsing()
+        }
+    }
+
+    @Test
+    fun `handler should not enable ephemeral browsing when useEphemeralSession is false or absent`() {
+        runRequestHandler(hashMapOf<String, Any?>("useEphemeralSession" to false)) { _, builder ->
+            verify(builder, never()).withEphemeralBrowsing()
+        }
+
+        runRequestHandler(hashMapOf<String, Any?>()) { _, builder ->
+            verify(builder, never()).withEphemeralBrowsing()
+        }
+    }
+
+    @Test
     fun `returns the error when the builder fails`() {
         val builder = mock<WebAuthProvider.Builder>()
         val mockResult = mock<Result>()


### PR DESCRIPTION
### Changes
- `LoginWebAuthRequestHandler` now calls `withEphemeralBrowsing()` when the `useEphemeralSession` login option is `true`, so Android honors it via Auth0.Android v4's ephemeral browsing (matching iOS/macOS). Previously it was accepted but ignored on Android.
- Adds unit tests covering `useEphemeralSession` true / false / absent.
- Documents the behavior change in `V3_MIGRATION_GUIDE.md`.

### Testing
- `./gradlew testDebugUnitTest` (new ephemeral tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)