### PR TITLE
fix: register Android web auth callbacks with the activity lifecycle

### DIFF
--- a/auth0_flutter/V3_MIGRATION_GUIDE.md
+++ b/auth0_flutter/V3_MIGRATION_GUIDE.md
@@ -17,6 +17,7 @@ behavior that surfaces through the Dart API.
 - [Behavior Changes](#behavior-changes)
   - [`credentialsManager.clearCredentials` now clears all stored data (Android)](#credentialsmanagerclearcredentials-now-clears-all-stored-data-android)
   - [`api.multifactorChallenge` requires `authenticatorId` (Android)](#apimultifactorchallenge-requires-authenticatorid-android)
+  - [Android Web Auth recovers login results across process death](#android-web-auth-recovers-login-results-across-process-death)
 - [Getting Help](#getting-help)
 
 ## Requirements Changes
@@ -105,6 +106,17 @@ final challenge = await auth0.api.multifactorChallenge(
 
 If you support one-time passwords and don't need to select a specific factor,
 you can skip the challenge request and call `api.loginWithOtp` directly.
+
+### Android Web Auth recovers login results across process death
+
+**Change:** Android Web Auth now registers its login callback against the
+activity lifecycle (via Auth0.Android v4's `WebAuthProvider.registerCallbacks`)
+instead of the deprecated global callback. As a result, a login result is
+delivered even if the activity is recreated across a configuration change or the
+process is killed and restarted while the browser is in the foreground.
+
+**Impact:** This is an internal improvement. The Dart API is unchanged and no
+code change is required.
 
 ## Getting Help
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/Auth0FlutterPlugin.kt
@@ -1,6 +1,8 @@
 package com.auth0.auth0_flutter
 
 import androidx.annotation.NonNull
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.provider.WebAuthProvider
@@ -12,6 +14,7 @@ import com.auth0.auth0_flutter.request_handlers.my_account.*
 import com.auth0.auth0_flutter.request_handlers.web_auth.LoginWebAuthRequestHandler
 import com.auth0.auth0_flutter.request_handlers.web_auth.LogoutWebAuthRequestHandler
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
@@ -108,6 +111,11 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     }
   }
 
+  private val processDeathLogoutCallback = object : Callback<Void?, AuthenticationException> {
+    override fun onSuccess(result: Void?) {}
+    override fun onFailure(exception: AuthenticationException) {}
+  }
+
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     binding = flutterPluginBinding
     val messenger = binding.binaryMessenger
@@ -189,20 +197,30 @@ class Auth0FlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     webAuthCallHandler.activity = binding.activity
     credentialsManagerCallHandler.activity = binding.activity
-    WebAuthProvider.addCallback(processDeathCallback)
+    registerWebAuthCallbacks(binding)
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
-    WebAuthProvider.removeCallback(processDeathCallback)
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
     webAuthCallHandler.activity = binding.activity
     credentialsManagerCallHandler.activity = binding.activity
-    WebAuthProvider.addCallback(processDeathCallback)
+    registerWebAuthCallbacks(binding)
   }
 
   override fun onDetachedFromActivity() {
-    WebAuthProvider.removeCallback(processDeathCallback)
+  }
+
+  private fun registerWebAuthCallbacks(binding: ActivityPluginBinding) {
+    val activityLifecycle = (binding.lifecycle as HiddenLifecycleReference).lifecycle
+    val lifecycleOwner = object : LifecycleOwner {
+      override val lifecycle: Lifecycle = activityLifecycle
+    }
+    WebAuthProvider.registerCallbacks(
+      lifecycleOwner,
+      loginCallback = processDeathCallback,
+      logoutCallback = processDeathLogoutCallback
+    )
   }
 }

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/Auth0FlutterPluginTest.kt
@@ -2,8 +2,10 @@ package com.auth0.auth0_flutter
 
 import android.app.Activity
 import android.content.Context
+import androidx.lifecycle.Lifecycle
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference
 import io.flutter.plugin.common.MethodChannel
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -95,6 +97,8 @@ class Auth0FlutterPluginTest {
             val mockActivityBindings = mock<ActivityPluginBinding>()
             val mockActivity = mock<Activity>()
             `when`(mockActivityBindings.activity).thenReturn(mockActivity)
+            `when`(mockActivityBindings.lifecycle)
+                .thenReturn(HiddenLifecycleReference(mock<Lifecycle>()))
 
             plugin.onAttachedToActivity(mockActivityBindings)
 


### PR DESCRIPTION
### Changes
- Replaces the deprecated global `WebAuthProvider.addCallback`/`removeCallback` with the lifecycle-aware `WebAuthProvider.registerCallbacks(lifecycleOwner, loginCallback, logoutCallback)`, using the activity lifecycle obtained from the plugin binding.
- Login results are now recovered across configuration changes and process death; lifecycle-scoped registration removes the manual add/remove in the detach callbacks.
- Adds a lifecycle stub to the existing `onAttachedToActivity` test.
- Documents the internal improvement in `V3_MIGRATION_GUIDE.md`.

### Testing
- `./gradlew testDebugUnitTest` (plugin tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)