### PR TITLE
af: update license references from MIT to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ For general support or usage questions, use the [Auth0 Community](https://commun
 
 <p align="center">Auth0 is an easy-to-implement, adaptable authentication and authorization platform. To learn more check out <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
-<p align="center">This project is licensed under the MIT license. See the <a href="./LICENSE"> LICENSE</a> file for more info.</p>
+<p align="center">This project is licensed under the Apache 2.0 license. See the <a href="./LICENSE">LICENSE</a> file for more info.</p>

--- a/auth0_flutter/README.md
+++ b/auth0_flutter/README.md
@@ -820,4 +820,4 @@ Please do not report security vulnerabilities on the public GitHub issue tracker
 
 <p align="center">Auth0 is an easy-to-implement, adaptable authentication and authorization platform. To learn more check out <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
-<p align="center">This project is licensed under the MIT license. See the <a href="./LICENSE"> LICENSE</a> file for more info.</p>
+<p align="center">This project is licensed under the Apache 2.0 license. See the <a href="./LICENSE">LICENSE</a> file for more info.</p>


### PR DESCRIPTION
## Changes

- Updated license text in root `README.md` and `auth0_flutter/README.md` from MIT to Apache 2.0
- Fixed link to point to the `./LICENSE` file

## References

N/A

## Testing

Documentation-only change; no code modified.

- [x] No tests required (docs-only change)