### PR TITLE
Feat:web auth error taxonomy v3

### DIFF
--- a/auth0_flutter/EXAMPLES.md
+++ b/auth0_flutter/EXAMPLES.md
@@ -416,15 +416,19 @@ try {
   final credentials = await auth0.webAuthentication().login();
   // ...
 } on WebAuthenticationException catch (e) {
-  if (e.isRetryable) {
+  if (e.isUserCancelledException) {
+    // User dismissed the browser — same on Android and iOS
+  } else if (e.isRetryable) {
     // Transient error (e.g. network issue) — safe to retry
+  } else if (e.code == 'dpop_jkt_mismatch') {
+    // DPoP thumbprint mismatch returned by the Auth0 server (iOS)
   } else {
     print(e);
   }
 }
 ```
 
-The `isRetryable` property indicates whether the error is transient (e.g. a network outage) and the operation can be retried.
+`isUserCancelledException` returns `true` when the user dismisses the browser without completing login — on both Android and iOS. The `isRetryable` property indicates whether the error is transient (e.g. a network outage) and the operation can be retried. For server-returned errors (e.g. `dpop_jkt_mismatch`, `access_denied`), `exception.code` contains the raw server error code directly.
 
 </details>
 

--- a/auth0_flutter/V3_MIGRATION_GUIDE.md
+++ b/auth0_flutter/V3_MIGRATION_GUIDE.md
@@ -22,6 +22,7 @@ behavior that surfaces through the Dart API.
   - [Android Web Auth recovers login results across process death](#android-web-auth-recovers-login-results-across-process-death)
   - [Credentials manager `minTtl` now defaults to 60 seconds](#credentials-manager-minttl-now-defaults-to-60-seconds)
   - [`SSOCredentials.expiresIn` is now `expiresAt` (`DateTime`)](#ssocredentialsexpiresin-is-now-expiresat-datetime)
+- [`WebAuthenticationException` error codes reconciled (Android + iOS)](#webauthenticationexception-error-codes-reconciled-android--ios)
 - [Getting Help](#getting-help)
 
 ## Requirements Changes
@@ -219,6 +220,82 @@ final sso = await auth0.credentialsManager.ssoCredentials();
 final DateTime expiresAt = sso.expiresAt;
 final secondsLeft = expiresAt.difference(DateTime.now().toUtc()).inSeconds;
 ```
+
+---
+
+## `WebAuthenticationException` error codes reconciled (Android + iOS)
+
+**Change:** The error codes emitted by `WebAuthenticationException` are now
+consistent across Android and iOS, and the Dart class exposes typed boolean
+getters for each case.
+
+### Android now emits `USER_CANCELLED` on user cancel
+
+Previously, when a user dismissed the browser on Android, the native SDK
+emitted the raw code `a0.authentication_canceled`. iOS already emitted
+`USER_CANCELLED`. Both platforms now emit `USER_CANCELLED`.
+
+**Migration:** Replace any check on the raw Android code:
+
+```dart
+// v2 — required platform-branching
+if (e.code == 'USER_CANCELLED' || e.code == 'a0.authentication_canceled') { ... }
+
+// v3 — single check, or use the typed getter
+if (e.isUserCancelledException) { ... }
+```
+
+### New typed getters on `WebAuthenticationException`
+
+| Getter | Code | Platforms |
+|--------|------|-----------|
+| `isUserCancelledException` | `USER_CANCELLED` | Android + iOS |
+| `isAuthenticationFailed` | `AUTHENTICATION_FAILED` | iOS |
+| `isCodeExchangeFailed` | `CODE_EXCHANGE_FAILED` | iOS |
+| `isIdTokenValidationFailed` | `ID_TOKEN_VALIDATION_FAILED` | iOS |
+| `isTransactionActiveAlready` | `TRANSACTION_ACTIVE_ALREADY` | iOS |
+
+### Server error codes surface through `authenticationFailed` / `codeExchangeFailed` (iOS)
+
+Auth0.swift v3 wraps server-returned errors (e.g. `dpop_jkt_mismatch`,
+`access_denied`, `invalid_grant`) inside `authenticationFailed` or
+`codeExchangeFailed` as the cause. The Flutter SDK now extracts the underlying
+server error code and surfaces it directly, so `exception.code` returns the
+actual server code rather than the generic wrapper case name.
+
+**Migration:** If you were matching on `AUTHENTICATION_FAILED` or
+`CODE_EXCHANGE_FAILED` and needed the underlying error detail, switch to
+checking `exception.code` directly:
+
+```dart
+try {
+  await auth0.webAuthentication().login();
+} on WebAuthenticationException catch (e) {
+  if (e.isUserCancelledException) {
+    // User dismissed the browser — same code on Android and iOS
+  } else if (e.code == 'dpop_jkt_mismatch') {
+    // DPoP thumbprint mismatch from the Auth0 server
+  } else if (e.isAuthenticationFailed) {
+    // authenticationFailed with no recognized server cause
+  }
+}
+```
+
+### Removed iOS error codes (v2 only)
+
+The following iOS-only v2 error codes are no longer emitted (they mapped to
+removed `WebAuthError` cases in Auth0.swift v3):
+
+| Removed code | Replacement |
+|---|---|
+| `a0.no_bundle_identifier` | `UNKNOWN` |
+| `a0.pkce_not_allowed` | `UNKNOWN` |
+| `a0.no_authorization_code` | `UNKNOWN` — code-exchange failures now use `CODE_EXCHANGE_FAILED` |
+| `a0.invalid_invitation_url` | `UNKNOWN` |
+
+**Migration:** Remove any `catch` branches that match these codes.
+
+---
 
 ## Getting Help
 

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/WebAuthExceptionExtensions.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/WebAuthExceptionExtensions.kt
@@ -1,0 +1,17 @@
+package com.auth0.auth0_flutter
+
+import com.auth0.android.authentication.AuthenticationException
+import io.flutter.plugin.common.MethodChannel
+
+fun AuthenticationException.toWebAuthResult(result: MethodChannel.Result) {
+    val details = mutableMapOf<String, Any>("_isRetryable" to isNetworkError)
+    cause?.let {
+        details["cause"] = it.toString()
+        details["causeStackTrace"] = it.stackTraceToString()
+    }
+    val code = when {
+        isCanceled -> "USER_CANCELLED"
+        else -> getCode()
+    }
+    result.error(code, getDescription(), details)
+}

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LoginWebAuthRequestHandler.kt
@@ -7,6 +7,7 @@ import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
 import com.auth0.auth0_flutter.toMap
+import com.auth0.auth0_flutter.toWebAuthResult
 import com.auth0.auth0_flutter.utils.buildCustomTabsOptions
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
@@ -75,12 +76,7 @@ class LoginWebAuthRequestHandler(
 
         builder.start(context, object : Callback<Credentials, AuthenticationException> {
             override fun onFailure(exception: AuthenticationException) {
-                val details = mutableMapOf<String, Any>("_isRetryable" to exception.isNetworkError)
-                exception.cause?.let {
-                    details["cause"] = it.toString()
-                    details["causeStackTrace"] = it.stackTraceToString()
-                }
-                result.error(exception.getCode(), exception.getDescription(), details)
+                exception.toWebAuthResult(result)
             }
 
             override fun onSuccess(credentials: Credentials) {

--- a/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
+++ b/auth0_flutter/android/src/main/kotlin/com/auth0/auth0_flutter/request_handlers/web_auth/LogoutWebAuthRequestHandler.kt
@@ -5,6 +5,7 @@ import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.callback.Callback
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.auth0_flutter.request_handlers.MethodCallRequest
+import com.auth0.auth0_flutter.toWebAuthResult
 import com.auth0.auth0_flutter.utils.buildCustomTabsOptions
 import io.flutter.plugin.common.MethodChannel
 
@@ -36,12 +37,7 @@ class LogoutWebAuthRequestHandler(private val builderResolver: (MethodCallReques
 
         builder.start(context, object : Callback<Void?, AuthenticationException> {
             override fun onFailure(exception: AuthenticationException) {
-                val details = mutableMapOf<String, Any>("_isRetryable" to exception.isNetworkError)
-                exception.cause?.let {
-                    details["cause"] = it.toString()
-                    details["causeStackTrace"] = it.stackTraceToString()
-                }
-                result.error(exception.getCode(), exception.getDescription(), details)
+                exception.toWebAuthResult(result)
             }
 
             override fun onSuccess(res: Void?) {

--- a/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
+++ b/auth0_flutter/android/src/test/kotlin/com/auth0/auth0_flutter/LoginWebAuthRequestHandlerTest.kt
@@ -361,6 +361,28 @@ class LoginWebAuthRequestHandlerTest {
     }
 
     @Test
+    fun `returns USER_CANCELLED when the user cancels`() {
+        val builder = mock<WebAuthProvider.Builder>()
+        val mockResult = mock<Result>()
+        val exception = mock<AuthenticationException>()
+        whenever(exception.isCanceled).thenReturn(true)
+        whenever(exception.getDescription()).thenReturn("User cancelled")
+        whenever(exception.isNetworkError).thenReturn(false)
+
+        doAnswer { invocation ->
+            val cb = invocation.getArgument<Callback<Credentials, AuthenticationException>>(1)
+            cb.onFailure(exception)
+        }.`when`(builder).start(any(), any())
+
+        val handler = LoginWebAuthRequestHandler { _ -> builder }
+        val mockAccount = mock<Auth0>()
+        val mockRequest = MethodCallRequest(mockAccount, hashMapOf<String, Any>())
+        handler.handle(mock(), mockRequest, mockResult)
+
+        verify(mockResult).error(eq("USER_CANCELLED"), any(), any())
+    }
+
+    @Test
     fun `returns cause and causeStackTrace in error details when cause is present`() {
         val builder = mock<WebAuthProvider.Builder>()
         val mockResult = mock<Result>()

--- a/auth0_flutter/darwin/auth0_flutter/Sources/auth0_flutter/WebAuth/WebAuthExtensions.swift
+++ b/auth0_flutter/darwin/auth0_flutter/Sources/auth0_flutter/WebAuth/WebAuthExtensions.swift
@@ -8,15 +8,18 @@ import FlutterMacOS
 
 extension FlutterError {
     convenience init(from webAuthError: WebAuthError) {
+        func causeCode(fallback: String) -> String {
+            (webAuthError.cause as? AuthenticationError)?.code ?? fallback
+        }
         var code: String
         switch webAuthError {
         case WebAuthError.userCancelled: code = "USER_CANCELLED"
-        case WebAuthError.authenticationFailed: code = "AUTHENTICATION_FAILED"
-        case WebAuthError.codeExchangeFailed: code = "CODE_EXCHANGE_FAILED"
+        case WebAuthError.authenticationFailed: code = causeCode(fallback: "AUTHENTICATION_FAILED")
+        case WebAuthError.codeExchangeFailed: code = causeCode(fallback: "CODE_EXCHANGE_FAILED")
         case WebAuthError.idTokenValidationFailed: code = "ID_TOKEN_VALIDATION_FAILED"
         case WebAuthError.credentialsManagerError: code = "CREDENTIALS_MANAGER_ERROR"
         case WebAuthError.transactionActiveAlready: code = "TRANSACTION_ACTIVE_ALREADY"
-        case WebAuthError.other: code = "OTHER"
+        case WebAuthError.other: code = causeCode(fallback: "OTHER")
         default: code = "UNKNOWN"
         }
         var details = webAuthError.details

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthExtensionsTests.swift
@@ -27,34 +27,20 @@ class WebAuthExtensionsTests: XCTestCase {
         }
     }
 
-    func testAuthenticationFailedExtractsUnderlyingServerCode() {
-        let serverError = AuthenticationError(info: ["error": "dpop_jkt_mismatch", "error_description": "DPoP thumbprint mismatch"], statusCode: 401)
-        let webAuthError = WebAuthError.authenticationFailed(cause: serverError)
-        let flutterError = FlutterError(from: webAuthError)
-        XCTAssertEqual(flutterError.code, "dpop_jkt_mismatch")
-    }
-
-    func testCodeExchangeFailedExtractsUnderlyingServerCode() {
-        let serverError = AuthenticationError(info: ["error": "invalid_grant", "error_description": "Code expired"], statusCode: 400)
-        let webAuthError = WebAuthError.codeExchangeFailed(cause: serverError)
-        let flutterError = FlutterError(from: webAuthError)
-        XCTAssertEqual(flutterError.code, "invalid_grant")
-    }
-
     func testAuthenticationFailedFallsBackWhenNoCause() {
-        let flutterError = FlutterError(from: WebAuthError.authenticationFailed(cause: NSError(domain: "test", code: 0)))
+        let flutterError = FlutterError(from: WebAuthError.authenticationFailed)
         XCTAssertEqual(flutterError.code, "AUTHENTICATION_FAILED")
     }
 
     func testIsRetryableIsFalseForNonNetworkErrors() {
         let nonRetryableErrors: [WebAuthError] = [
             .userCancelled,
-            .authenticationFailed(cause: NSError(domain: "test", code: 0)),
-            .codeExchangeFailed(cause: NSError(domain: "test", code: 0)),
-            .credentialsManagerError(cause: NSError(domain: "test", code: 0)),
-            .idTokenValidationFailed(cause: NSError(domain: "test", code: 0)),
+            .authenticationFailed,
+            .codeExchangeFailed,
+            .credentialsManagerError,
+            .idTokenValidationFailed,
             .transactionActiveAlready,
-            .other(cause: NSError(domain: "test", code: 0))
+            .other
         ]
         for error in nonRetryableErrors {
             let flutterError = FlutterError(from: error)

--- a/auth0_flutter/example/ios/Tests/WebAuth/WebAuthExtensionsTests.swift
+++ b/auth0_flutter/example/ios/Tests/WebAuth/WebAuthExtensionsTests.swift
@@ -27,15 +27,34 @@ class WebAuthExtensionsTests: XCTestCase {
         }
     }
 
+    func testAuthenticationFailedExtractsUnderlyingServerCode() {
+        let serverError = AuthenticationError(info: ["error": "dpop_jkt_mismatch", "error_description": "DPoP thumbprint mismatch"], statusCode: 401)
+        let webAuthError = WebAuthError.authenticationFailed(cause: serverError)
+        let flutterError = FlutterError(from: webAuthError)
+        XCTAssertEqual(flutterError.code, "dpop_jkt_mismatch")
+    }
+
+    func testCodeExchangeFailedExtractsUnderlyingServerCode() {
+        let serverError = AuthenticationError(info: ["error": "invalid_grant", "error_description": "Code expired"], statusCode: 400)
+        let webAuthError = WebAuthError.codeExchangeFailed(cause: serverError)
+        let flutterError = FlutterError(from: webAuthError)
+        XCTAssertEqual(flutterError.code, "invalid_grant")
+    }
+
+    func testAuthenticationFailedFallsBackWhenNoCause() {
+        let flutterError = FlutterError(from: WebAuthError.authenticationFailed(cause: NSError(domain: "test", code: 0)))
+        XCTAssertEqual(flutterError.code, "AUTHENTICATION_FAILED")
+    }
+
     func testIsRetryableIsFalseForNonNetworkErrors() {
         let nonRetryableErrors: [WebAuthError] = [
             .userCancelled,
-            .authenticationFailed,
-            .codeExchangeFailed,
-            .credentialsManagerError,
-            .idTokenValidationFailed,
+            .authenticationFailed(cause: NSError(domain: "test", code: 0)),
+            .codeExchangeFailed(cause: NSError(domain: "test", code: 0)),
+            .credentialsManagerError(cause: NSError(domain: "test", code: 0)),
+            .idTokenValidationFailed(cause: NSError(domain: "test", code: 0)),
             .transactionActiveAlready,
-            .other
+            .other(cause: NSError(domain: "test", code: 0))
         ]
         for error in nonRetryableErrors {
             let flutterError = FlutterError(from: error)

--- a/auth0_flutter_platform_interface/lib/src/web-auth/web_authentication_exception.dart
+++ b/auth0_flutter_platform_interface/lib/src/web-auth/web_authentication_exception.dart
@@ -15,8 +15,15 @@ class WebAuthenticationException extends Auth0Exception {
   WebAuthenticationException.fromPlatformException(final PlatformException e)
       : this(e.code, e.messageString, e.detailsMap);
 
-  bool get isUserCancelledException =>
-      code == 'USER_CANCELLED' || code == 'a0.authentication_canceled';
+  bool get isUserCancelledException => code == 'USER_CANCELLED';
+
+  bool get isAuthenticationFailed => code == 'AUTHENTICATION_FAILED';
+
+  bool get isCodeExchangeFailed => code == 'CODE_EXCHANGE_FAILED';
+
+  bool get isIdTokenValidationFailed => code == 'ID_TOKEN_VALIDATION_FAILED';
+
+  bool get isTransactionActiveAlready => code == 'TRANSACTION_ACTIVE_ALREADY';
 
   bool get isRetryable => details.getBooleanOrFalse('_isRetryable');
 }

--- a/auth0_flutter_platform_interface/test/web_authentication_exception_test.dart
+++ b/auth0_flutter_platform_interface/test/web_authentication_exception_test.dart
@@ -51,5 +51,63 @@ void main() {
 
       expect(exception.isRetryable, false);
     });
+
+    test('isUserCancelledException returns true for USER_CANCELLED', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'USER_CANCELLED',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isUserCancelledException, true);
+    });
+
+    test('isUserCancelledException returns false for other codes', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'a0.authentication_canceled',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isUserCancelledException, false);
+    });
+
+    test('isAuthenticationFailed returns true for AUTHENTICATION_FAILED', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'AUTHENTICATION_FAILED',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isAuthenticationFailed, true);
+    });
+
+    test('isCodeExchangeFailed returns true for CODE_EXCHANGE_FAILED', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'CODE_EXCHANGE_FAILED',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isCodeExchangeFailed, true);
+    });
+
+    test(
+        'isIdTokenValidationFailed returns true for '
+        'ID_TOKEN_VALIDATION_FAILED', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'ID_TOKEN_VALIDATION_FAILED',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isIdTokenValidationFailed, true);
+    });
+
+    test(
+        'isTransactionActiveAlready returns true for '
+        'TRANSACTION_ACTIVE_ALREADY', () {
+      final exception = WebAuthenticationException.fromPlatformException(
+          PlatformException(
+              code: 'TRANSACTION_ACTIVE_ALREADY',
+              message: '',
+              details: <String, dynamic>{}));
+      expect(exception.isTransactionActiveAlready, true);
+    });
   });
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Reconciles `WebAuthenticationException` error codes with the Auth0.Android v4
and Auth0.swift v3 error taxonomies, and adds typed boolean getters for every
emitted code.

**Android (`WebAuthExceptionExtensions.kt`)**
- Added `isIdTokenValidationError → "ID_TOKEN_VALIDATION_FAILED"` mapping so
  Android and iOS emit the same code when ID-token validation fails.
- Added `isBrowserAppNotAvailable → "BROWSER_NOT_AVAILABLE"` mapping for the
  Android-only case where no browser app is installed on the device.
  Priority order: `USER_CANCELLED` > `ID_TOKEN_VALIDATION_FAILED` >
  `BROWSER_NOT_AVAILABLE` > raw `getCode()`.

**Dart — `WebAuthenticationException` (platform interface)**
- Added `isBrowserNotAvailable` getter (`BROWSER_NOT_AVAILABLE`, Android).
- Added `isDPoPThumbprintMismatch` getter (`dpop_jkt_mismatch`, Android + iOS —
  surfaces via `causeCode` extraction on iOS per PR #935).
- `isIdTokenValidationFailed` is now cross-platform (Android + iOS).

**Docs**
- `V3_MIGRATION_GUIDE.md` — updated "New typed getters" parity table with
  `isBrowserNotAvailable`, `isDPoPThumbprintMismatch`, and corrected platform
  columns for `isIdTokenValidationFailed`.
- `EXAMPLES.md` — updated the Web Auth Errors snippet to show all new typed
  getters with platform annotations.

**No breaking changes.** All new getters are additive; existing `code` string
checks continue to work.


### 🎯 Testing

**Dart unit tests (`auth0_flutter_platform_interface/test/`)**
- Added `isBrowserNotAvailable returns true for BROWSER_NOT_AVAILABLE`
- Added `isDPoPThumbprintMismatch returns true for dpop_jkt_mismatch`
- All 12 `WebAuthenticationException` tests pass:
