### PR TITLE
feat: dpop web auth init config

### DIFF
--- a/auth0_flutter/example/lib/example_app.dart
+++ b/auth0_flutter/example/lib/example_app.dart
@@ -194,12 +194,17 @@ class _ExampleAppState extends State<ExampleApp> {
             'Expires At: ${credentials.expiresAt}';
       } else {
         // Mobile (Android/iOS): Use WebAuth with DPoP
-        final webAuthDPoP = auth0.webAuthentication(
+        final auth0DPoP = Auth0(
+          dotenv.env['AUTH0_DOMAIN']!,
+          dotenv.env['AUTH0_CLIENT_ID']!,
+          useDPoP: true, // Enable DPoP for mobile
+        );
+
+        final webAuthDPoP = auth0DPoP.webAuthentication(
           scheme: dotenv.env['AUTH0_CUSTOM_SCHEME'],
         );
 
         final result = await webAuthDPoP.login(
-          useDPoP: true, // Enable DPoP for mobile
           useHTTPS: true,
           audience: dotenv.env['AUTH0_AUDIENCE'],
         );

--- a/auth0_flutter/lib/auth0_flutter.dart
+++ b/auth0_flutter/lib/auth0_flutter.dart
@@ -164,7 +164,8 @@ class Auth0 {
   WebAuthentication webAuthentication(
           {final String? scheme, final bool useCredentialsManager = true}) =>
       WebAuthentication(_account, _userAgent, scheme,
-          useCredentialsManager ? credentialsManager : null);
+          useCredentialsManager ? credentialsManager : null,
+          useDPoP: _useDPoP);
 
   /// Creates a class of [WindowsWebAuthentication], the Windows-specific
   /// class for interacting with the [Auth0 Universal Login page](https://auth0.com/docs/authenticate/login/auth0-universal-login).

--- a/auth0_flutter/lib/src/mobile/web_authentication.dart
+++ b/auth0_flutter/lib/src/mobile/web_authentication.dart
@@ -24,9 +24,12 @@ class WebAuthentication {
   final UserAgent _userAgent;
   final String? _scheme;
   final CredentialsManager? _credentialsManager;
+  final bool _useDPoP;
 
   WebAuthentication(
-      this._account, this._userAgent, this._scheme, this._credentialsManager);
+      this._account, this._userAgent, this._scheme, this._credentialsManager,
+      {bool useDPoP = false})
+      : _useDPoP = useDPoP;
 
   /// Redirects the user to the [Auth0 Universal Login page](https://auth0.com/docs/authenticate/login/auth0-universal-login) for authentication. If successful, it returns
   /// a set of tokens, as well as the user's profile (constructed from ID token
@@ -74,8 +77,9 @@ class WebAuthentication {
   /// See [CustomTabsOptions] for available settings.
   /// * (android only): [allowedBrowsers] Defines an allowlist of browser
   /// packages. **Deprecated**: use [customTabsOptions] instead.
-  /// * [useDPoP] enables DPoP for enhanced token security.
-  /// See README for details. Defaults to `false`.
+  ///
+  /// DPoP-bound tokens are obtained when `useDPoP` is set to `true` on the
+  /// [Auth0] constructor.
   Future<Credentials> login(
       {final String? audience,
       final Set<String> scopes = const {
@@ -95,8 +99,7 @@ class WebAuthentication {
       final Map<String, String> parameters = const {},
       final IdTokenValidationConfig idTokenValidationConfig =
           const IdTokenValidationConfig(),
-      final SafariViewController? safariViewController,
-      final bool useDPoP = false}) async {
+      final SafariViewController? safariViewController}) async {
     final credentials = await Auth0FlutterWebAuthPlatform.instance.login(
         _createWebAuthRequest(WebAuthLoginOptions(
             audience: audience,
@@ -113,7 +116,7 @@ class WebAuthentication {
             customTabsOptions: customTabsOptions,
             // ignore: deprecated_member_use_from_same_package
             allowedBrowsers: allowedBrowsers,
-            useDPoP: useDPoP)));
+            useDPoP: _useDPoP)));
 
     await _credentialsManager?.storeCredentials(credentials);
 

--- a/auth0_flutter/test/mobile/web_authentication_test.dart
+++ b/auth0_flutter/test/mobile/web_authentication_test.dart
@@ -484,9 +484,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true);
+            .login();
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -533,11 +533,12 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
-            useDPoP: true,
-            audience: 'test-audience',
-            scopes: {'openid', 'profile', 'email'},
-            organizationId: 'org_123');
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
+            .webAuthentication()
+            .login(
+                audience: 'test-audience',
+                scopes: {'openid', 'profile', 'email'},
+                organizationId: 'org_123');
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -567,9 +568,10 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        final result = await Auth0('test-domain', 'test-clientId')
-            .webAuthentication()
-            .login(useDPoP: true);
+        final result =
+            await Auth0('test-domain', 'test-clientId', useDPoP: true)
+                .webAuthentication()
+                .login();
 
         final verificationResult =
             verify(mockedCMPlatform.saveCredentials(captureAny)).captured.single
@@ -587,9 +589,9 @@ void main() {
         when(mockedPlatform.login(any))
             .thenAnswer((_) async => TestPlatform.loginResult);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication(useCredentialsManager: false)
-            .login(useDPoP: true);
+            .login();
 
         verifyNever(mockedCMPlatform.saveCredentials(any));
       });
@@ -600,9 +602,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true, redirectUrl: 'https://example.com/callback');
+            .login(redirectUrl: 'https://example.com/callback');
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -619,9 +621,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true, useHTTPS: true);
+            .login(useHTTPS: true);
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -637,9 +639,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true, useEphemeralSession: true);
+            .login(useEphemeralSession: true);
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -655,9 +657,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true, parameters: {'custom_param': 'custom_value'});
+            .login(parameters: {'custom_param': 'custom_value'});
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -674,9 +676,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
-            useDPoP: true,
-            invitationUrl: 'https://example.com/invite?ticket=abc123');
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
+            .webAuthentication()
+            .login(invitationUrl: 'https://example.com/invite?ticket=abc123');
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -694,11 +696,12 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
-            useDPoP: true,
-            safariViewController: const SafariViewController(
-                presentationStyle:
-                    SafariViewControllerPresentationStyle.fullScreen));
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
+            .webAuthentication()
+            .login(
+                safariViewController: const SafariViewController(
+                    presentationStyle:
+                        SafariViewControllerPresentationStyle.fullScreen));
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -718,9 +721,11 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId').webAuthentication().login(
-            useDPoP: true,
-            allowedBrowsers: ['com.android.chrome', 'org.mozilla.firefox']);
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
+            .webAuthentication()
+            .login(
+                // ignore: deprecated_member_use_from_same_package
+                allowedBrowsers: ['com.android.chrome', 'org.mozilla.firefox']);
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -737,9 +742,10 @@ void main() {
         final mockCm = MockCredentialsManager();
         when(mockCm.storeCredentials(any)).thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId', credentialsManager: mockCm)
+        await Auth0('test-domain', 'test-clientId',
+                credentialsManager: mockCm, useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true);
+            .login();
 
         verifyNever(mockedCMPlatform.saveCredentials(any));
 
@@ -775,9 +781,10 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        final result = await Auth0('test-domain', 'test-clientId')
-            .webAuthentication()
-            .login(useDPoP: true);
+        final result =
+            await Auth0('test-domain', 'test-clientId', useDPoP: true)
+                .webAuthentication()
+                .login();
 
         expect(result.accessToken, 'dpop-token');
         expect(result.tokenType, 'DPoP');
@@ -790,16 +797,16 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        final result = await Auth0('test-domain', 'test-clientId')
-            .webAuthentication()
-            .login(
-                useDPoP: true,
-                audience: 'https://api.example.com',
-                scopes: {'openid', 'profile', 'email', 'offline_access'},
-                organizationId: 'org_123',
-                redirectUrl: 'myapp://callback',
-                useHTTPS: true,
-                parameters: {'connection': 'google-oauth2'});
+        final result =
+            await Auth0('test-domain', 'test-clientId', useDPoP: true)
+                .webAuthentication()
+                .login(
+                    audience: 'https://api.example.com',
+                    scopes: {'openid', 'profile', 'email', 'offline_access'},
+                    organizationId: 'org_123',
+                    redirectUrl: 'myapp://callback',
+                    useHTTPS: true,
+                    parameters: {'connection': 'google-oauth2'});
 
         final verificationResult = verify(mockedPlatform.login(captureAny))
             .captured
@@ -834,9 +841,9 @@ void main() {
         when(mockedCMPlatform.saveCredentials(any))
             .thenAnswer((_) async => true);
 
-        await Auth0('test-domain', 'test-clientId')
+        await Auth0('test-domain', 'test-clientId', useDPoP: true)
             .webAuthentication()
-            .login(useDPoP: true);
+            .login();
 
         final savedCredentials =
             verify(mockedCMPlatform.saveCredentials(captureAny)).captured.single


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Moves the DPoP (Demonstrating Proof-of-Possession) toggle for Web Authentication from a per-`login()` call parameter to the `Auth0` client constructor, so it is configured once at initialization and applied internally by the SDK on every Web Auth login. This aligns Web Auth with `CredentialsManager` and `Passwordless`, which already consume the init-level `useDPoP` flag.

**Public API changes:**

- `WebAuthentication.login()` — **removed** the `useDPoP` parameter. DPoP is no longer configured per login call.
- `Auth0(...)` constructor — the existing `useDPoP` flag now also governs Web Authentication. It is threaded through `Auth0.webAuthentication()` into `WebAuthentication` and applied internally on each `login()`.
- `WebAuthentication` constructor — now accepts an internal `useDPoP` flag (set by `Auth0.webAuthentication()`; not intended for direct instantiation).

**Usage:**

```dart
// Configure DPoP once at init; the SDK applies it to every Web Auth login.
final auth0 = Auth0('DOMAIN', 'CLIENT_ID', useDPoP: true);

final credentials = await auth0.webAuthentication().login();
```

`useDPoP` defaults to `false` (Bearer tokens). When omitted, behavior is unchanged.

### 🎯 Testing

- Unit tests in `auth0_flutter/test/mobile/web_authentication_test.dart` were updated to set `useDPoP: true` on the `Auth0(...)` constructor instead of on `.login()`. The DPoP Authentication and DPoP Integration test groups assert that the flag set at init reaches the native `WebAuthLoginOptions.useDPoP`, and the "disabled" / "defaults to false" cases assert `useDPoP == false` when the flag is not set. All tests pass:

