### PR TITLE
Release afpi-v2.6.1

### DIFF
--- a/auth0_flutter_platform_interface/CHANGELOG.md
+++ b/auth0_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [afpi-v2.6.1](https://github.com/auth0/auth0-flutter/tree/afpi-v2.6.1) (2026-09-07)
+[Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.6.0...afpi-v2.6.1)
+
+**Fixed**
+- fix: replace deprecated cpprestsdk dependency with cpp-httplib to fix vcpkg state [\#906](https://github.com/auth0/auth0-flutter/pull/906) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [afpi-v2.6.0](https://github.com/auth0/auth0-flutter/tree/afpi-v2.6.0) (2026-07-31)
 [Full Changelog](https://github.com/auth0/auth0-flutter/compare/afpi-v2.5.0...afpi-v2.6.0)
 

--- a/auth0_flutter_platform_interface/pubspec.yaml
+++ b/auth0_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth0_flutter_platform_interface
 description: A common platform interface for the auth0_flutter federated plugin.
-version: 2.6.0
+version: 2.6.1
 
 homepage: https://github.com/auth0/auth0-flutter
 


### PR DESCRIPTION

**Fixed**
- fix: replace deprecated cpprestsdk dependency with cpp-httplib to fix vcpkg state [\#906](https://github.com/auth0/auth0-flutter/pull/906) ([NandanPrabhu](https://github.com/NandanPrabhu))