### PR TITLE
fix: apply Kotlin Gradle Plugin only when AGP has no built-in Kotlin

### DIFF
--- a/auth0_flutter/android/build.gradle
+++ b/auth0_flutter/android/build.gradle
@@ -16,7 +16,15 @@ plugins {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+def builtInKotlin = providers.gradleProperty("android.builtInKotlin")
+        .map { it.toBoolean() }
+        .orElse(agpMajor >= 9)
+        .get()
+if (agpMajor < 9 || !builtInKotlin) {
+    pluginManager.apply('kotlin-android')
+}
 
 def libApplicationId = 'com.auth0.auth0_flutter'
 
@@ -41,10 +49,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'
@@ -67,6 +71,14 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
+        }
+    }
+}
+
+plugins.withId("org.jetbrains.kotlin.android") {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
         }
     }
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Android Gradle Plugin 9 compiles Kotlin itself ("built-in Kotlin") and fails the build when a module also applies the Kotlin Gradle Plugin (KGP):

```
Failed to apply plugin 'org.jetbrains.kotlin.android'
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

Flutter 3.47 scaffolds apps on AGP 9.1.0, so any app depending on `auth0_flutter` currently has to opt out with `android.builtInKotlin=false` — which in turn forces every *other* plugin in the app back onto KGP.

This changes `auth0_flutter/android/build.gradle` to apply KGP only where AGP will not compile Kotlin itself:

- **AGP ≤ 8** (example app / CI): unchanged — KGP is applied exactly as before.
- **AGP 9+**, built-in Kotlin (the default): KGP is not applied; AGP compiles the Kotlin sources.
- **AGP 9+**, host opted out with `android.builtInKotlin=false`: KGP is applied, as before.

The `kotlinOptions { jvmTarget = '17' }` block is KGP-only DSL and does not exist under built-in Kotlin, so it moves behind `plugins.withId("org.jetbrains.kotlin.android")` using `JvmTarget.JVM_17`; with built-in Kotlin, AGP derives the JVM target from `compileOptions.targetCompatibility` (already `VERSION_17`).

`pluginManager.apply('kotlin-android')` is used instead of `apply plugin:` on purpose: the Flutter tool detects KGP usage by regex-scanning plugin build scripts and would otherwise keep listing `auth0_flutter` in its KGP notice even on AGP 9, where this branch never runs. This mirrors the conditional apply shipped by `firebase_core`, `stripe_android`, and `mobile_scanner`.

No public API change.

Fixes #923.

### 🎯 Testing

Build-script only; no runtime code changes.

- **AGP 8 (existing users / CI / example app) — verified end-to-end.** Built the `auth0_flutter/example` app to a debug APK on AGP 8.10.1: `✓ Built build/app/outputs/flutter-apk/app-debug.apk`. On AGP ≤ 8 the script takes the original `agpMajor < 9` branch and applies KGP identically to before, so existing consumers are unaffected.

